### PR TITLE
Fix ESM bundle filename and remove UMD bundle reference

### DIFF
--- a/packages/lib/package.json
+++ b/packages/lib/package.json
@@ -22,8 +22,7 @@
   "license": "MIT",
   "author": "Javier González Garcés",
   "main": "dist/index.js",
-  "umd:main": "dist/mobx-keystone.umd.production.js",
-  "module": "dist/mobx-keystone.es.production.js",
+  "module": "dist/mobx-keystone.esm.js",
   "typings": "dist/index.d.ts",
   "files": [
     "dist"


### PR DESCRIPTION
The ESM bundle filename in `packages/lib/package.json` does not match the actually built filename and there is a reference to a UMD bundle which currently is not built. Would you like to build a UMD bundle, too? This needs to be explicitly enabled since [TSDX v0.7.0](https://github.com/palmerhq/tsdx/releases/tag/v0.7.0).