### PR TITLE
better spreading support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Change Log
 
+## 0.17.0
+
+- Better support for array / object spreading, reassing to filter/map, etc. Objects and arrays will be automatically unconverted from tree nodes when detached.
+
 ## 0.16.0
 
 - [BREAKING CHANGE] Again changes to flows so typings are better. Check the updated flow section of the documentation to see how to work with them now (should be much easier).

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## 0.17.0
 
-- Better support for array / object spreading, reassing to filter/map, etc. Objects and arrays will be automatically unconverted from tree nodes when detached.
+- Better support for array / object spreading, reassign to filter/map, etc. Objects and arrays will be automatically unconverted from tree nodes when detached.
 
 ## 0.16.0
 

--- a/packages/lib/package.json
+++ b/packages/lib/package.json
@@ -1,6 +1,6 @@
 {
   "name": "mobx-keystone",
-  "version": "0.16.0",
+  "version": "0.17.0",
   "description": "A MobX powered state management solution based on data trees with first class support for Typescript, snapshots, patches and much more",
   "keywords": [
     "mobx",

--- a/packages/lib/src/snapshot/internal.ts
+++ b/packages/lib/src/snapshot/internal.ts
@@ -50,6 +50,18 @@ function getInternalSnapshotParent(
 /**
  * @ignore
  */
+export const unsetInternalSnapshot = action("unsetInternalSnapshot", (value: any) => {
+  const oldSn = getInternalSnapshot(value) as SnapshotData<any>
+
+  if (oldSn) {
+    snapshots.delete(value)
+    oldSn.atom.reportChanged()
+  }
+})
+
+/**
+ * @ignore
+ */
 export const setInternalSnapshot = action(
   "setInternalSnapshot",
   <T extends object>(value: any, standard: T): void => {

--- a/packages/lib/src/tweaker/core.ts
+++ b/packages/lib/src/tweaker/core.ts
@@ -6,7 +6,7 @@ import { failure, isPrimitive } from "../utils"
 /**
  * @ignore
  */
-export const tweakedObjects = new WeakSet<Object>()
+export const tweakedObjects = new WeakMap<Object, undefined | (() => void)>()
 
 /**
  * @ignore

--- a/packages/lib/src/tweaker/tweakFrozen.ts
+++ b/packages/lib/src/tweaker/tweakFrozen.ts
@@ -11,7 +11,7 @@ export function tweakFrozen<T extends Frozen<any>>(
   frozenObj: T,
   parentPath: ParentPath<any> | undefined
 ): T {
-  tweakedObjects.add(frozenObj)
+  tweakedObjects.set(frozenObj, undefined)
   setParent(frozenObj, parentPath)
 
   // we DON'T want data proxified, but the snapshot is the data itself

--- a/packages/lib/src/tweaker/tweakModel.ts
+++ b/packages/lib/src/tweaker/tweakModel.ts
@@ -6,7 +6,7 @@ import { tweakedObjects } from "./core"
  * @ignore
  */
 export function tweakModel<T>(value: T, parentPath: ParentPath<any> | undefined): T {
-  tweakedObjects.add(value)
+  tweakedObjects.set(value, undefined)
   setParent(value, parentPath)
 
   // nothing to do for models, data is already proxified and its parent is set

--- a/packages/lib/test/model/onChildAttachedTo.test.ts
+++ b/packages/lib/test/model/onChildAttachedTo.test.ts
@@ -161,16 +161,12 @@ test("dynamic target", () => {
 
     @modelAction
     addTodo(todo: Todo) {
-      const oldTodos = this.todos.slice()
-      this.todos.length = 0
-      this.todos = [...oldTodos, todo]
+      this.todos = [...this.todos, todo]
     }
 
     @modelAction
     removeTodo(todo: Todo) {
-      const oldTodos = this.todos.slice()
-      this.todos.length = 0
-      this.todos = oldTodos.filter(t => t !== todo)
+      this.todos = this.todos.filter(t => t !== todo)
     }
   }
 

--- a/packages/lib/test/spread/spread.test.ts
+++ b/packages/lib/test/spread/spread.test.ts
@@ -1,0 +1,498 @@
+import { getSnapshot, model, Model, modelAction, onPatches, Patch, prop } from "../../src"
+import { isTweakedObject } from "../../src/tweaker/core"
+import "../commonSetup"
+
+test("reassigning an array via spreading", () => {
+  @model("SpreadArr_Obj")
+  class Obj extends Model({
+    x: prop(),
+  }) {}
+
+  @model("SpreadArr")
+  class SpreadArr extends Model({
+    arr: prop<Obj[]>(() => []),
+  }) {
+    @modelAction
+    add(x: number) {
+      this.arr = [...this.arr, new Obj({ x })]
+      return this.arr
+    }
+
+    @modelAction
+    set(arr: Obj[]) {
+      this.arr = arr
+    }
+  }
+
+  const events: { patches: Patch[]; invPatches: Patch[] }[] = []
+
+  const arr = new SpreadArr({})
+  onPatches(arr, (patches, invPatches) => {
+    events.push({
+      patches,
+      invPatches,
+    })
+  })
+
+  const a1 = arr.add(1)
+  const a2 = arr.add(2)
+  const a3 = arr.add(3)
+
+  expect(arr.arr[0].x).toBe(1)
+  expect(arr.arr[1].x).toBe(2)
+  expect(arr.arr[2].x).toBe(3)
+
+  expect(getSnapshot(arr)).toMatchInlineSnapshot(`
+            Object {
+              "$modelType": "SpreadArr",
+              "arr": Array [
+                Object {
+                  "$modelType": "SpreadArr_Obj",
+                  "x": 1,
+                },
+                Object {
+                  "$modelType": "SpreadArr_Obj",
+                  "x": 2,
+                },
+                Object {
+                  "$modelType": "SpreadArr_Obj",
+                  "x": 3,
+                },
+              ],
+            }
+      `)
+
+  expect(events).toMatchInlineSnapshot(`
+        Array [
+          Object {
+            "invPatches": Array [
+              Object {
+                "op": "replace",
+                "path": Array [
+                  "arr",
+                ],
+                "value": Array [],
+              },
+            ],
+            "patches": Array [
+              Object {
+                "op": "replace",
+                "path": Array [
+                  "arr",
+                ],
+                "value": Array [
+                  Object {
+                    "$modelType": "SpreadArr_Obj",
+                    "x": 1,
+                  },
+                ],
+              },
+            ],
+          },
+          Object {
+            "invPatches": Array [
+              Object {
+                "op": "replace",
+                "path": Array [
+                  "arr",
+                ],
+                "value": Array [
+                  Object {
+                    "$modelType": "SpreadArr_Obj",
+                    "x": 1,
+                  },
+                ],
+              },
+            ],
+            "patches": Array [
+              Object {
+                "op": "replace",
+                "path": Array [
+                  "arr",
+                ],
+                "value": Array [
+                  Object {
+                    "$modelType": "SpreadArr_Obj",
+                    "x": 1,
+                  },
+                  Object {
+                    "$modelType": "SpreadArr_Obj",
+                    "x": 2,
+                  },
+                ],
+              },
+            ],
+          },
+          Object {
+            "invPatches": Array [
+              Object {
+                "op": "replace",
+                "path": Array [
+                  "arr",
+                ],
+                "value": Array [
+                  Object {
+                    "$modelType": "SpreadArr_Obj",
+                    "x": 1,
+                  },
+                  Object {
+                    "$modelType": "SpreadArr_Obj",
+                    "x": 2,
+                  },
+                ],
+              },
+            ],
+            "patches": Array [
+              Object {
+                "op": "replace",
+                "path": Array [
+                  "arr",
+                ],
+                "value": Array [
+                  Object {
+                    "$modelType": "SpreadArr_Obj",
+                    "x": 1,
+                  },
+                  Object {
+                    "$modelType": "SpreadArr_Obj",
+                    "x": 2,
+                  },
+                  Object {
+                    "$modelType": "SpreadArr_Obj",
+                    "x": 3,
+                  },
+                ],
+              },
+            ],
+          },
+        ]
+    `)
+  events.length = 0
+
+  expect(a1).not.toBe(a2)
+  expect(a1).not.toBe(a3)
+
+  expect(a2).not.toBe(a1)
+  expect(a2).not.toBe(a3)
+
+  expect(a3).not.toBe(a1)
+  expect(a3).not.toBe(a2)
+
+  expect(arr.arr).toBe(a3)
+
+  expect(isTweakedObject(a1)).toBeFalsy()
+  expect(isTweakedObject(a2)).toBeFalsy()
+  expect(isTweakedObject(a3)).toBeTruthy()
+
+  arr.set(a1)
+  expect(arr.arr).toHaveLength(1)
+
+  expect(isTweakedObject(a1)).toBeTruthy()
+  expect(isTweakedObject(a2)).toBeFalsy()
+  expect(isTweakedObject(a3)).toBeFalsy()
+
+  expect(getSnapshot(arr)).toMatchInlineSnapshot(`
+            Object {
+              "$modelType": "SpreadArr",
+              "arr": Array [
+                Object {
+                  "$modelType": "SpreadArr_Obj",
+                  "x": 1,
+                },
+              ],
+            }
+      `)
+
+  expect(events).toMatchInlineSnapshot(`
+        Array [
+          Object {
+            "invPatches": Array [
+              Object {
+                "op": "replace",
+                "path": Array [
+                  "arr",
+                ],
+                "value": Array [
+                  Object {
+                    "$modelType": "SpreadArr_Obj",
+                    "x": 1,
+                  },
+                  Object {
+                    "$modelType": "SpreadArr_Obj",
+                    "x": 2,
+                  },
+                  Object {
+                    "$modelType": "SpreadArr_Obj",
+                    "x": 3,
+                  },
+                ],
+              },
+            ],
+            "patches": Array [
+              Object {
+                "op": "replace",
+                "path": Array [
+                  "arr",
+                ],
+                "value": Array [
+                  Object {
+                    "$modelType": "SpreadArr_Obj",
+                    "x": 1,
+                  },
+                ],
+              },
+            ],
+          },
+        ]
+    `)
+  events.length = 0
+})
+
+test("reassigning an object via spreading", () => {
+  @model("SpreadObj_Obj")
+  class Obj extends Model({
+    x: prop(),
+  }) {}
+
+  @model("SpreadObj")
+  class SpreadObj extends Model({
+    spreadObj: prop<{ [k: string]: Obj }>(() => ({})),
+  }) {
+    @modelAction
+    add(n: string, x: number) {
+      this.spreadObj = {
+        ...this.spreadObj,
+        [n]: new Obj({ x }),
+      }
+      return this.spreadObj
+    }
+
+    @modelAction
+    set(spreadObj: { [k: string]: Obj }) {
+      this.spreadObj = spreadObj
+    }
+  }
+
+  const events: { patches: Patch[]; invPatches: Patch[] }[] = []
+
+  const o = new SpreadObj({})
+  onPatches(o, (patches, invPatches) => {
+    events.push({
+      patches,
+      invPatches,
+    })
+  })
+
+  const o1 = o.add("one", 1)
+  const o2 = o.add("two", 2)
+  const o3 = o.add("three", 3)
+
+  expect(o.spreadObj["one"].x).toBe(1)
+  expect(o.spreadObj["two"].x).toBe(2)
+  expect(o.spreadObj["three"].x).toBe(3)
+
+  expect(getSnapshot(o)).toMatchInlineSnapshot(`
+            Object {
+              "$modelType": "SpreadObj",
+              "spreadObj": Object {
+                "one": Object {
+                  "$modelType": "SpreadObj_Obj",
+                  "x": 1,
+                },
+                "three": Object {
+                  "$modelType": "SpreadObj_Obj",
+                  "x": 3,
+                },
+                "two": Object {
+                  "$modelType": "SpreadObj_Obj",
+                  "x": 2,
+                },
+              },
+            }
+      `)
+
+  expect(events).toMatchInlineSnapshot(`
+    Array [
+      Object {
+        "invPatches": Array [
+          Object {
+            "op": "replace",
+            "path": Array [
+              "spreadObj",
+            ],
+            "value": Object {},
+          },
+        ],
+        "patches": Array [
+          Object {
+            "op": "replace",
+            "path": Array [
+              "spreadObj",
+            ],
+            "value": Object {
+              "one": Object {
+                "$modelType": "SpreadObj_Obj",
+                "x": 1,
+              },
+            },
+          },
+        ],
+      },
+      Object {
+        "invPatches": Array [
+          Object {
+            "op": "replace",
+            "path": Array [
+              "spreadObj",
+            ],
+            "value": Object {
+              "one": Object {
+                "$modelType": "SpreadObj_Obj",
+                "x": 1,
+              },
+            },
+          },
+        ],
+        "patches": Array [
+          Object {
+            "op": "replace",
+            "path": Array [
+              "spreadObj",
+            ],
+            "value": Object {
+              "one": Object {
+                "$modelType": "SpreadObj_Obj",
+                "x": 1,
+              },
+              "two": Object {
+                "$modelType": "SpreadObj_Obj",
+                "x": 2,
+              },
+            },
+          },
+        ],
+      },
+      Object {
+        "invPatches": Array [
+          Object {
+            "op": "replace",
+            "path": Array [
+              "spreadObj",
+            ],
+            "value": Object {
+              "one": Object {
+                "$modelType": "SpreadObj_Obj",
+                "x": 1,
+              },
+              "two": Object {
+                "$modelType": "SpreadObj_Obj",
+                "x": 2,
+              },
+            },
+          },
+        ],
+        "patches": Array [
+          Object {
+            "op": "replace",
+            "path": Array [
+              "spreadObj",
+            ],
+            "value": Object {
+              "one": Object {
+                "$modelType": "SpreadObj_Obj",
+                "x": 1,
+              },
+              "three": Object {
+                "$modelType": "SpreadObj_Obj",
+                "x": 3,
+              },
+              "two": Object {
+                "$modelType": "SpreadObj_Obj",
+                "x": 2,
+              },
+            },
+          },
+        ],
+      },
+    ]
+  `)
+  events.length = 0
+
+  expect(o1).not.toBe(o2)
+  expect(o1).not.toBe(o3)
+
+  expect(o2).not.toBe(o1)
+  expect(o2).not.toBe(o3)
+
+  expect(o3).not.toBe(o1)
+  expect(o3).not.toBe(o2)
+
+  expect(o.spreadObj).toBe(o3)
+
+  expect(isTweakedObject(o1)).toBeFalsy()
+  expect(isTweakedObject(o2)).toBeFalsy()
+  expect(isTweakedObject(o3)).toBeTruthy()
+
+  o.set(o1)
+  expect(Object.keys(o.spreadObj)).toEqual(["one"])
+
+  expect(isTweakedObject(o1)).toBeTruthy()
+  expect(isTweakedObject(o2)).toBeFalsy()
+  expect(isTweakedObject(o3)).toBeFalsy()
+
+  expect(getSnapshot(o)).toMatchInlineSnapshot(`
+            Object {
+              "$modelType": "SpreadObj",
+              "spreadObj": Object {
+                "one": Object {
+                  "$modelType": "SpreadObj_Obj",
+                  "x": 1,
+                },
+              },
+            }
+      `)
+
+  expect(events).toMatchInlineSnapshot(`
+    Array [
+      Object {
+        "invPatches": Array [
+          Object {
+            "op": "replace",
+            "path": Array [
+              "spreadObj",
+            ],
+            "value": Object {
+              "one": Object {
+                "$modelType": "SpreadObj_Obj",
+                "x": 1,
+              },
+              "three": Object {
+                "$modelType": "SpreadObj_Obj",
+                "x": 3,
+              },
+              "two": Object {
+                "$modelType": "SpreadObj_Obj",
+                "x": 2,
+              },
+            },
+          },
+        ],
+        "patches": Array [
+          Object {
+            "op": "replace",
+            "path": Array [
+              "spreadObj",
+            ],
+            "value": Object {
+              "one": Object {
+                "$modelType": "SpreadObj_Obj",
+                "x": 1,
+              },
+            },
+          },
+        ],
+      },
+    ]
+  `)
+  events.length = 0
+})


### PR DESCRIPTION
- Better support for array / object spreading, reassing to filter/map, etc. Objects and arrays will be automatically unconverted from tree nodes when detached.

Basically stuff such as
```
this.todos = [...this.todos, newTodo]
this.todos = this.todos.filter(t => t.done)
```

Now will work without complaining that the objects were already in the tree and already had a parent. (Note that it is usually recommended to use mutable methods to generate smaller patches though)