### PR TITLE
better flow typings

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Change Log
 
+## 0.15.0
+
+- [BREAKING CHANGE] Using flows in TypeScript should result in improved typings, but it requires TypeScript >= 3.6.2. Check the updated flow section of the documentation to see how to work with them now.
+
 ## 0.14.2
 
 - Fixed `getChildrenObjects` and `onChildAttachedTo` so they don't report the model data objects (`$`). Set the option `includeModelDataObjects` to true to get the old behaviour back in `getChildrenObjects`.

--- a/README.md
+++ b/README.md
@@ -55,7 +55,7 @@ This library requires a more or less modern Javascript environment to work, name
 
 In other words, it should work on mostly anything except _it won't work in Internet Explorer_.
 
-If you are using Typescript, then version >= 3.5.3 is recommended, though it _might_ work with older versions.
+If you are using Typescript, then version >= 3.6.2 is recommended, though it _might_ work with older versions.
 
 ## Installation
 

--- a/packages/benchmark/package.json
+++ b/packages/benchmark/package.json
@@ -17,8 +17,8 @@
   },
   "devDependencies": {
     "@types/benchmark": "^1.0.31",
-    "cross-env": "^5.2.0",
+    "cross-env": "^5.2.1",
     "shx": "^0.3.2",
-    "typescript": "^3.5.3"
+    "typescript": "^3.6.2"
   }
 }

