### PR TITLE
Root ref and other goodies

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,9 @@
 ## 0.19.0
 
 - Added `setDefaultComputed` and `getProviderNode` to contexts.
+- [BREAKING CHANGE] `getChildrenObjects` will now never report interim data objects (`$`).
+- Optimizations to `getChildrenObjects` and `onChildAttachedTo`.
+- Added `rootRef`s.
 
 ## 0.18.0
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## 0.19.0
 
-- Added `setDefaultComputed` to contexts.
+- Added `setDefaultComputed` and `getProviderNode` to contexts.
 
 ## 0.18.0
 

--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
   ],
   "devDependencies": {
     "coveralls": "^3.0.4",
-    "eslint": "^6.3.0",
+    "eslint": "^6.4.0",
     "lerna": "^3.15.0",
     "netlify-cli": "^2.15.0",
     "prettier": "^1.17.0"

--- a/packages/lib/package.json
+++ b/packages/lib/package.json
@@ -1,6 +1,6 @@
 {
   "name": "mobx-keystone",
-  "version": "0.18.0",
+  "version": "0.19.0",
   "description": "A MobX powered state management solution based on data trees with first class support for Typescript, snapshots, patches and much more",
   "keywords": [
     "mobx",

--- a/packages/lib/package.json
+++ b/packages/lib/package.json
@@ -49,13 +49,13 @@
     "mobx": "^5.0.0",
     "shx": "^0.3.2",
     "spec.ts": "^1.1.3",
-    "ts-node": "^8.3.0",
+    "ts-node": "^8.4.1",
     "tsdx": "^0.9.2",
     "typedoc": "^0.15.0",
     "typescript": "^3.6.3"
   },
   "dependencies": {
-    "ts-toolbelt": "^3.8.92",
+    "ts-toolbelt": "^3.11.0",
     "tslib": "^1.10.0"
   },
   "directories": {

--- a/packages/lib/src/context/context.ts
+++ b/packages/lib/src/context/context.ts
@@ -32,7 +32,7 @@ export interface Context<T> {
   get(node: object): T
 
   /**
-   * Gets node that will provide the context value, or undefined
+   * Gets node that will provide the context value, or `undefined`
    * if it comes from the default.
    * @param node
    */

--- a/packages/lib/src/parent/core.ts
+++ b/packages/lib/src/parent/core.ts
@@ -1,4 +1,4 @@
-import { createAtom, IAtom, ObservableSet } from "mobx"
+import { createAtom, IAtom } from "mobx"
 import { ParentPath } from "./path"
 
 /**
@@ -10,11 +10,6 @@ export const objectParents = new WeakMap<object, ParentPath<object> | undefined>
  * @ignore
  */
 export const objectParentsAtoms = new WeakMap<object, IAtom>()
-
-/**
- * @ignore
- */
-export const objectChildren = new WeakMap<object, ObservableSet<object>>()
 
 /**
  * @ignore

--- a/packages/lib/src/parent/coreObjectChildren.ts
+++ b/packages/lib/src/parent/coreObjectChildren.ts
@@ -1,0 +1,119 @@
+import { action, createAtom, IAtom, observable, ObservableSet } from "mobx"
+import { isModel } from "../model/utils"
+import { fastGetParent, fastIsModelDataObject } from "./path"
+
+const defaultObservableSetOptions = { deep: false }
+
+const objectChildren = new WeakMap<
+  object,
+  {
+    shallow: ObservableSet<object>
+    deep: ReadonlySet<object>
+    deepDirty: boolean
+    deepAtom: IAtom
+  }
+>()
+
+/**
+ * @ignore
+ */
+export function initializeObjectChildren(node: object) {
+  if (objectChildren.has(node)) {
+    return
+  }
+
+  objectChildren.set(node, {
+    shallow: observable.set(undefined, defaultObservableSetOptions),
+    deep: new Set<object>(),
+    deepDirty: true,
+    deepAtom: createAtom("deepChildrenAtom"),
+  })
+}
+
+/**
+ * @ignore
+ */
+export function getObjectChildren(node: object): ReadonlySet<object> {
+  return objectChildren.get(node)!.shallow
+}
+
+/**
+ * @ignore
+ */
+export function getDeepObjectChildren(node: object): ReadonlySet<object> {
+  const obj = objectChildren.get(node)!
+  if (obj.deepDirty) {
+    updateDeepObjectChildren(node)
+  }
+  obj.deepAtom.reportObserved()
+  return obj.deep
+}
+
+const updateDeepObjectChildren = action(
+  (node: object): ReadonlySet<object> => {
+    const obj = objectChildren.get(node)!
+    if (!obj.deepDirty) {
+      return obj.deep
+    }
+
+    const nodeIsModel = isModel(node)
+    const set = new Set<object>()
+
+    const childrenIter = getObjectChildren(node)!.values()
+    let ch = childrenIter.next()
+    while (!ch.done) {
+      if (!nodeIsModel || !fastIsModelDataObject(ch.value)) {
+        set.add(ch.value)
+      }
+
+      const ret = updateDeepObjectChildren(ch.value)
+      const retIter = ret.values()
+      let retCur = retIter.next()
+      while (!retCur.done) {
+        set.add(retCur.value)
+        retCur = retIter.next()
+      }
+
+      ch = childrenIter.next()
+    }
+
+    obj.deep = set
+    obj.deepDirty = false
+    obj.deepAtom.reportChanged()
+    return set
+  }
+)
+
+/**
+ * @ignore
+ */
+export const addObjectChild = action((node: object, child: object) => {
+  const obj = objectChildren.get(node)!
+  obj.shallow.add(child)
+
+  invalidateDeepChildren(node)
+})
+
+/**
+ * @ignore
+ */
+export const removeObjectChild = action((node: object, child: object) => {
+  const obj = objectChildren.get(node)!
+  obj.shallow.delete(child)
+
+  invalidateDeepChildren(node)
+})
+
+function invalidateDeepChildren(node: object) {
+  const obj = objectChildren.get(node)!
+
+  if (!obj.deepDirty) {
+    obj.deepDirty = true
+    obj.deepAtom.reportChanged()
+  }
+
+  const parent = fastGetParent(node)
+  if (parent) {
+    invalidateDeepChildren(parent)
+  }
+}

--- a/packages/lib/src/parent/onChildAttachedTo.ts
+++ b/packages/lib/src/parent/onChildAttachedTo.ts
@@ -1,5 +1,4 @@
 import { reaction } from "mobx"
-import { BaseModel } from "../model"
 import { assertIsFunction } from "../utils"
 import { getChildrenObjects } from "./getChildrenObjects"
 
@@ -57,10 +56,18 @@ export function onChildAttachedTo(
   const getChildrenObjectOpts = { deep: opts.deep }
   const getCurrentChildren = () => {
     let t = target()
-    if (t instanceof BaseModel) {
-      t = t.$
+    const children = getChildrenObjects(t, getChildrenObjectOpts)
+
+    const set = new Set<object>()
+
+    const iter = children.values()
+    let cur = iter.next()
+    while (!cur.done) {
+      set.add(cur.value)
+      cur = iter.next()
     }
-    return getChildrenObjects(t, getChildrenObjectOpts)
+
+    return set
   }
 
   const currentChildren = opts.runForCurrentChildren ? new Set<object>() : getCurrentChildren()

--- a/packages/lib/src/parent/optimizedWalkTree.ts
+++ b/packages/lib/src/parent/optimizedWalkTree.ts
@@ -1,0 +1,45 @@
+import { isModel } from "../model/utils"
+import { getSnapshot } from "../snapshot/getSnapshot"
+import { getObjectChildren } from "./coreObjectChildren"
+
+/**
+ * @ignore
+ *
+ * Like walkTree parent first mode, except that it won't revisit deeply unchanged nodes
+ * and will cache any results for that tree branch.
+ * Used to search (e.g., resolve IDs).
+ */
+export function optimizedWalkTreeSearch<T = void>(
+  target: object,
+  alreadyVisited: WeakMap<object, T | undefined>,
+  predicate: (node: object) => T | undefined
+): T | undefined {
+  let realTarget = target
+  if (isModel(target)) {
+    realTarget = target.$
+  }
+
+  const targetSn = getSnapshot(realTarget)
+  if (alreadyVisited.has(targetSn)) {
+    return alreadyVisited.get(targetSn)
+  }
+
+  const ret = predicate(target)
+  alreadyVisited.set(targetSn, ret)
+  if (ret !== undefined) {
+    return ret
+  }
+
+  const childrenIter = getObjectChildren(realTarget)!.values()
+  let cur = childrenIter.next()
+  while (!cur.done) {
+    const child = cur.value
+    const ret = optimizedWalkTreeSearch(child, alreadyVisited, predicate)
+    if (ret !== undefined) {
+      return ret
+    }
+    cur = childrenIter.next()
+  }
+
+  return undefined
+}

--- a/packages/lib/src/parent/path.ts
+++ b/packages/lib/src/parent/path.ts
@@ -2,6 +2,7 @@ import { BaseModel } from "../model/BaseModel"
 import { assertTweakedObject } from "../tweaker/core"
 import { isObject } from "../utils"
 import { objectParents, reportParentPathObserved } from "./core"
+import { getDeepObjectChildren } from "./coreObjectChildren"
 
 /**
  * Path from an object to its immediate parent.
@@ -190,15 +191,19 @@ export function isChildOfParent(child: object, parent: object): boolean {
   assertTweakedObject(child, "child")
   assertTweakedObject(parent, "parent")
 
-  let current = child
-  let parentPath
-  while ((parentPath = fastGetParentPath(current))) {
-    current = parentPath.parent
-    if (current === parent) {
+  // since deep children does not include "$" we will check the parent
+  if (fastIsModelDataObject(child)) {
+    child = fastGetParent(child)!
+    // edge case, where we are checking if $ is child of model directly
+    if (child === parent) {
       return true
     }
   }
-  return false
+  if (fastIsModelDataObject(parent)) {
+    parent = fastGetParent(parent)!
+  }
+
+  return getDeepObjectChildren(parent).has(child)
 }
 
 /**

--- a/packages/lib/src/parent/walkTree.ts
+++ b/packages/lib/src/parent/walkTree.ts
@@ -1,5 +1,5 @@
 import { assertTweakedObject } from "../tweaker/core"
-import { objectChildren } from "./core"
+import { getObjectChildren } from "./coreObjectChildren"
 
 /**
  * Mode for the `walkTree` method.
@@ -49,7 +49,7 @@ function walkTreeParentFirst<T = void>(
     return ret
   }
 
-  const childrenIter = objectChildren.get(target)!.values()
+  const childrenIter = getObjectChildren(target)!.values()
   let ch = childrenIter.next()
   while (!ch.done) {
     const ret = walkTreeParentFirst(ch.value, predicate)
@@ -66,7 +66,7 @@ function walkTreeChildrenFirst<T = void>(
   target: object,
   predicate: (node: object) => T | undefined
 ): T | undefined {
-  const childrenIter = objectChildren.get(target)!.values()
+  const childrenIter = getObjectChildren(target)!.values()
   let ch = childrenIter.next()
   while (!ch.done) {
     const ret = walkTreeChildrenFirst(ch.value, predicate)

--- a/packages/lib/src/ref/Ref.ts
+++ b/packages/lib/src/ref/Ref.ts
@@ -1,0 +1,63 @@
+import { computed } from "mobx"
+import { ModelClass } from "../model/BaseModel"
+import { Model } from "../model/Model"
+import { typesString } from "../typeChecking/primitives"
+import { tProp } from "../typeChecking/tProp"
+import { failure } from "../utils"
+
+/**
+ * A reference model base type.
+ * Use `customRef` to create a custom ref constructor.
+ */
+export abstract class Ref<T extends object> extends Model({
+  /**
+   * Reference id.
+   */
+  id: tProp(typesString),
+}) {
+  protected abstract resolve(): T | undefined
+
+  /**
+   * The object this reference points to, or undefined if the reference is currently invalid.
+   */
+  @computed
+  get maybeCurrent(): T | undefined {
+    return this.resolve()
+  }
+
+  /**
+   * If the reference is currently valid.
+   */
+  @computed
+  get isValid(): boolean {
+    return !!this.maybeCurrent
+  }
+
+  /**
+   * The object this reference points to, or throws if invalid.
+   */
+  @computed
+  get current(): T {
+    const current = this.maybeCurrent
+
+    if (!current) {
+      throw failure(
+        `a reference of type '${this.$modelType}' could not resolve an object with id '${this.id}'`
+      )
+    }
+
+    return current
+  }
+}
+
+export declare const customRefTypeSymbol: unique symbol
+
+/** A ref constructor for custom refs */
+export interface RefConstructor<T extends object> {
+  (valueOrID: T | string): Ref<T>
+
+  refClass: ModelClass<Ref<T>>
+
+  /** @internal */
+  [customRefTypeSymbol]: T // just for typings
+}

--- a/packages/lib/src/ref/Ref.ts
+++ b/packages/lib/src/ref/Ref.ts
@@ -18,7 +18,7 @@ export abstract class Ref<T extends object> extends Model({
   protected abstract resolve(): T | undefined
 
   /**
-   * The object this reference points to, or undefined if the reference is currently invalid.
+   * The object this reference points to, or `undefined` if the reference is currently invalid.
    */
   @computed
   get maybeCurrent(): T | undefined {

--- a/packages/lib/src/ref/core.ts
+++ b/packages/lib/src/ref/core.ts
@@ -12,7 +12,7 @@ export type RefResolver<T extends object> = (ref: Ref<T>) => T | undefined
 /**
  * Reference ID resolver type.
  */
-export type RefIdResolver<T extends object> = (target: T) => string | undefined
+export type RefIdResolver<T extends object | unknown> = (target: T) => string | undefined
 
 /**
  * Reference resolve valude changed hook type.

--- a/packages/lib/src/ref/core.ts
+++ b/packages/lib/src/ref/core.ts
@@ -1,0 +1,109 @@
+import { reaction } from "mobx"
+import { model } from "../model/modelDecorator"
+import { isModel } from "../model/utils"
+import { assertIsObject, failure } from "../utils"
+import { Ref, RefConstructor } from "./Ref"
+
+/**
+ * Reference resolver type.
+ */
+export type RefResolver<T extends object> = (ref: Ref<T>) => T | undefined
+
+/**
+ * Reference ID resolver type.
+ */
+export type RefIdResolver<T extends object> = (target: T) => string | undefined
+
+/**
+ * Reference resolve valude changed hook type.
+ */
+export type RefOnResolvedValueChange<T extends object> = (
+  ref: Ref<T>,
+  newValue: T | undefined,
+  oldValue: T | undefined
+) => void
+
+/**
+ * @ignore
+ */
+export function internalCustomRef<T extends object>(
+  modelTypeId: string,
+  resolverGen: () => RefResolver<T>,
+  getId: RefIdResolver<T>,
+  onResolvedValueChange: RefOnResolvedValueChange<T> | undefined
+): RefConstructor<T> {
+  @model(modelTypeId)
+  class CustomRef extends Ref<T> {
+    private resolver?: RefResolver<T>
+
+    resolve(): T | undefined {
+      if (!this.resolver) {
+        this.resolver = resolverGen()
+      }
+
+      return this.resolver(this)
+    }
+  }
+
+  const fn = (target: T) => {
+    let id: string | undefined
+    if (typeof target === "string") {
+      id = target
+    } else {
+      assertIsObject(target, "target")
+      id = getId(target)
+    }
+
+    if (typeof id !== "string") {
+      throw failure("ref target object must have an id of string type")
+    }
+
+    const model = new CustomRef({
+      id,
+    })
+
+    // listen to changes
+    if (onResolvedValueChange) {
+      let oldValue = model.maybeCurrent
+      // TODO: will not disposing this leak?
+      reaction(
+        () => model.maybeCurrent,
+        newValue => {
+          if (newValue !== oldValue) {
+            const savedOldValue = oldValue
+            oldValue = newValue
+            onResolvedValueChange!(model, newValue, savedOldValue)
+          }
+        },
+        {
+          fireImmediately: true,
+        }
+      )
+    }
+
+    return model
+  }
+  fn.refClass = CustomRef
+
+  return (fn as any) as RefConstructor<T>
+}
+
+/**
+ * Uses a model `getRefId()` method whenever possible to get a reference ID.
+ * If the model does not have an implementation of that method it returns `undefined`.
+ * If the model has an implementation, but that implementation returns anything other than
+ * a `string` it will throw.
+ *
+ * @param target Target object to get the ID from.
+ * @returns The string ID or `undefined`.
+ */
+export function getModelRefId(target: object): string | undefined {
+  if (isModel(target) && target.getRefId) {
+    const id = target.getRefId()
+    if (typeof id !== "string") {
+      throw failure("'getRefId()' must return a string when present")
+    }
+    return id
+  }
+  return undefined
+}

--- a/packages/lib/src/ref/customRef.ts
+++ b/packages/lib/src/ref/customRef.ts
@@ -1,56 +1,11 @@
-import { computed, reaction } from "mobx"
-import { ModelClass } from "../model/BaseModel"
-import { Model } from "../model/Model"
-import { model } from "../model/modelDecorator"
-import { isModel } from "../model/utils"
-import { typesString } from "../typeChecking/primitives"
-import { tProp } from "../typeChecking/tProp"
-import { assertIsObject, failure } from "../utils"
-
-/**
- * A reference model base type.
- * Use `customRef` to create a custom ref constructor.
- */
-export abstract class Ref<T extends object> extends Model({
-  /**
-   * Reference id.
-   */
-  id: tProp(typesString),
-}) {
-  protected abstract resolve(): T | undefined
-
-  /**
-   * The object this reference points to, or undefined if the reference is currently invalid.
-   */
-  @computed
-  get maybeCurrent(): T | undefined {
-    return this.resolve()
-  }
-
-  /**
-   * If the reference is currently valid.
-   */
-  @computed
-  get isValid(): boolean {
-    return !!this.maybeCurrent
-  }
-
-  /**
-   * The object this reference points to, or throws if invalid.
-   */
-  @computed
-  get current(): T {
-    const current = this.maybeCurrent
-
-    if (!current) {
-      throw failure(
-        `a reference of type '${this.$modelType}' could not resolve an object with id '${this.id}'`
-      )
-    }
-
-    return current
-  }
-}
+import {
+  getModelRefId,
+  internalCustomRef,
+  RefIdResolver,
+  RefOnResolvedValueChange,
+  RefResolver,
+} from "./core"
+import { RefConstructor } from "./Ref"
 
 /**
  * Custom reference options.
@@ -62,15 +17,15 @@ export interface CustomRefOptions<T extends object> {
    * @param ref Reference object.
    * @returns The resolved object or undefined if it could not be resolved.
    */
-  resolve(ref: Ref<T>): T | undefined
+  resolve: RefResolver<T>
 
   /**
-   * Must return the ID associated to the given target object.
-   * If not provided it will try to get the reference Id from the model `getRefId()` method.
+   * Must return the ID associated to the given target object, or `undefined` if it has no ID.
+   * If not provided it will try to get the reference id from the model `getRefId()` method.
    *
    * @param target Target object.
    */
-  getId?(target: T): string
+  getId?: RefIdResolver<T>
 
   /**
    * What should happen when the resolved value changes.
@@ -79,19 +34,7 @@ export interface CustomRefOptions<T extends object> {
    * @param newValue New resolved value.
    * @param oldValue Old resolved value.
    */
-  onResolvedValueChange?(ref: Ref<T>, newValue: T | undefined, oldValue: T | undefined): void
-}
-
-export declare const customRefTypeSymbol: unique symbol
-
-/** A ref constructor for custom refs */
-export interface RefConstructor<T extends object> {
-  (valueOrID: T | string): Ref<T>
-
-  refClass: ModelClass<Ref<T>>
-
-  /** @internal */
-  [customRefTypeSymbol]: T // just for typings
+  onResolvedValueChange?: RefOnResolvedValueChange<T>
 }
 
 /**
@@ -108,61 +51,5 @@ export function customRef<T extends object>(
 ): RefConstructor<T> {
   const getId = options.getId || getModelRefId
 
-  @model(modelTypeId)
-  class CustomRef extends Ref<T> {
-    resolve(): T | undefined {
-      return options.resolve(this)
-    }
-  }
-
-  const fn = (target: T) => {
-    let id: string
-    if (typeof target === "string") {
-      id = target
-    } else {
-      assertIsObject(target, "target")
-      id = getId(target)
-    }
-    const model = new CustomRef({
-      id,
-    })
-
-    // listen to changes
-    if (options.onResolvedValueChange) {
-      let oldValue = model.maybeCurrent
-      // TODO: will not disposing this leak?
-      reaction(
-        () => model.maybeCurrent,
-        newValue => {
-          if (newValue !== oldValue) {
-            const savedOldValue = oldValue
-            oldValue = newValue
-            options.onResolvedValueChange!(model, newValue, savedOldValue)
-          }
-        },
-        {
-          fireImmediately: true,
-        }
-      )
-    }
-
-    return model
-  }
-  fn.refClass = CustomRef
-
-  return (fn as any) as RefConstructor<T>
-}
-
-function getModelRefId(target: object): string {
-  if (!isModel(target)) {
-    throw failure("automatic reference id resolution only works over model instances")
-  }
-  if (!target.getRefId) {
-    throw failure("'getRefId()' must exist for automatic reference id resolution to work")
-  }
-  const id = target.getRefId()
-  if (typeof id !== "string") {
-    throw failure("'getRefId()' must return a string for automatic reference id resolution to work")
-  }
-  return id
+  return internalCustomRef(modelTypeId, () => options.resolve, getId, options.onResolvedValueChange)
 }

--- a/packages/lib/src/ref/index.ts
+++ b/packages/lib/src/ref/index.ts
@@ -1,1 +1,4 @@
-export { customRef, CustomRefOptions, Ref, RefConstructor } from "./customRef"
+export { getModelRefId, RefIdResolver, RefOnResolvedValueChange, RefResolver } from "./core"
+export { customRef, CustomRefOptions } from "./customRef"
+export { Ref, RefConstructor } from "./Ref"
+export { rootRef, RootRefOptions } from "./rootRef"

--- a/packages/lib/src/ref/rootRef.ts
+++ b/packages/lib/src/ref/rootRef.ts
@@ -20,7 +20,7 @@ export interface RootRefOptions<T extends object> {
    *
    * @param target Target object.
    */
-  getId?: RefIdResolver<any>
+  getId?: RefIdResolver<unknown>
 
   /**
    * What should happen when the resolved value changes.

--- a/packages/lib/src/ref/rootRef.ts
+++ b/packages/lib/src/ref/rootRef.ts
@@ -1,6 +1,7 @@
 import { action, createAtom } from "mobx"
 import { optimizedWalkTreeSearch } from "../parent/optimizedWalkTree"
 import { fastGetRoot } from "../parent/path"
+import { getSnapshot } from "../snapshot/getSnapshot"
 import {
   getModelRefId,
   internalCustomRef,
@@ -60,7 +61,7 @@ export function rootRef<T extends object>(
       // if the root changes then our list of already visited changes
       if (lastRefRoot !== refRoot) {
         lastRefRoot = refRoot
-        alreadyVisited = new WeakMap<object, T | undefined>()
+        alreadyVisited = new WeakMap()
       }
       cachedAtom.reportObserved()
 
@@ -68,6 +69,9 @@ export function rootRef<T extends object>(
         return cachedTarget
       }
 
+      // read root snapshot just to mark it as dependency
+      // (when not found, everytime anything in the tree changes we will perform another search)
+      getSnapshot(refRoot)
       const newTarget = resolveRefRoot(ref, refRoot, getId, alreadyVisited)
       if (newTarget !== cachedTarget) {
         cachedTarget = newTarget

--- a/packages/lib/src/ref/rootRef.ts
+++ b/packages/lib/src/ref/rootRef.ts
@@ -1,0 +1,119 @@
+import { action, createAtom } from "mobx"
+import { optimizedWalkTreeSearch } from "../parent/optimizedWalkTree"
+import { fastGetRoot } from "../parent/path"
+import {
+  getModelRefId,
+  internalCustomRef,
+  RefIdResolver,
+  RefOnResolvedValueChange,
+  RefResolver,
+} from "./core"
+import { Ref, RefConstructor } from "./Ref"
+
+/**
+ * Custom reference options.
+ */
+export interface RootRefOptions<T extends object> {
+  /**
+   * Must return the ID associated to the given target object, or `undefined` if it has no ID.
+   * If not provided it will try to get the reference id from the model `getRefId()` method.
+   *
+   * @param target Target object.
+   */
+  getId?: RefIdResolver<any>
+
+  /**
+   * What should happen when the resolved value changes.
+   *
+   * @param ref Reference object.
+   * @param newValue New resolved value.
+   * @param oldValue Old resolved value.
+   */
+  onResolvedValueChange?: RefOnResolvedValueChange<T>
+}
+
+/**
+ * Creates a root ref to an object, which in its snapshot form has an id.
+ * A root ref will only be able to resolve references as long as both the Ref
+ * and the referenced object share a common root.
+ *
+ * @typeparam T Target object type.
+ * @param modelTypeId Unique model type id.
+ * @param [options] Root reference options.
+ * @returns A function that allows you to construct that type of root reference.
+ */
+export function rootRef<T extends object>(
+  modelTypeId: string,
+  options?: RootRefOptions<T>
+): RefConstructor<T> {
+  const getId = (options && options.getId) || getModelRefId
+  const onResolvedValueChange = options && options.onResolvedValueChange
+
+  const resolverGen = (): RefResolver<T> => {
+    const cachedAtom = createAtom("rootRefCachedTarget")
+    let cachedTarget: T | undefined
+    let alreadyVisited: WeakMap<object, T | undefined>
+    let lastRefRoot: object
+
+    return ref => {
+      const refRoot = fastGetRoot(ref)
+      // if the root changes then our list of already visited changes
+      if (lastRefRoot !== refRoot) {
+        lastRefRoot = refRoot
+        alreadyVisited = new WeakMap<object, T | undefined>()
+      }
+      cachedAtom.reportObserved()
+
+      if (isRefRootCachedTargetOk(ref, refRoot, cachedTarget, getId)) {
+        return cachedTarget
+      }
+
+      const newTarget = resolveRefRoot(ref, refRoot, getId, alreadyVisited)
+      if (newTarget !== cachedTarget) {
+        cachedTarget = newTarget
+        cachedAtom.reportChanged()
+      }
+      return newTarget
+    }
+  }
+
+  return internalCustomRef(modelTypeId, resolverGen, getId, onResolvedValueChange)
+}
+
+function isRefRootCachedTargetOk<T extends object>(
+  ref: Ref<T>,
+  refRoot: object,
+  cachedTarget: T | undefined,
+  getId: RefIdResolver<T>
+): cachedTarget is T {
+  if (!cachedTarget) return false
+  if (ref.id !== getId(cachedTarget)) return false
+  if (refRoot !== fastGetRoot(cachedTarget)) return false
+  return true
+}
+
+/**
+ * @ignore
+ */
+export const resolveRefRoot = action(
+  <T extends object>(
+    ref: Ref<T>,
+    refRoot: object,
+    getId: RefIdResolver<T>,
+    alreadyVisited: WeakMap<object, T | undefined>
+  ): T | undefined => {
+    // this will mark all snapshots that don't have the required id deeply inside as visited
+    // that way we only traverse changed parts of the tree when looking for new ids
+    const found = optimizedWalkTreeSearch(refRoot, alreadyVisited, child => {
+      const id = getId(child as T)
+      if (id === ref.id) {
+        // found
+        return child as T
+      } else {
+        return undefined
+      }
+    })
+
+    return found
+  }
+)

--- a/packages/lib/src/rootStore/rootStore.ts
+++ b/packages/lib/src/rootStore/rootStore.ts
@@ -23,7 +23,7 @@ export const registerRootStore = action(
     assertTweakedObject(node, "node")
 
     if (rootStores.has(node)) {
-      throw failure("object already marked as root store")
+      throw failure("object already registered as root store")
     }
 
     if (!isRoot(node)) {

--- a/packages/lib/src/tweaker/tweak.ts
+++ b/packages/lib/src/tweaker/tweak.ts
@@ -1,7 +1,7 @@
 import { action, isObservableObject } from "mobx"
 import { Frozen } from "../frozen/Frozen"
 import { isModel } from "../model/utils"
-import { objectChildren } from "../parent/core"
+import { getObjectChildren } from "../parent/coreObjectChildren"
 import { fastGetParent, ParentPath } from "../parent/path"
 import { setParent } from "../parent/setParent"
 import { unsetInternalSnapshot } from "../snapshot/internal"
@@ -112,7 +112,7 @@ export function tryUntweak(value: any) {
   // we have to make a copy since it will be changed
   // we have to iterate ourselves since it seems like babel does not do downlevel iteration
   const children = []
-  const childrenIter = objectChildren.get(value)!.values()
+  const childrenIter = getObjectChildren(value)!.values()
   let childrenCur = childrenIter.next()
   while (!childrenCur.done) {
     children.push(childrenCur.value)

--- a/packages/lib/src/typeChecking/ref.ts
+++ b/packages/lib/src/typeChecking/ref.ts
@@ -1,4 +1,4 @@
-import { Ref } from "../ref/customRef"
+import { Ref } from "../ref/Ref"
 import { typesObject } from "./object"
 import { typesString } from "./primitives"
 import { IdentityType } from "./schemas"

--- a/packages/lib/test/context/context.test.ts
+++ b/packages/lib/test/context/context.test.ts
@@ -96,16 +96,22 @@ test("context with static values", () => {
   }
 
   // should use the default for now
-  expect(ctx.get(p)).toBe(1)
   expectReactionCalls(0, 0, 0)
+  expect(ctx.get(p)).toBe(1)
   expect(ctx.get(p.p2!)).toBe(1)
   expect(ctx.get(p.arr)).toBe(1)
+  expect(ctx.getProviderNode(p)).toBe(undefined)
+  expect(ctx.getProviderNode(p.p2!)).toBe(undefined)
+  expect(ctx.getProviderNode(p.arr)).toBe(undefined)
 
   ctx.set(p, 2)
   expectReactionCalls(1, 1, 1)
   expect(ctx.get(p)).toBe(2)
   expect(ctx.get(p.p2!)).toBe(2)
   expect(ctx.get(p.arr)).toBe(2)
+  expect(ctx.getProviderNode(p)).toBe(p)
+  expect(ctx.getProviderNode(p.p2!)).toBe(p)
+  expect(ctx.getProviderNode(p.arr)).toBe(p)
 
   // set same value again
   ctx.set(p, 2)
@@ -113,24 +119,36 @@ test("context with static values", () => {
   expect(ctx.get(p)).toBe(2)
   expect(ctx.get(p.p2!)).toBe(2)
   expect(ctx.get(p.arr)).toBe(2)
+  expect(ctx.getProviderNode(p)).toBe(p)
+  expect(ctx.getProviderNode(p.p2!)).toBe(p)
+  expect(ctx.getProviderNode(p.arr)).toBe(p)
 
   ctx.set(p.p2!, 3)
   expectReactionCalls(0, 1, 0)
   expect(ctx.get(p)).toBe(2)
   expect(ctx.get(p.p2!)).toBe(3)
   expect(ctx.get(p.arr)).toBe(2)
+  expect(ctx.getProviderNode(p)).toBe(p)
+  expect(ctx.getProviderNode(p.p2!)).toBe(p.p2)
+  expect(ctx.getProviderNode(p.arr)).toBe(p)
 
   ctx.unset(p)
   expectReactionCalls(1, 0, 1)
   expect(ctx.get(p)).toBe(1)
   expect(ctx.get(p.p2!)).toBe(3)
   expect(ctx.get(p.arr)).toBe(1)
+  expect(ctx.getProviderNode(p)).toBe(undefined)
+  expect(ctx.getProviderNode(p.p2!)).toBe(p.p2)
+  expect(ctx.getProviderNode(p.arr)).toBe(undefined)
 
   ctx.setDefault(5)
   expectReactionCalls(1, 0, 1)
   expect(ctx.get(p)).toBe(5)
   expect(ctx.get(p.p2!)).toBe(3)
   expect(ctx.get(p.arr)).toBe(5)
+  expect(ctx.getProviderNode(p)).toBe(undefined)
+  expect(ctx.getProviderNode(p.p2!)).toBe(p.p2)
+  expect(ctx.getProviderNode(p.arr)).toBe(undefined)
 })
 
 test("context with computed values", () => {

--- a/packages/lib/test/model/onChildAttachedTo.test.ts
+++ b/packages/lib/test/model/onChildAttachedTo.test.ts
@@ -44,6 +44,9 @@ beforeEach(() => {
         () => node,
         child => {
           const path = getParentToChildPath(node, child)!
+          if (!path) {
+            fail("path between " + node + " and " + child + " could not be found")
+          }
           log("attached", node, child, path)
           return () => {
             log("detached", node, child, path)

--- a/packages/lib/test/parent/__snapshots__/getChildrenObjects.test.ts.snap
+++ b/packages/lib/test/parent/__snapshots__/getChildrenObjects.test.ts.snap
@@ -1,0 +1,51 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`getChildrenObjects {deep: true}: after delete 1`] = `
+Array [
+  "array",
+  "1-1",
+  "array",
+  "1-1-1",
+  "1-1-2",
+  "1-2",
+  "array",
+  "1-2-1",
+  "1-2-2",
+]
+`;
+
+exports[`getChildrenObjects {deep: true}: after re-add 1`] = `
+Array [
+  "array",
+  "1-1",
+  "array",
+  "1-1-1",
+  "1-1-2",
+  "1-2",
+  "array",
+  "1-2-1",
+  "1-2-2",
+  "1-3",
+  "array",
+  "1-3-1",
+  "1-3-2",
+]
+`;
+
+exports[`getChildrenObjects {deep: true}: initial 1`] = `
+Array [
+  "array",
+  "1-1",
+  "array",
+  "1-1-1",
+  "1-1-2",
+  "1-2",
+  "array",
+  "1-2-1",
+  "1-2-2",
+  "1-3",
+  "array",
+  "1-3-1",
+  "1-3-2",
+]
+`;

--- a/packages/lib/test/parent/getChildrenObjects.test.ts
+++ b/packages/lib/test/parent/getChildrenObjects.test.ts
@@ -1,0 +1,106 @@
+import { computed, isObservableArray, reaction } from "mobx"
+import { getChildrenObjects, model, Model, prop, runUnprotected } from "../../src"
+import "../commonSetup"
+import { autoDispose } from "../utils"
+
+@model("C")
+class C extends Model({ id: prop<string>(), children: prop<C[] | undefined>(undefined) }) {}
+
+const deep = true
+
+test(`getChildrenObjects {deep: ${deep}}`, () => {
+  const getChildren = (n: object) => getChildrenObjects(n, { deep })
+
+  const c = new C({
+    id: "1",
+    children: [
+      new C({
+        id: "1-1",
+        children: [new C({ id: "1-1-1" }), new C({ id: "1-1-2" })],
+      }),
+      new C({
+        id: "1-2",
+        children: [new C({ id: "1-2-1" }), new C({ id: "1-2-2" })],
+      }),
+      new C({
+        id: "1-3",
+        children: [new C({ id: "1-3-1" }), new C({ id: "1-3-2" })],
+      }),
+    ],
+  })
+
+  const getChildrenIds = (n: any) =>
+    [...getChildren(n).values()].map((n2: any) => (isObservableArray(n2) ? "array" : n2.id))
+
+  let initialChildren = getChildren(c)
+  let initialChildren1 = getChildren(c.children![0])
+  let initialChildren3 = getChildren(c.children![2])
+
+  let childrenChanges = 0
+  let children1Changes = 0
+  let children3Changes = 0
+
+  autoDispose(
+    reaction(
+      () => getChildren(c),
+      () => {
+        childrenChanges++
+      }
+    )
+  )
+  autoDispose(
+    reaction(
+      () => getChildren(c.children![0]),
+      () => {
+        children1Changes++
+      }
+    )
+  )
+  const children3 = c.children![2]
+  const computedChildren3 = computed(() => getChildren(children3))
+  autoDispose(
+    reaction(
+      () => computedChildren3.get(),
+      () => {
+        children3Changes++
+      }
+    )
+  )
+
+  const expectChildrenChanges = (c: number, c1: number, c3: number) => {
+    expect(childrenChanges).toBe(c)
+    expect(children1Changes).toBe(c1)
+    expect(children3Changes).toBe(c3)
+    childrenChanges = 0
+    children1Changes = 0
+    children3Changes = 0
+  }
+
+  // should always return the same set when unchanged
+  expect(getChildren(c)).toBe(initialChildren)
+  expect(getChildren(c)).toBe(initialChildren)
+  expect(getChildren(c.children![0])).toBe(initialChildren1)
+  expect(getChildren(c.children![0])).toBe(initialChildren1)
+  expect(getChildren(c.children![2])).toBe(initialChildren3)
+  expect(getChildren(c.children![2])).toBe(initialChildren3)
+
+  expect(getChildrenIds(c)).toMatchSnapshot("initial")
+  expectChildrenChanges(0, 0, 0)
+
+  // delete some
+  let deleted!: C
+  runUnprotected(() => {
+    deleted = c.children!.pop()!
+  })
+
+  expect(getChildrenIds(c)).toMatchSnapshot("after delete")
+  expectChildrenChanges(1, 0, 0)
+
+  // add them back
+  runUnprotected(() => {
+    c.children!.push(deleted)
+  })
+
+  expect(getChildrenIds(c)).toMatchSnapshot("after re-add")
+  expectChildrenChanges(1, 0, 0)
+})

--- a/packages/lib/test/parent/parent.test.ts
+++ b/packages/lib/test/parent/parent.test.ts
@@ -90,7 +90,7 @@ test("parent", () => {
     path: ["$", "arr", 0, "$"],
   })
 
-  expect(Array.from(getChildrenObjects(p).values())).toEqual([])
+  expect(Array.from(getChildrenObjects(p).values())).toEqual([p.arr, p.p2])
   expect(Array.from(getChildrenObjects(p.$).values())).toEqual([p.arr, p.p2])
   expect(Array.from(getChildrenObjects(p.arr).values())).toEqual(p.arr)
   expect(Array.from(getChildrenObjects(p.p2!).values())).toEqual([])

--- a/packages/lib/test/parent/walkTree.test.ts
+++ b/packages/lib/test/parent/walkTree.test.ts
@@ -1,5 +1,15 @@
 import { autorun, observable, ObservableMap, runInAction } from "mobx"
-import { AnyModel, detach, model, Model, prop, walkTree, WalkTreeMode } from "../../src"
+import {
+  AnyModel,
+  detach,
+  model,
+  Model,
+  modelAction,
+  prop,
+  walkTree,
+  WalkTreeMode,
+} from "../../src"
+import { optimizedWalkTreeSearch } from "../../src/parent/optimizedWalkTree"
 import "../commonSetup"
 
 test("walktree should be reactive", () => {
@@ -67,4 +77,120 @@ test("walktree should be reactive", () => {
   detach(c2)
 
   expect([...r.registry.entries()]).toEqual([["1", c1], ["3", c3]])
+})
+
+test("optimizedWalkTree", () => {
+  @model("root2")
+  class Root extends Model({
+    children: prop<Child[]>(() => []),
+  }) {
+    id = "root"
+
+    @modelAction
+    addChild(child: Child) {
+      this.children.push(child)
+    }
+  }
+
+  @model("child2")
+  class Child extends Model({
+    id: prop<string>(),
+    child: prop<Child | undefined>(undefined),
+  }) {
+    @modelAction
+    setId(id: string) {
+      this.id = id
+    }
+  }
+
+  const c1 = new Child({ id: "1", child: new Child({ id: "1-1" }) })
+  const c2 = new Child({ id: "2", child: new Child({ id: "2-1" }) })
+  const c3 = new Child({ id: "3", child: new Child({ id: "3-1" }) })
+  const r = new Root({
+    children: [c1, c2, c3],
+  })
+
+  const visited: string[] = []
+
+  const alreadyVisited = new WeakMap<object, any>()
+  const revisit = () => {
+    optimizedWalkTreeSearch(r, alreadyVisited, n => {
+      visited.push((n as any).id)
+    })
+  }
+
+  // initial
+  revisit()
+  // undefined is the children array
+  expect(visited).toMatchInlineSnapshot(`
+    Array [
+      "root",
+      undefined,
+      "1",
+      "1-1",
+      "2",
+      "2-1",
+      "3",
+      "3-1",
+    ]
+  `)
+  visited.length = 0
+
+  // nothing changed
+  revisit()
+  expect(visited).toMatchInlineSnapshot(`Array []`)
+  visited.length = 0
+
+  // add a child
+  r.addChild(new Child({ id: "4", child: new Child({ id: "4-1" }) }))
+  revisit()
+  expect(visited).toMatchInlineSnapshot(`
+    Array [
+      "root",
+      undefined,
+      "4",
+      "4-1",
+    ]
+  `)
+  visited.length = 0
+
+  // nothing changed
+  revisit()
+  expect(visited).toMatchInlineSnapshot(`Array []`)
+  visited.length = 0
+
+  // change a deep child
+  r.children[0]!.child!.setId("1-1ch")
+  revisit()
+  expect(visited).toMatchInlineSnapshot(`
+    Array [
+      "root",
+      undefined,
+      "1",
+      "1-1ch",
+    ]
+  `)
+  visited.length = 0
+
+  // nothing changed
+  revisit()
+  expect(visited).toMatchInlineSnapshot(`Array []`)
+  visited.length = 0
+
+  // change a shallow child
+  r.children[0]!.setId("1ch")
+  revisit()
+  expect(visited).toMatchInlineSnapshot(`
+    Array [
+      "root",
+      undefined,
+      "1ch",
+    ]
+  `)
+  visited.length = 0
+
+  // nothing changed
+  revisit()
+  expect(visited).toMatchInlineSnapshot(`Array []`)
+  visited.length = 0
 })

--- a/packages/lib/test/ref/customRef.test.ts
+++ b/packages/lib/test/ref/customRef.test.ts
@@ -193,11 +193,17 @@ test("array ref works", () => {
   // clone should not be affected
   expect(cloneC.selectedCountries).toEqual([cloneC.countries["spain"], cloneC.countries["uk"]])
 })
-test("getRefId", () => {
+
+test("single selection with getRefId", () => {
   @model("myApp/Todo")
   class Todo extends Model({ id: prop<string>() }) {
     getRefId() {
       return this.id
+    }
+
+    @modelAction
+    setId(id: string) {
+      this.id = id
     }
   }
 
@@ -230,6 +236,7 @@ test("getRefId", () => {
     // getId(todo) {
     //   return todo.id
     // },
+
     resolve(ref) {
       // get the todo list where this ref is
       const todoList = findParent<TodoList>(ref, n => n instanceof TodoList)
@@ -238,6 +245,7 @@ test("getRefId", () => {
       // but if it is attached then try to find it
       return todoList.list.find(todo => todo.id === ref.id)
     },
+
     onResolvedValueChange(ref, newTodo, oldTodo) {
       if (oldTodo && !newTodo) {
         // if the todo value we were referencing disappeared then remove the reference
@@ -252,4 +260,9 @@ test("getRefId", () => {
     selectedRef: todoRef("b"),
   })
   expect(list.selectedTodo).toBe(list.list[1])
+
+  // if we change the todo id then the ref should be gone
+  list.list[1].setId("c")
+  expect(list.list[1].id).toBe("c")
+  expect(list.selectedTodo).toBe(undefined)
 })

--- a/packages/lib/test/ref/rootRef.test.ts
+++ b/packages/lib/test/ref/rootRef.test.ts
@@ -1,0 +1,347 @@
+import { computed, remove, set } from "mobx"
+import {
+  clone,
+  detach,
+  getParent,
+  getSnapshot,
+  model,
+  Model,
+  modelAction,
+  prop,
+  Ref,
+  rootRef,
+  runUnprotected,
+} from "../../src"
+import * as rootRefModule from "../../src/ref/rootRef"
+import "../commonSetup"
+
+@model("Country")
+class Country extends Model({
+  id: prop<string>(),
+  weather: prop<string>(),
+}) {
+  getRefId() {
+    return this.id
+  }
+}
+
+@model("Countries")
+class Countries extends Model({
+  countries: prop<{ [k: string]: Country }>(() => ({})),
+  selectedCountryRef: prop<Ref<Country> | undefined>(),
+  selectedCountriesRef: prop<Ref<Country>[]>(() => []),
+}) {
+  @computed
+  get selectedCountry() {
+    return this.selectedCountryRef ? this.selectedCountryRef.current : undefined
+  }
+
+  @computed
+  get selectedCountries() {
+    return this.selectedCountriesRef.map(r => r.current)
+  }
+
+  @modelAction
+  removeCountry(name: string) {
+    // this is valid in mobx5 but not mobx4
+    // delete this.countries[name]
+    remove(this.countries, name)
+  }
+
+  @modelAction
+  addCountry(c: Country) {
+    set(this.countries, c.id, c)
+  }
+
+  @modelAction
+  setSelectedCountry(country: Country | undefined) {
+    this.selectedCountryRef = country ? countryRef(country) : undefined
+  }
+
+  @modelAction
+  setSelectedCountries(countries: Country[]) {
+    this.selectedCountriesRef = countries.map(c => countryRef(c))
+  }
+}
+
+const countryRef = rootRef<Country>("countryRef", {
+  onResolvedValueChange(ref, newValue, oldValue) {
+    if (oldValue && !newValue) {
+      detach(ref)
+    }
+  },
+})
+
+const initialCountries: () => { [k: string]: Country } = () => ({
+  spain: new Country({
+    id: "spain",
+    weather: "sunny",
+  }),
+  uk: new Country({
+    id: "uk",
+    weather: "rainy",
+  }),
+  france: new Country({
+    id: "france",
+    weather: "soso",
+  }),
+})
+
+test("single ref works", () => {
+  const c = new Countries({
+    countries: initialCountries(),
+  })
+
+  expect(c.selectedCountryRef).toBeUndefined()
+  expect(c.selectedCountry).toBeUndefined()
+
+  const spain = c.countries["spain"]
+  c.setSelectedCountry(spain)
+  expect(c.selectedCountry).toBe(spain)
+
+  const r = c.selectedCountryRef!
+  expect(getSnapshot(r)).toMatchInlineSnapshot(`
+    Object {
+      "$modelType": "countryRef",
+      "id": "spain",
+    }
+  `)
+  expect(r.isValid).toBe(true)
+  expect(r.maybeCurrent).toBe(spain)
+  expect(r.current).toBe(spain)
+
+  // cloning should be ok
+  const cloneC = clone(c)
+  expect(cloneC.countries["spain"]).toBeTruthy()
+  const cloneCSelectedCountry = cloneC.selectedCountry
+  expect(cloneCSelectedCountry).toBe(cloneC.countries["spain"])
+
+  // remove referenced country
+  c.removeCountry("spain")
+
+  // should auto detach itself
+  expect(c.selectedCountry).toBeUndefined()
+  expect(c.selectedCountryRef).toBeUndefined()
+
+  expect(getParent(r)).toBeUndefined()
+  expect(r.isValid).toBe(false)
+  expect(r.maybeCurrent).toBeUndefined()
+  expect(() => r.current).toThrow(
+    "a reference of type 'countryRef' could not resolve an object with id 'spain'"
+  )
+
+  // clone should not be affected
+  expect(cloneC.selectedCountry).toBe(cloneC.countries["spain"])
+})
+
+test("array ref works", () => {
+  const c = new Countries({
+    countries: initialCountries(),
+  })
+
+  expect(c.selectedCountriesRef).toEqual([])
+  expect(c.selectedCountries).toEqual([])
+
+  const spain = c.countries["spain"]
+  const uk = c.countries["uk"]
+  c.setSelectedCountries([spain, uk])
+  expect(c.selectedCountries).toEqual([spain, uk])
+
+  const r = c.selectedCountriesRef
+  expect(getSnapshot(r)).toMatchInlineSnapshot(`
+    Array [
+      Object {
+        "$modelType": "countryRef",
+        "id": "spain",
+      },
+      Object {
+        "$modelType": "countryRef",
+        "id": "uk",
+      },
+    ]
+  `)
+  expect(r.map(rr => rr.isValid)).toEqual([true, true])
+  expect(r.map(rr => rr.maybeCurrent)).toEqual([spain, uk])
+  expect(r.map(rr => rr.current)).toEqual([spain, uk])
+
+  // cloning should be ok
+  const cloneC = clone(c)
+  expect(cloneC.countries["spain"]).toBeTruthy()
+  expect(cloneC.countries["uk"]).toBeTruthy()
+  expect(cloneC.selectedCountries).toEqual([cloneC.countries["spain"], cloneC.countries["uk"]])
+
+  // remove referenced country
+  const oldR = r.slice()
+  c.removeCountry("spain")
+
+  // should auto detach itself
+  expect(c.selectedCountries).toEqual([uk])
+  expect(c.selectedCountriesRef).toHaveLength(1)
+
+  expect(getParent(oldR[0])).toBeUndefined()
+  expect(oldR[0].isValid).toBe(false)
+  expect(oldR[0].maybeCurrent).toBeUndefined()
+  expect(() => oldR[0].current).toThrow(
+    "a reference of type 'countryRef' could not resolve an object with id 'spain'"
+  )
+
+  expect(c.selectedCountriesRef[0]).toBe(oldR[1])
+  expect(getParent(oldR[1])).toBe(c.selectedCountriesRef)
+  expect(oldR[1].isValid).toBe(true)
+  expect(oldR[1].maybeCurrent).toBe(uk)
+  expect(oldR[1].current).toBe(uk)
+
+  // clone should not be affected
+  expect(cloneC.selectedCountries).toEqual([cloneC.countries["spain"], cloneC.countries["uk"]])
+})
+
+test("single selection with custom getId", () => {
+  @model("myApp/Todo")
+  class Todo extends Model({ id: prop<string>() }) {
+    @modelAction
+    setId(id: string) {
+      this.id = id
+    }
+  }
+
+  @model("myApp/TodoList")
+  class TodoList extends Model({
+    list: prop<Todo[]>(() => []),
+    selectedRef: prop<Ref<Todo> | undefined>(),
+  }) {
+    // ...
+
+    // not strictly needed, but neat
+    @computed
+    get selectedTodo() {
+      return this.selectedRef ? this.selectedRef.current : undefined
+    }
+
+    @modelAction
+    selectTodo(todoId: string | undefined) {
+      if (!todoId) {
+        this.selectedRef = undefined
+      } else {
+        const todo = this.list.find(todo => todo.id === todoId)
+        this.selectedRef = todoRef(todo!)
+      }
+    }
+  }
+
+  const todoRef = rootRef<Todo>("myApp/TodoRef", {
+    getId(todo) {
+      return todo instanceof Todo ? todo.id : undefined
+    },
+
+    onResolvedValueChange(ref, newTodo, oldTodo) {
+      if (oldTodo && !newTodo) {
+        // if the todo value we were referencing disappeared then remove the reference
+        // from its parent
+        detach(ref)
+      }
+    },
+  })
+
+  const list = new TodoList({
+    list: [new Todo({ id: "a" }), new Todo({ id: "b" })],
+    selectedRef: todoRef("b"),
+  })
+  expect(list.selectedTodo).toBe(list.list[1])
+
+  // if we change the todo id then the ref should be gone
+  list.list[1].setId("c")
+  expect(list.list[1].id).toBe("c")
+  expect(list.selectedTodo).toBe(undefined)
+})
+
+const countryRef2 = rootRef<Country>("countryRef2")
+
+test("moving ref between roots", () => {
+  const c1 = new Countries({
+    countries: initialCountries(),
+  })
+  const c1Spain = c1.countries["spain"]
+
+  const c2 = new Countries({
+    countries: initialCountries(),
+  })
+  const c2Spain = c2.countries["spain"]
+
+  const ref = countryRef(c1Spain)
+  expect(ref.isValid).toBe(false)
+
+  runUnprotected(() => {
+    c1.selectedCountryRef = ref
+  })
+  expect(c1.selectedCountryRef!.current).toBe(c1Spain)
+  expect(c2.selectedCountryRef).toBe(undefined)
+
+  // switch to c2
+  runUnprotected(() => {
+    c1.selectedCountryRef = undefined
+    c2.selectedCountryRef = ref
+  })
+  expect(c2.selectedCountryRef!.current).toBe(c2Spain)
+  expect(c1.selectedCountryRef).toBe(undefined)
+
+  // switch back to c1
+  runUnprotected(() => {
+    c2.selectedCountryRef = undefined
+    c1.selectedCountryRef = ref
+  })
+  expect(c2.selectedCountryRef).toBe(undefined)
+  expect(c1.selectedCountryRef!.current).toBe(c1Spain)
+})
+
+describe("resolution is cached", () => {
+  let resolveRefRootMock: jest.SpyInstance<object | undefined, any[]>
+
+  beforeEach(() => {
+    resolveRefRootMock = jest.spyOn(rootRefModule, "resolveRefRoot")
+  })
+
+  afterEach(() => {
+    resolveRefRootMock.mockRestore()
+  })
+
+  test("is cached", () => {
+    const c = new Countries({
+      countries: initialCountries(),
+    })
+    const cSpain = c.countries["spain"]
+
+    expect(resolveRefRootMock).not.toHaveBeenCalled()
+
+    const ref = countryRef2(cSpain)
+    expect(resolveRefRootMock).not.toHaveBeenCalled()
+
+    // when not valid it should get called everytime
+    expect(ref.isValid).toBe(false)
+    expect(resolveRefRootMock).toHaveBeenCalledTimes(1)
+    expect(ref.isValid).toBe(false)
+    expect(resolveRefRootMock).toHaveBeenCalledTimes(2)
+
+    runUnprotected(() => {
+      c.selectedCountryRef = ref
+    })
+    expect(resolveRefRootMock).toHaveBeenCalledTimes(2)
+
+    // once valid it should be only called once
+    expect(ref.current).toBe(cSpain)
+    expect(resolveRefRootMock).toHaveBeenCalledTimes(3)
+    expect(ref.current).toBe(cSpain)
+    expect(resolveRefRootMock).toHaveBeenCalledTimes(3)
+
+    c.removeCountry("spain")
+    expect(ref.maybeCurrent).toBe(undefined)
+    expect(resolveRefRootMock).toHaveBeenCalledTimes(4)
+    expect(ref.maybeCurrent).toBe(undefined)
+    expect(resolveRefRootMock).toHaveBeenCalledTimes(5)
+
+    c.addCountry(cSpain)
+    expect(ref.current).toBe(cSpain)
+    expect(resolveRefRootMock).toHaveBeenCalledTimes(6)
+    expect(ref.current).toBe(cSpain)
+    expect(resolveRefRootMock).toHaveBeenCalledTimes(6)
+  })
+})

--- a/packages/site/src/contexts.mdx
+++ b/packages/site/src/contexts.mdx
@@ -62,3 +62,4 @@ The returned context object has the following methods:
 - `set(node, value)` - Sets the (static) value a node will provide for itself and its children. Usually called in `onInit`.
 - `setComputed(node, () => value)` - Sets the (computed) value a node will provide for itself and its children. Usually called in `onInit`.
 - `unset(node)` - Make the node no longer provide a context value.
+- `getProviderNode(node)` - Gets the node that will provide the value, or undefined if it will come from the default value.

--- a/packages/site/src/references.mdx
+++ b/packages/site/src/references.mdx
@@ -12,9 +12,38 @@ This means that, for example, if we wanted to have a list of todos and a selecte
 
 References allow us to work around this limitation by making a "fake" node that is just a pointer to another object given an ID.
 
+## Root references
+
+Root references are references that can be resolved as long as both the reference and the referenced object live under the same tree, this is, as long as they share a common root.
+
+They are created like this:
+
+```ts
+const myRef = rootRef<T>("some unique model type id", {
+  getId?(target: any): string | undefined {
+    // given an object (which could or could not be of the target type)
+    // what is its id? or undefined if it has no id
+    // note that we should only returns ids if our reference should be able to reference them
+  },
+  onResolvedValueChange?(ref: Ref<T>, newValue: T | undefined, oldValue: T | undefined) {
+    // what should happen when the resolved value changes?
+  },
+})
+```
+
+Note that if the reference points to a model and that model class specifies a method named `getRefId()` then `getId` can be omitted.
+
+Reference objects can then be created using `myRef(target: T)` or `myRef(id: string)` and offer the following properties:
+
+- `isValid` - If the reference is valid (can be currently resolved).
+- `current` - The object this reference points to, or throws if invalid.
+- `maybeCurrent` - The object this reference points to, or `undefined` if invalid.
+
 ## Custom references
 
-References are customizable and are created like this:
+Custom references are a bit more powerful than root references, but a bit harder to set up.
+
+They are created like this:
 
 ```ts
 const myRef = customRef<T>("some unique model type id", {
@@ -31,13 +60,9 @@ const myRef = customRef<T>("some unique model type id", {
 })
 ```
 
-Note that if the reference points to a model and that model class specifies a method named `getRefId()` then `getId` can be omitted.
+Again, if the reference points to a model and that model class specifies a method named `getRefId()` then `getId` can be omitted.
 
-Reference objects can then be created using `myRef(target: T)` or `myRef(id: string)` and offer the following properties:
-
-- `isValid` - If the reference is valid (can be currently resolved).
-- `current` - The object this reference points to, or throws if invalid.
-- `maybeCurrent` - The object this reference points to, or `undefined` if invalid.
+They can be created exactly the same way as root references and offer the exact same properties.
 
 ## Example: Reference to single selected Todo
 
@@ -45,8 +70,25 @@ Imagine that we had a todo list where each todo item had a unique `id: string` p
 It could be done like this:
 
 ```ts
+// we could use a root reference that makes use of getRefId on models...
+const todoRef = rootRef<Todo>("myApp/TodoRef", {
+  // this works, but we will use getRefId() from the Todo class instead
+  // getId(maybeTodo) {
+  //   return maybeTodo instanceof Todo ? maybeTodo.id : undefined
+  // },
+
+  onResolvedValueChange(ref, newTodo, oldTodo) {
+    if (oldTodo && !newTodo) {
+      // if the todo value we were referencing disappeared then remove the reference
+      // from its parent
+      detach(ref)
+    }
+  },
+})
+
+// ...or a custom reference
 const todoRef = customRef<Todo>("myApp/TodoRef", {
-  // this works, but we will implement getRefId() on the Todo class instead
+  // we could omit this since getRefId() is declared on the Todo class
   // getId(todo) {
   //   return todo.id
   // },

--- a/packages/site/src/references.mdx
+++ b/packages/site/src/references.mdx
@@ -22,7 +22,7 @@ They are created like this:
 const myRef = rootRef<T>("some unique model type id", {
   getId?(target: unknown): string | undefined {
     // given an object (which could or could not be of the target type)
-    // what is its id? or undefined if it has no id
+    // what is its id? or `undefined` if it has no id
     // note that we should only returns ids if our reference should be able to reference them
   },
   onResolvedValueChange?(ref: Ref<T>, newValue: T | undefined, oldValue: T | undefined) {

--- a/packages/site/src/references.mdx
+++ b/packages/site/src/references.mdx
@@ -20,7 +20,7 @@ They are created like this:
 
 ```ts
 const myRef = rootRef<T>("some unique model type id", {
-  getId?(target: any): string | undefined {
+  getId?(target: unknown): string | undefined {
     // given an object (which could or could not be of the target type)
     // what is its id? or undefined if it has no id
     // note that we should only returns ids if our reference should be able to reference them

--- a/packages/site/src/treeLikeStructure.mdx
+++ b/packages/site/src/treeLikeStructure.mdx
@@ -115,12 +115,12 @@ If the predicate is matched it will return the found node.
 If none is found it will return `undefined`.
 A max depth of 0 is infinite, but another one can be given.
 
-### `getChildrenObjects(node: object, options?: { deep?: boolean, includeModelDataObjects?: boolean }): Set<object>`
+### `getChildrenObjects(node: object, options?: { deep?: boolean }): Set<object>`
 
-Returns all the children objects (this is, excluding primitives) of an object.
+Returns an observable set with all the children objects (this is, excluding primitives) of an object.
 
 Pass the options object with the `deep` option (defaults to `false`) set to `true` to get the children deeply or `false` to get them shallowly.
-Set `includeModelDataObjects` (defaults to `false`) to get the model interim data objects (`$`) or `false` not to.
+Models will report their props as their children directly, so interim data objects (`$`) won't be returned.
 
 ### `walkTree<T = void>(target: object, predicate: (node: any) => T | undefined, mode: WalkTreeMode): T | undefined`
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -6188,10 +6188,10 @@ eslint-visitor-keys@^1.0.0, eslint-visitor-keys@^1.1.0:
   resolved "https://registry.yarnpkg.com/eslint-visitor-keys/-/eslint-visitor-keys-1.1.0.tgz#e2a82cea84ff246ad6fb57f9bde5b46621459ec2"
   integrity sha512-8y9YjtM1JBJU/A9Kc+SbaOV4y29sSWckBwMHa+FGtVj5gN/sbnKDf6xJUl+8g7FAij9LVaP8C24DUiH/f/2Z9A==
 
-eslint@^6.1.0, eslint@^6.3.0:
-  version "6.3.0"
-  resolved "https://registry.yarnpkg.com/eslint/-/eslint-6.3.0.tgz#1f1a902f67bfd4c354e7288b81e40654d927eb6a"
-  integrity sha512-ZvZTKaqDue+N8Y9g0kp6UPZtS4FSY3qARxBs7p4f0H0iof381XHduqVerFWtK8DPtKmemqbqCFENWSQgPR/Gow==
+eslint@^6.1.0, eslint@^6.4.0:
+  version "6.4.0"
+  resolved "https://registry.yarnpkg.com/eslint/-/eslint-6.4.0.tgz#5aa9227c3fbe921982b2eda94ba0d7fae858611a"
+  integrity sha512-WTVEzK3lSFoXUovDHEbkJqCVPEPwbhCq4trDktNI6ygs7aO41d4cDT0JFAT5MivzZeVLWlg7vHL+bgrQv/t3vA==
   dependencies:
     "@babel/code-frame" "^7.0.0"
     ajv "^6.10.0"
@@ -14328,10 +14328,10 @@ ts-jest@^24.0.2:
     semver "^5.5"
     yargs-parser "10.x"
 
-ts-node@^8.3.0:
-  version "8.3.0"
-  resolved "https://registry.yarnpkg.com/ts-node/-/ts-node-8.3.0.tgz#e4059618411371924a1fb5f3b125915f324efb57"
-  integrity sha512-dyNS/RqyVTDcmNM4NIBAeDMpsAdaQ+ojdf0GOLqE6nwJOgzEkdRNzJywhDfwnuvB10oa6NLVG1rUJQCpRN7qoQ==
+ts-node@^8.4.1:
+  version "8.4.1"
+  resolved "https://registry.yarnpkg.com/ts-node/-/ts-node-8.4.1.tgz#270b0dba16e8723c9fa4f9b4775d3810fd994b4f"
+  integrity sha512-5LpRN+mTiCs7lI5EtbXmF/HfMeCjzt7DH9CZwtkr6SywStrNQC723wG+aOWFiLNn7zT3kD/RnFqi3ZUfr4l5Qw==
   dependencies:
     arg "^4.1.0"
     diff "^4.0.1"
@@ -14339,10 +14339,10 @@ ts-node@^8.3.0:
     source-map-support "^0.5.6"
     yn "^3.0.0"
 
-ts-toolbelt@^3.8.92:
-  version "3.8.92"
-  resolved "https://registry.yarnpkg.com/ts-toolbelt/-/ts-toolbelt-3.8.92.tgz#2ab4c4de478447812d17a46a877466110bc719c7"
-  integrity sha512-8weyhjSrpxBdkcSZF4qV6aq/q7S795dKS3SWxGhAs7msilb3eVN8ozuXBlDR5ivQVFvp9cfgwXb+Nb4aKEg0tg==
+ts-toolbelt@^3.11.0:
+  version "3.11.0"
+  resolved "https://registry.yarnpkg.com/ts-toolbelt/-/ts-toolbelt-3.11.0.tgz#5e8eb060a45cfad95eb0f6f3538cee136209f70e"
+  integrity sha512-OJ+baLKTSsXgao7weQdjbGIAEjriPWKy63zZQhRNvtslYA4igN8gHn/6B71NQlSzB0Lt0/tolJfaL6Dc38cESw==
 
 tsdx@^0.9.2:
   version "0.9.2"


### PR DESCRIPTION
## 0.19.0

- Added `setDefaultComputed` and `getProviderNode` to contexts.
- [BREAKING CHANGE] `getChildrenObjects` will now never report interim data objects (`$`).
- Optimizations to `getChildrenObjects` and `onChildAttachedTo`.
- Added `rootRef`s.
