### PR TITLE
Back ref

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Change Log
 
+## 0.20.0
+
+- Added `isRefOfType(ref, refType)` to check if a ref is of a given ref type.
+
 ## 0.19.0
 
 - Added `setDefaultComputed` and `getProviderNode` to contexts.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## 0.20.0
 
 - Added `isRefOfType(ref, refType)` to check if a ref is of a given ref type.
+- Added `getRefsResolvingTo(node, refType?)` to be able to get back references that are currently pointing to a node.
 
 ## 0.19.0
 

--- a/packages/lib/src/ref/Ref.ts
+++ b/packages/lib/src/ref/Ref.ts
@@ -61,3 +61,18 @@ export interface RefConstructor<T extends object> {
   /** @internal */
   [customRefTypeSymbol]: T // just for typings
 }
+
+/**
+ * Checks if a ref object is of a given ref type.
+ *
+ * @typeparam T Referenced object type.
+ * @param ref Reference object.
+ * @param refType Reference type.
+ * @returns `true` if it is of the given type, false otherwise.
+ */
+export function isRefOfType<T extends object>(
+  ref: Ref<object>,
+  refType: RefConstructor<T>
+): ref is Ref<T> {
+  return ref instanceof refType.refClass
+}

--- a/packages/lib/src/ref/core.ts
+++ b/packages/lib/src/ref/core.ts
@@ -75,23 +75,23 @@ export function internalCustomRef<T extends object>(
 
     // listen to changes
 
-    let oldTarget: T | undefined
-    let firstTime = true
+    let savedOldTarget: T | undefined
+    let savedFirstTime = true
 
     // TODO: will not disposing this leak and force the ref to be kept in mem?
     reaction(
       () => ref.maybeCurrent,
       newTarget => {
-        const savedOldTarget = oldTarget
-        const savedFirstTime = firstTime
+        const oldTarget = savedOldTarget
+        const firstTime = savedFirstTime
         // update early in case of thrown exceptions
-        oldTarget = newTarget
-        firstTime = false
+        savedOldTarget = newTarget
+        savedFirstTime = false
 
-        updateBackRefs(ref, fn as any, newTarget, savedOldTarget)
+        updateBackRefs(ref, fn as any, newTarget, oldTarget)
 
-        if (!savedFirstTime && onResolvedValueChange && newTarget !== savedOldTarget) {
-          onResolvedValueChange(ref, newTarget, savedOldTarget)
+        if (!firstTime && onResolvedValueChange && newTarget !== oldTarget) {
+          onResolvedValueChange(ref, newTarget, oldTarget)
         }
       },
       { fireImmediately: true }

--- a/packages/lib/src/ref/core.ts
+++ b/packages/lib/src/ref/core.ts
@@ -1,8 +1,19 @@
-import { reaction } from "mobx"
+import { observable, ObservableSet, reaction } from "mobx"
 import { model } from "../model/modelDecorator"
 import { isModel } from "../model/utils"
+import { assertTweakedObject } from "../tweaker/core"
 import { assertIsObject, failure } from "../utils"
 import { Ref, RefConstructor } from "./Ref"
+
+interface BackRefs<T extends object> {
+  all: ObservableSet<Ref<T>>
+  byType: WeakMap<RefConstructor<T>, ObservableSet<Ref<T>>>
+}
+
+/**
+ * Back-references from object to the references that point to it.
+ */
+const objectBackRefs = new WeakMap<object, BackRefs<object>>()
 
 /**
  * Reference resolver type.
@@ -58,30 +69,35 @@ export function internalCustomRef<T extends object>(
       throw failure("ref target object must have an id of string type")
     }
 
-    const model = new CustomRef({
+    const ref = new CustomRef({
       id,
     })
 
     // listen to changes
-    if (onResolvedValueChange) {
-      let oldValue = model.maybeCurrent
-      // TODO: will not disposing this leak?
-      reaction(
-        () => model.maybeCurrent,
-        newValue => {
-          if (newValue !== oldValue) {
-            const savedOldValue = oldValue
-            oldValue = newValue
-            onResolvedValueChange!(model, newValue, savedOldValue)
-          }
-        },
-        {
-          fireImmediately: true,
-        }
-      )
-    }
 
-    return model
+    let oldTarget: T | undefined
+    let firstTime = true
+
+    // TODO: will not disposing this leak and force the ref to be kept in mem?
+    reaction(
+      () => ref.maybeCurrent,
+      newTarget => {
+        const savedOldTarget = oldTarget
+        const savedFirstTime = firstTime
+        // update early in case of thrown exceptions
+        oldTarget = newTarget
+        firstTime = false
+
+        updateBackRefs(ref, fn as any, newTarget, savedOldTarget)
+
+        if (!savedFirstTime && onResolvedValueChange && newTarget !== savedOldTarget) {
+          onResolvedValueChange(ref, newTarget, savedOldTarget)
+        }
+      },
+      { fireImmediately: true }
+    )
+
+    return ref
   }
   fn.refClass = CustomRef
 
@@ -106,4 +122,64 @@ export function getModelRefId(target: object): string | undefined {
     return id
   }
   return undefined
+}
+
+function getBackRefs(target: object, refType?: RefConstructor<object>): ObservableSet<Ref<object>> {
+  let backRefs = objectBackRefs.get(target)
+  if (!backRefs) {
+    backRefs = {
+      all: observable.set(undefined, { deep: false }),
+      byType: new WeakMap(),
+    }
+    objectBackRefs.set(target, backRefs)
+  }
+
+  if (!refType) {
+    return backRefs.all
+  } else {
+    let byType = backRefs.byType.get(refType)
+    if (!byType) {
+      byType = observable.set(undefined, { deep: false })
+      backRefs.byType.set(refType, byType)
+    }
+    return byType
+  }
+}
+
+/**
+ * Gets all references that resolve to a given object.
+ *
+ * @typeparam T Referenced object type.
+ * @param target Node the references point to.
+ * @param [refType] Pass it to filter by only references of a given type, or do not to get references of any type.
+ * @returns An observable set with all reference objects that point to the given object.
+ */
+export function getRefsResolvingTo<T extends object>(
+  target: T,
+  refType?: RefConstructor<T>
+): ObservableSet<Ref<T>> {
+  assertTweakedObject(target, "target")
+
+  const refTypeObject = refType as RefConstructor<object> | undefined
+  return getBackRefs(target, refTypeObject) as ObservableSet<Ref<T>>
+}
+
+function updateBackRefs<T extends object>(
+  ref: Ref<T>,
+  refClass: RefConstructor<T>,
+  newTarget: T | undefined,
+  oldTarget: T | undefined
+) {
+  if (newTarget === oldTarget) {
+    return
+  }
+
+  if (oldTarget) {
+    getBackRefs(oldTarget).delete(ref)
+    getBackRefs(oldTarget, refClass as RefConstructor<object>).delete(ref)
+  }
+  if (newTarget) {
+    getBackRefs(newTarget).add(ref)
+    getBackRefs(newTarget, refClass as RefConstructor<object>).add(ref)
+  }
 }

--- a/packages/lib/src/ref/customRef.ts
+++ b/packages/lib/src/ref/customRef.ts
@@ -1,3 +1,4 @@
+import { action } from "mobx"
 import {
   getModelRefId,
   internalCustomRef,
@@ -45,11 +46,16 @@ export interface CustomRefOptions<T extends object> {
  * @param options Custom reference options.
  * @returns A function that allows you to construct that type of custom reference.
  */
-export function customRef<T extends object>(
-  modelTypeId: string,
-  options: CustomRefOptions<T>
-): RefConstructor<T> {
-  const getId = options.getId || getModelRefId
+export const customRef = action(
+  "customRef",
+  <T extends object>(modelTypeId: string, options: CustomRefOptions<T>): RefConstructor<T> => {
+    const getId = options.getId || getModelRefId
 
-  return internalCustomRef(modelTypeId, () => options.resolve, getId, options.onResolvedValueChange)
-}
+    return internalCustomRef(
+      modelTypeId,
+      () => options.resolve,
+      getId,
+      options.onResolvedValueChange
+    )
+  }
+)

--- a/packages/lib/src/ref/index.ts
+++ b/packages/lib/src/ref/index.ts
@@ -1,4 +1,10 @@
-export { getModelRefId, RefIdResolver, RefOnResolvedValueChange, RefResolver } from "./core"
+export {
+  getModelRefId,
+  getRefsResolvingTo,
+  RefIdResolver,
+  RefOnResolvedValueChange,
+  RefResolver,
+} from "./core"
 export { customRef, CustomRefOptions } from "./customRef"
 export { isRefOfType, Ref, RefConstructor } from "./Ref"
 export { rootRef, RootRefOptions } from "./rootRef"

--- a/packages/lib/src/ref/index.ts
+++ b/packages/lib/src/ref/index.ts
@@ -1,4 +1,4 @@
 export { getModelRefId, RefIdResolver, RefOnResolvedValueChange, RefResolver } from "./core"
 export { customRef, CustomRefOptions } from "./customRef"
-export { Ref, RefConstructor } from "./Ref"
+export { isRefOfType, Ref, RefConstructor } from "./Ref"
 export { rootRef, RootRefOptions } from "./rootRef"

--- a/packages/lib/test/ref/customRef.test.ts
+++ b/packages/lib/test/ref/customRef.test.ts
@@ -7,6 +7,7 @@ import {
   getParent,
   getParentPath,
   getSnapshot,
+  isRefOfType,
   model,
   Model,
   modelAction,
@@ -328,4 +329,23 @@ describe("resolution", () => {
     expect(calls).toBe(4)
     expect(lastValue).toBe(cSpain)
   })
+})
+
+test("isRefOfType", () => {
+  const c = new Countries({
+    countries: initialCountries(),
+  })
+  const cSpain = c.countries["spain"]
+
+  const ref = countryRef(cSpain)
+  const ref2 = countryRef2(cSpain)
+
+  expect(isRefOfType(ref, countryRef)).toBe(true)
+  expect(isRefOfType(ref2, countryRef)).toBe(false)
+  expect(isRefOfType(ref, countryRef2)).toBe(false)
+  expect(isRefOfType(ref2, countryRef2)).toBe(true)
+
+  // check generic is ok
+  const refObj = ref as Ref<object>
+  expect(isRefOfType(refObj, countryRef)).toBe(true)
 })

--- a/packages/lib/test/ref/rootRef.test.ts
+++ b/packages/lib/test/ref/rootRef.test.ts
@@ -4,6 +4,7 @@ import {
   detach,
   getParent,
   getSnapshot,
+  isRefOfType,
   model,
   Model,
   modelAction,
@@ -384,4 +385,23 @@ describe("resolution", () => {
     expect(calls).toBe(4)
     expect(lastValue).toBe(cSpain)
   })
+})
+
+test("isRefOfType", () => {
+  const c = new Countries({
+    countries: initialCountries(),
+  })
+  const cSpain = c.countries["spain"]
+
+  const ref = countryRef(cSpain)
+  const ref2 = countryRef2(cSpain)
+
+  expect(isRefOfType(ref, countryRef)).toBe(true)
+  expect(isRefOfType(ref2, countryRef)).toBe(false)
+  expect(isRefOfType(ref, countryRef2)).toBe(false)
+  expect(isRefOfType(ref2, countryRef2)).toBe(true)
+
+  // check generic is ok
+  const refObj = ref as Ref<object>
+  expect(isRefOfType(refObj, countryRef)).toBe(true)
 })

--- a/packages/lib/test/ref/rootRef.test.ts
+++ b/packages/lib/test/ref/rootRef.test.ts
@@ -3,6 +3,7 @@ import {
   clone,
   detach,
   getParent,
+  getRefsResolvingTo,
   getSnapshot,
   isRefOfType,
   model,
@@ -306,7 +307,7 @@ describe("resolution", () => {
     resolveRefRootMock.mockRestore()
   })
 
-  test("is cached", () => {
+  test("is cached and backrefs", () => {
     const c = new Countries({
       countries: initialCountries(),
     })
@@ -315,36 +316,71 @@ describe("resolution", () => {
     expect(resolveRefRootMock).not.toHaveBeenCalled()
 
     const ref = countryRef2(cSpain)
-    expect(resolveRefRootMock).not.toHaveBeenCalled()
 
-    // when not valid it should get called everytime
+    // wrap in computeds just to make sure it is ok
+    const countryRefBackRefs = computed(() =>
+      Array.from(getRefsResolvingTo(cSpain, countryRef).values())
+    )
+    const countryRef2BackRefs = computed(() =>
+      Array.from(getRefsResolvingTo(cSpain, countryRef2).values())
+    )
+    const allBackRefs = computed(() => Array.from(getRefsResolvingTo(cSpain).values()))
+
+    function checkBackRefs() {
+      // this kind of ref is not being used, so should be empty always
+      expect(countryRefBackRefs.get()).toEqual([])
+
+      if (ref.maybeCurrent === cSpain) {
+        expect(allBackRefs.get()).toEqual([ref])
+        expect(countryRef2BackRefs.get()).toEqual([ref])
+      } else {
+        expect(allBackRefs.get()).toEqual([])
+        expect(countryRef2BackRefs.get()).toEqual([])
+      }
+    }
+
+    // called once because of auto reaction to changes
+    expect(resolveRefRootMock).toHaveBeenCalledTimes(1)
+
+    // when not valid it should be cached while nothing in its tree changes
     expect(ref.isValid).toBe(false)
     expect(resolveRefRootMock).toHaveBeenCalledTimes(1)
     expect(ref.isValid).toBe(false)
-    expect(resolveRefRootMock).toHaveBeenCalledTimes(2)
+    expect(resolveRefRootMock).toHaveBeenCalledTimes(1)
+
+    checkBackRefs()
 
     runUnprotected(() => {
       c.selectedCountryRef = ref
     })
+    // auto finds new value
     expect(resolveRefRootMock).toHaveBeenCalledTimes(2)
 
-    // once valid it should be only called once
+    // once valid it is cached
     expect(ref.current).toBe(cSpain)
-    expect(resolveRefRootMock).toHaveBeenCalledTimes(3)
+    expect(resolveRefRootMock).toHaveBeenCalledTimes(2)
     expect(ref.current).toBe(cSpain)
-    expect(resolveRefRootMock).toHaveBeenCalledTimes(3)
+    expect(resolveRefRootMock).toHaveBeenCalledTimes(2)
+
+    checkBackRefs()
 
     c.removeCountry("spain")
+    expect(resolveRefRootMock).toHaveBeenCalledTimes(3)
     expect(ref.maybeCurrent).toBe(undefined)
-    expect(resolveRefRootMock).toHaveBeenCalledTimes(4)
+    expect(resolveRefRootMock).toHaveBeenCalledTimes(3)
     expect(ref.maybeCurrent).toBe(undefined)
-    expect(resolveRefRootMock).toHaveBeenCalledTimes(5)
+    expect(resolveRefRootMock).toHaveBeenCalledTimes(3)
+
+    checkBackRefs()
 
     c.addCountry(cSpain)
+    expect(resolveRefRootMock).toHaveBeenCalledTimes(4)
     expect(ref.current).toBe(cSpain)
-    expect(resolveRefRootMock).toHaveBeenCalledTimes(6)
+    expect(resolveRefRootMock).toHaveBeenCalledTimes(4)
     expect(ref.current).toBe(cSpain)
-    expect(resolveRefRootMock).toHaveBeenCalledTimes(6)
+    expect(resolveRefRootMock).toHaveBeenCalledTimes(4)
+
+    checkBackRefs()
   })
 
   test("is reactive", () => {

--- a/packages/site/src/references.mdx
+++ b/packages/site/src/references.mdx
@@ -64,6 +64,10 @@ Again, if the reference points to a model and that model class specifies a metho
 
 They can be created exactly the same way as root references and offer the exact same properties.
 
+## Checking if a reference is of a given type
+
+`isRefOfType(ref, refType)` can be used to check if a reference object is of a given type. For example, `isRefOfType(myRef(...), myRef)` will return true.
+
 ## Example: Reference to single selected Todo
 
 Imagine that we had a todo list where each todo item had a unique `id: string` property, and we could select a single todo item or none.

--- a/packages/site/src/references.mdx
+++ b/packages/site/src/references.mdx
@@ -68,6 +68,11 @@ They can be created exactly the same way as root references and offer the exact 
 
 `isRefOfType(ref, refType)` can be used to check if a reference object is of a given type. For example, `isRefOfType(myRef(...), myRef)` will return true.
 
+## Back-references
+
+Sometimes it is useful to get back all references that currently resolve to a given node.
+For this you can use `getRefsResolvingTo(target, refType?)`, where `target` is the node the references are pointing to and `refType` is an optional argument that when provided will ensure only references of a given type are returned. It returns an observable set of reference objects that point to the target.
+
 ## Example: Reference to single selected Todo
 
 Imagine that we had a todo list where each todo item had a unique `id: string` property, and we could select a single todo item or none.


### PR DESCRIPTION
## 0.20.0

- Added `isRefOfType(ref, refType)` to check if a ref is of a given ref type.
- Added `getRefsResolvingTo(node, refType?)` to be able to get back references that are currently pointing to a node.