--- a/packages/lib/package.json
+++ b/packages/lib/package.json
@@ -1,6 +1,6 @@
 {
   "name": "mobx-keystone",
-  "version": "0.14.2",
+  "version": "0.15.0",
   "description": "A MobX powered state management solution based on data trees with first class support for Typescript, snapshots, patches and much more",
   "keywords": [
     "mobx",
@@ -47,7 +47,7 @@
     "ts-node": "^8.3.0",
     "tsdx": "^0.9.0",
     "typedoc": "^0.15.0",
-    "typescript": "^3.5.1"
+    "typescript": "^3.6.2"
   },
   "dependencies": {
     "ts-toolbelt": "^3.8.63"

--- a/packages/lib/package.json
+++ b/packages/lib/package.json
@@ -33,7 +33,8 @@
     "test": "tsdx test",
     "test:perf": "yarn build && yarn test:perf:run",
     "test:perf:run": "cd perf_bench && export NODE_ENV=production && /usr/bin/time node --expose-gc --require ts-node/register ./report.ts",
-    "build-docs": "shx rm -rf ../site/src/public/api && typedoc --options ./typedocconfig.js",
+    "fix-tsdocs": "shx rm -rf ../../node_modules/typedoc/node_modules/typescript",
+    "build-docs": "shx rm -rf ../site/src/public/api && yarn fix-tsdocs && typedoc --options ./typedocconfig.js",
     "lint": "eslint \"src/**/*.ts\" \"test/**/*.ts\""
   },
   "peerDependencies": {

--- a/packages/lib/src/action/builtInActions.ts
+++ b/packages/lib/src/action/builtInActions.ts
@@ -28,5 +28,5 @@ const builtInActionValues = new Set(Object.values(BuiltInAction))
  * @returns true if it is a built-in action, false otherwise.
  */
 export function isBuiltInAction(actionName: string): actionName is BuiltInAction {
-  return builtInActionValues.has(actionName)
+  return builtInActionValues.has(actionName as BuiltInAction)
 }

--- a/packages/lib/src/action/hookActions.ts
+++ b/packages/lib/src/action/hookActions.ts
@@ -28,5 +28,5 @@ const hookActionValues = new Set(Object.values(HookAction))
  * @returns true if it is a hook, false otherwise.
  */
 export function isHookAction(actionName: string): actionName is HookAction {
-  return hookActionValues.has(actionName)
+  return hookActionValues.has(actionName as HookAction)
 }

--- a/packages/lib/src/action/index.ts
+++ b/packages/lib/src/action/index.ts
@@ -13,9 +13,9 @@ export {
   castModelFlow,
   castYield,
   FlowFunction,
+  FlowFunctionAsPromiseFunction,
   isModelFlow,
   modelFlow,
-  ModelFlow,
   PromiseFunction,
 } from "./modelFlow"
 export { runUnprotected } from "./protection"

--- a/packages/lib/src/action/index.ts
+++ b/packages/lib/src/action/index.ts
@@ -9,5 +9,13 @@ export {
 export { HookAction, isHookAction } from "./hookActions"
 export { ActionMiddleware, ActionMiddlewareDisposer, addActionMiddleware } from "./middleware"
 export { isModelAction, modelAction } from "./modelAction"
-export { FlowRet, isModelFlow, modelFlow } from "./modelFlow"
+export {
+  castModelFlow,
+  castYield,
+  FlowFunction,
+  isModelFlow,
+  modelFlow,
+  ModelFlow,
+  PromiseFunction,
+} from "./modelFlow"
 export { runUnprotected } from "./protection"

--- a/packages/lib/src/action/modelFlow.ts
+++ b/packages/lib/src/action/modelFlow.ts
@@ -214,15 +214,22 @@ function checkModelFlowArgs(target: any, propertyKey: string, value: any) {
   checkModelDecoratorArgs("modelFlow", target, propertyKey)
 }
 
+/**
+ * A flow function, this is, a function that returns a generator (a generator function).
+ */
 export type FlowFunction<A extends any[], R> = (...args: A) => Generator<any, R, any>
+
+/**
+ * A function that returns a promise.
+ */
 export type PromiseFunction<A extends any[], R> = (...args: A) => Promise<R>
 
-export type ModelFlow<FN extends FlowFunction<any[], any>> = FN extends FlowFunction<
-  infer A,
-  infer R
->
-  ? (...args: A) => Promise<R>
-  : never
+/**
+ * Transforms a flow function into a promise function.
+ */
+export type FlowFunctionAsPromiseFunction<
+  FN extends FlowFunction<any[], any>
+> = FN extends FlowFunction<infer A, infer R> ? (...args: A) => Promise<R> : never
 
 /**
  * Tricks the TS compiler into thinking a model flow generator function is a function that
@@ -239,7 +246,9 @@ export type ModelFlow<FN extends FlowFunction<any[], any>> = FN extends FlowFunc
  * @param fn Generator function.
  * @returns
  */
-export function castModelFlow<FN extends FlowFunction<any[], any>>(fn: FN): ModelFlow<FN> {
+export function castModelFlow<FN extends FlowFunction<any[], any>>(
+  fn: FN
+): FlowFunctionAsPromiseFunction<FN> {
   return fn as any
 }
 

--- a/packages/lib/test/actionMiddleware/transactionMiddleware.test.ts
+++ b/packages/lib/test/actionMiddleware/transactionMiddleware.test.ts
@@ -1,6 +1,7 @@
 import {
+  castModelFlow,
+  castYield,
   findParent,
-  FlowRet,
   model,
   Model,
   modelAction,
@@ -117,22 +118,22 @@ class P2Flow extends Model({
   }
 
   @modelFlow
-  *addY(n: number, error: boolean) {
+  addY = castModelFlow(function*(this: P2Flow, n: number, error: boolean) {
     yield delay(5)
     this.y += n
     if (error) {
       throw new Error("addY - Error")
     }
     return this.y
-  }
+  })
 
   @modelFlow
-  *addParentX(n: number, error: boolean) {
+  addParentX = castModelFlow(function*(this: P2Flow, n: number, error: boolean) {
     const parent = findParent<PFlow>(this, p => p instanceof PFlow)!
     yield delay(5)
-    const ret: FlowRet<typeof parent.addX> = yield parent.addX(n, error)
+    const ret = castYield(parent.addX, yield parent.addX(n, error))
     return ret
-  }
+  })
 
   @modelAction
   addZ(n: number) {
@@ -148,23 +149,23 @@ class PFlow extends Model({
 }) {
   @transaction
   @modelFlow
-  addX = function*(this: PFlow, n: number, error: boolean) {
+  addX = castModelFlow(function*(this: PFlow, n: number, error: boolean) {
     this.x += n
     yield delay(5)
     if (error) {
       throw new Error("addX - Error")
     }
     return this.x
-  };
+  })
 
   @transaction
   @modelFlow
-  *addY(a: number, b: number, error: boolean) {
+  addY = castModelFlow(function*(this: PFlow, a: number, b: number, error: boolean) {
     this.p2.y += a
     yield delay(5)
     yield this.p2.addY(b, error)
     return this.p2.y
-  }
+  })
 }
 
 describe("transactionMiddleware - async", () => {

--- a/packages/site/package.json
+++ b/packages/site/package.json
@@ -23,6 +23,6 @@
     "docz": "^1.2.0",
     "docz-theme-default": "^1.2.0",
     "raw-loader": "^3.0.0",
-    "typescript": "^3.5.3"
+    "typescript": "^3.6.2"
   }
 }

--- a/packages/site/src/intro.mdx
+++ b/packages/site/src/intro.mdx
@@ -54,7 +54,7 @@ This library requires a more or less modern Javascript environment to work, name
 
 In other words, it should work on mostly anything except _it won't work in Internet Explorer_.
 
-If you are using Typescript, then version >= 3.5.3 is recommended, though it _might_ work with older versions.
+If you are using Typescript, then version >= 3.6.2 is recommended, though it _might_ work with older versions.
 
 ## Installation
 

--- a/packages/site/src/models.mdx
+++ b/packages/site/src/models.mdx
@@ -147,13 +147,34 @@ interface Book {
 class BookStore extends Model({
   books: prop<Book[]>(() => []),
 }) {
+  // Typescript version
+
   @modelFlow
-  // we use * (a function generator) where we would use`async`
-  *fetchMyBooksAsync(token: string) {
+  // we use function* (a function generator) where we would use`async`
+  // the cast function is only to trick TS into thinking this is a method
+  // that returns a promise, it is not required for plain JS
+  // not how when using TS we need to specify the type of `this`, this is
+  // again not needed for plain JS
+  fetchMyBooksAsync = castModelFlow(function*(this: BookStore, token: string) {
     // we use `yield` where we would use `await`
-    // however since Typescript doesn't get along well with typed generators (yet)
-    // we can optionally use FlowRet to cast the return value to the proper type
-    const myBooks: FlowRet<typeof myBackendClient.getBooks> = yield myBackendClient.getBooks(token)
+    // since TS doesn't get along well with typed generators (yet)
+    // we can optionally use castYield to cast the return value to the proper type
+    // passing as first argument the function we are going to call
+    const myBooks = castYield(myBackendClient.getBooks, yield myBackendClient.getBooks(token))
+    // in plain JS (or if you don't care that the return type is any or want to
+    // typecast it yourself) you can just use
+    // `const myBooks = yield myBackendClient.getBooks(token)`
+
+    this.books = myBooks
+  });
+
+  // plain Javascript version
+
+  @modelFlow
+  // we use function* (a function generator) where we would use`async`
+  *fetchMyBooksAsync(token) {
+    // we use `yield` where we would use `await`
+    const myBooks = yield myBackendClient.getBooks(token)
 
     this.books = myBooks
   }

--- a/yarn.lock
+++ b/yarn.lock
@@ -5222,13 +5222,20 @@ create-react-context@^0.2.1, create-react-context@^0.2.3:
     fbjs "^0.8.0"
     gud "^1.0.0"
 
-cross-env@5.2.0, cross-env@^5.2.0:
+cross-env@5.2.0:
   version "5.2.0"
   resolved "https://registry.yarnpkg.com/cross-env/-/cross-env-5.2.0.tgz#6ecd4c015d5773e614039ee529076669b9d126f2"
   integrity sha512-jtdNFfFW1hB7sMhr/H6rW1Z45LFqyI431m3qU6bFXcQ3Eh7LtBuG3h74o7ohHZ3crrRkkqHlo4jYHFPcjroANg==
   dependencies:
     cross-spawn "^6.0.5"
     is-windows "^1.0.0"
+
+cross-env@^5.2.1:
+  version "5.2.1"
+  resolved "https://registry.yarnpkg.com/cross-env/-/cross-env-5.2.1.tgz#b2c76c1ca7add66dc874d11798466094f551b34d"
+  integrity sha512-1yHhtcfAd1r4nwQgknowuUNfIT9E8dOMMspC36g45dN+iD1blloi7xp8X/xAIDnjHWyt1uQ8PHk2fkNaym7soQ==
+  dependencies:
+    cross-spawn "^6.0.5"
 
 cross-spawn@6.0.5, cross-spawn@^6.0.0, cross-spawn@^6.0.5:
   version "6.0.5"
@@ -15262,10 +15269,15 @@ typescript@3.3.4000:
   resolved "https://registry.yarnpkg.com/typescript/-/typescript-3.3.4000.tgz#76b0f89cfdbf97827e1112d64f283f1151d6adf0"
   integrity sha512-jjOcCZvpkl2+z7JFn0yBOoLQyLoIkNZAs/fYJkUG6VKy6zLPHJGfQJYFHzibB6GJaF/8QrcECtlQ5cpvRHSMEA==
 
-typescript@3.5.x, typescript@^3.4.5, typescript@^3.5.1, typescript@^3.5.3:
+typescript@3.5.x:
   version "3.5.3"
   resolved "https://registry.yarnpkg.com/typescript/-/typescript-3.5.3.tgz#c830f657f93f1ea846819e929092f5fe5983e977"
   integrity sha512-ACzBtm/PhXBDId6a6sDJfroT2pOWt/oOnk4/dElG5G33ZL776N3Y6/6bKZJBFpd+b05F3Ct9qDjMeJmRWtE2/g==
+
+typescript@^3.4.5, typescript@^3.6.2:
+  version "3.6.2"
+  resolved "https://registry.yarnpkg.com/typescript/-/typescript-3.6.2.tgz#105b0f1934119dde543ac8eb71af3a91009efe54"
+  integrity sha512-lmQ4L+J6mnu3xweP8+rOrUwzmN+MRAj7TgtJtDaXE5PMyX2kCrklhg3rvOsOIfNeAWMQWO2F1GPc1kMD2vLAfw==
 
 ua-parser-js@^0.7.18:
   version "0.7.20"


### PR DESCRIPTION
[BREAKING CHANGE] Using flows in TypeScript should result in improved typings, but it requires TypeScript >= 3.6.2. Check the updated flow section of the documentation to see how to work with them now.

Scheduled for 0.15.0