### PR TITLE
Subclassing with abstract class

### DIFF
--- a/packages/lib/src/model/Model.ts
+++ b/packages/lib/src/model/Model.ts
@@ -50,10 +50,10 @@ export interface _Model<TProps extends ModelProps> {
  * @returns
  */
 export function ExtendedModel<TProps extends ModelProps, TBaseModel extends AnyModel>(
-  baseModel: ModelClass<TBaseModel>,
+  baseModel: Function & { prototype: TBaseModel },
   modelProps: TProps
 ): _ExtendedModel<TBaseModel, TProps> {
-  return internalModel<TProps, TBaseModel>(modelProps, baseModel)
+  return internalModel<TProps, TBaseModel>(modelProps, baseModel as ModelClass<TBaseModel>)
 }
 
 /**

--- a/packages/lib/test/model/subclassing.test.ts
+++ b/packages/lib/test/model/subclassing.test.ts
@@ -301,3 +301,34 @@ test("abstract-ish model classes", () => {
   expect(b.error).toBe("too short")
   expect(b instanceof StringA).toBe(true)
 })
+
+test("abstract model classes", () => {
+  abstract class A<P> extends Model({}) {
+    public abstract value: P
+
+    public abstract validate(_value: P): string | undefined
+
+    @computed
+    public get error(): string | undefined {
+      return this.validate(this.value)
+    }
+  }
+
+  abstract class StringA extends A<string> {}
+
+  @model("B")
+  class B extends ExtendedModel(StringA, {
+    value: prop<string>(),
+  }) {
+    public validate(value: string): string | undefined {
+      return value.length < 3 ? "too short" : undefined
+    }
+  }
+
+  const b = new B({ value: "hi" })
+  expect(b.value).toBe("hi")
+  expect(b.validate("ho")).toBe("too short")
+  expect(b.validate("long")).toBe(undefined)
+  expect(b.error).toBe("too short")
+  expect(b instanceof StringA).toBe(true)
+})


### PR DESCRIPTION
Regarding extending an abstract base class with `ExtendedModel` (https://github.com/xaviergonz/mobx-keystone/issues/2#issuecomment-523160527):

How about using [this suggestion](https://stackoverflow.com/a/38642922) for typing an abstract class:

```ts
type Constructor<T> = Function & { prototype: T }
```

The problem with using `ModelClass<T>` for typing abstract classes is that abstract classes don't have `new (...): ...` because they cannot be instantiated.