### PR TITLE
do not expose/use/require "$" in paths

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Change Log
 
+## 0.21.0
+
+- [BREAKING CHANGE] Paths to model properties will no longer report interim data objects (`$`). This means that properties are now direct children of model objects, which should be cleaner and more understandable.
+
 ## 0.20.2
 
 - Fixed a possible memory leak with refs.

--- a/packages/lib/package.json
+++ b/packages/lib/package.json
@@ -1,6 +1,6 @@
 {
   "name": "mobx-keystone",
-  "version": "0.20.2",
+  "version": "0.21.0",
   "description": "A MobX powered state management solution based on data trees with first class support for Typescript, snapshots, patches and much more",
   "keywords": [
     "mobx",

--- a/packages/lib/src/actionMiddlewares/onActionMiddleware.ts
+++ b/packages/lib/src/actionMiddlewares/onActionMiddleware.ts
@@ -104,7 +104,7 @@ export function serializeActionCallArgument(argValue: any): any {
   if (isPrimitive(argValue)) {
     return argValue
   }
-  if (isTweakedObject(argValue)) {
+  if (isTweakedObject(argValue, true)) {
     return getSnapshot(argValue)
   }
 

--- a/packages/lib/src/context/context.ts
+++ b/packages/lib/src/context/context.ts
@@ -159,6 +159,8 @@ class ContextClass<T> implements Context<T> {
 
   @action
   set(node: object, value: T) {
+    assertTweakedObject(node, "node")
+
     this.nodeContextValue.set(node, {
       type: "value",
       value,
@@ -168,12 +170,16 @@ class ContextClass<T> implements Context<T> {
 
   @action
   setComputed(node: object, valueFn: () => T) {
+    assertTweakedObject(node, "node")
+
     this.nodeContextValue.set(node, { type: "computed", value: computed(valueFn) })
     this.getNodeAtom(node).reportChanged()
   }
 
   @action
   unset(node: object) {
+    assertTweakedObject(node, "node")
+
     this.nodeContextValue.delete(node)
     this.getNodeAtom(node).reportChanged()
   }

--- a/packages/lib/src/model/BaseModel.ts
+++ b/packages/lib/src/model/BaseModel.ts
@@ -19,11 +19,6 @@ declare const creationDataTypeSymbol: unique symbol
 export const modelInitializedSymbol = Symbol("modelInitialized")
 
 /**
- * @ignore
- */
-export const dataObjectParent = new WeakMap<object, AnyModel>()
-
-/**
  * Base abstract class for models. Use `Model` instead when extending.
  *
  * Never override the constructor, use `onInit` or `onAttachedToRootStore` instead.

--- a/packages/lib/src/model/newModel.ts
+++ b/packages/lib/src/model/newModel.ts
@@ -1,7 +1,6 @@
 import { action, set } from "mobx"
 import { O } from "ts-toolbelt"
 import { isModelAutoTypeCheckingEnabled } from "../globalConfig/globalConfig"
-import { getInternalSnapshot, linkInternalSnapshot } from "../snapshot/internal"
 import { tweakModel } from "../tweaker/tweakModel"
 import { tweakPlainObject } from "../tweaker/tweakPlainObject"
 import { failure, inDevMode, makePropReadonly } from "../utils"
@@ -79,10 +78,6 @@ export const internalNewModel = action(
       false,
       true
     )
-    const newSn = getInternalSnapshot(obsData as any)!
-
-    // make the model use the inner data field snapshot
-    linkInternalSnapshot(modelObj, newSn)
 
     // link it, and make it readonly
     modelObj.$ = obsData

--- a/packages/lib/src/parent/core.ts
+++ b/packages/lib/src/parent/core.ts
@@ -1,4 +1,5 @@
 import { createAtom, IAtom } from "mobx"
+import { isModel } from "../model/utils"
 import { ParentPath } from "./path"
 
 /**
@@ -47,4 +48,24 @@ export function reportParentPathObserved(node: object) {
  */
 export function reportParentPathChanged(node: object) {
   createParentPathAtom(node).reportChanged()
+}
+
+/**
+ * @ignore
+ */
+export const dataObjectParent = new WeakMap<object, object>()
+
+/**
+ * @ignore
+ */
+export function dataToModelNode<T extends object>(node: T): T {
+  const modelNode = dataObjectParent.get(node)
+  return (modelNode as T) || node
+}
+
+/**
+ * @ignore
+ */
+export function modelToDataNode<T extends object>(node: T): T {
+  return isModel(node) ? node.$ : node
 }

--- a/packages/lib/src/parent/coreObjectChildren.ts
+++ b/packages/lib/src/parent/coreObjectChildren.ts
@@ -1,6 +1,5 @@
 import { action, createAtom, IAtom, observable, ObservableSet } from "mobx"
-import { isModel } from "../model/utils"
-import { fastGetParent, fastIsModelDataObject } from "./path"
+import { fastGetParent } from "./path"
 
 const defaultObservableSetOptions = { deep: false }
 
@@ -56,15 +55,12 @@ const updateDeepObjectChildren = action(
       return obj.deep
     }
 
-    const nodeIsModel = isModel(node)
     const set = new Set<object>()
 
     const childrenIter = getObjectChildren(node)!.values()
     let ch = childrenIter.next()
     while (!ch.done) {
-      if (!nodeIsModel || !fastIsModelDataObject(ch.value)) {
-        set.add(ch.value)
-      }
+      set.add(ch.value)
 
       const ret = updateDeepObjectChildren(ch.value)
       const retIter = ret.values()

--- a/packages/lib/src/parent/detach.ts
+++ b/packages/lib/src/parent/detach.ts
@@ -4,7 +4,7 @@ import { ActionContextActionType } from "../action/context"
 import { wrapInAction } from "../action/wrapInAction"
 import { assertTweakedObject } from "../tweaker/core"
 import { failure } from "../utils"
-import { fastGetParentPath } from "./path"
+import { fastGetParentPathIncludingDataObjects } from "./path"
 
 /**
  * Detaches a given object from a tree.
@@ -29,7 +29,7 @@ const wrappedInternalDetach = wrapInAction(
 function internalDetach(this: object): void {
   const node = this
 
-  const parentPath = fastGetParentPath(node)
+  const parentPath = fastGetParentPathIncludingDataObjects(node)
   if (!parentPath) return
 
   const { parent, path } = parentPath

--- a/packages/lib/src/parent/getChildrenObjects.ts
+++ b/packages/lib/src/parent/getChildrenObjects.ts
@@ -1,10 +1,8 @@
-import { isModel } from "../model"
 import { assertTweakedObject } from "../tweaker/core"
 import { getDeepObjectChildren, getObjectChildren } from "./coreObjectChildren"
 
 /**
  * Returns all the children objects (this is, excluding primitives) of an object.
- * Excludes model interim data objects (`$`), so models will report their props as children directly.
  *
  * @param node Object to get the list of children from.
  * @param [options] An optional object with the `deep` option (defaults to false) to true to get
@@ -20,10 +18,6 @@ export function getChildrenObjects(
   assertTweakedObject(node, "node")
 
   if (!options || !options.deep) {
-    if (isModel(node)) {
-      node = node.$
-    }
-
     return getObjectChildren(node)
   } else {
     return getDeepObjectChildren(node)

--- a/packages/lib/src/parent/onChildAttachedTo.ts
+++ b/packages/lib/src/parent/onChildAttachedTo.ts
@@ -1,4 +1,5 @@
 import { reaction } from "mobx"
+import { assertTweakedObject } from "../tweaker/core"
 import { assertIsFunction } from "../utils"
 import { getChildrenObjects } from "./getChildrenObjects"
 
@@ -56,6 +57,8 @@ export function onChildAttachedTo(
   const getChildrenObjectOpts = { deep: opts.deep }
   const getCurrentChildren = () => {
     let t = target()
+    assertTweakedObject(t, "target()")
+
     const children = getChildrenObjects(t, getChildrenObjectOpts)
 
     const set = new Set<object>()

--- a/packages/lib/src/patch/applyPatches.ts
+++ b/packages/lib/src/patch/applyPatches.ts
@@ -2,7 +2,7 @@ import { remove, set } from "mobx"
 import { BuiltInAction } from "../action/builtInActions"
 import { ActionContextActionType } from "../action/context"
 import { wrapInAction } from "../action/wrapInAction"
-import { BaseModel } from "../model/BaseModel"
+import { modelToDataNode } from "../parent/core"
 import { Patch } from "../patch/Patch"
 import { fromSnapshot } from "../snapshot/fromSnapshot"
 import { reconcileSnapshot } from "../snapshot/reconcileSnapshot"
@@ -108,21 +108,16 @@ function pathArrayToObjectAndProp(
     }
   }
 
+  let target: any = modelToDataNode(obj)
+
   if (path.length === 0) {
     return {
-      target: obj,
+      target,
     }
   }
 
-  let target: any = obj
-  if (target instanceof BaseModel) {
-    target = target.$
-  }
   for (let i = 0; i <= path.length - 2; i++) {
-    target = target[path[i]]
-    if (target instanceof BaseModel) {
-      target = target.$
-    }
+    target = modelToDataNode(target[path[i]])
   }
 
   return {

--- a/packages/lib/src/patch/emitPatch.ts
+++ b/packages/lib/src/patch/emitPatch.ts
@@ -1,5 +1,4 @@
 import { action, isAction } from "mobx"
-import { BaseModel } from "../model/BaseModel"
 import { fastGetParentPath } from "../parent/path"
 import { assertTweakedObject } from "../tweaker/core"
 import { assertIsFunction, deleteFromArray } from "../utils"
@@ -123,11 +122,8 @@ function emitPatch(
   if (parentPath) {
     // tweak patches so they include the child path
     const childPath = parentPath.path
-    const parentIsModel = parentPath.parent instanceof BaseModel
-    const newPatches = parentIsModel ? patches : patches.map(p => addPathToPatch(p, childPath))
-    const newInversePatches = parentIsModel
-      ? inversePatches
-      : inversePatches.map(p => addPathToPatch(p, childPath))
+    const newPatches = patches.map(p => addPathToPatch(p, childPath))
+    const newInversePatches = inversePatches.map(p => addPathToPatch(p, childPath))
 
     // false to avoid emitting global patches again for the same change
     emitPatch(parentPath.parent, newPatches, newInversePatches, false)

--- a/packages/lib/src/patch/patchRecorder.ts
+++ b/packages/lib/src/patch/patchRecorder.ts
@@ -1,3 +1,4 @@
+import { assertTweakedObject } from "../tweaker/core"
 import { onGlobalPatches, onPatches, OnPatchesDisposer } from "./emitPatch"
 import { Patch } from "./Patch"
 
@@ -50,6 +51,8 @@ export function patchRecorder(
   subtreeRoot: object,
   opts?: { recording?: boolean; filter?(patches: Patch[], inversePatches: Patch[]): boolean }
 ): PatchRecorder {
+  assertTweakedObject(subtreeRoot, "subtreeRoot")
+
   return internalPatchRecorder(subtreeRoot, opts)
 }
 

--- a/packages/lib/src/redux/connectReduxDevTools.ts
+++ b/packages/lib/src/redux/connectReduxDevTools.ts
@@ -7,6 +7,7 @@ import {
 import { fastGetRootPath, RootPath } from "../parent/path"
 import { applySnapshot } from "../snapshot/applySnapshot"
 import { getSnapshot } from "../snapshot/getSnapshot"
+import { assertTweakedObject } from "../tweaker/core"
 
 /**
  * Connects a tree node to a redux dev tools instance.
@@ -25,6 +26,8 @@ export function connectReduxDevTools(
     logArgsNearName?: boolean
   }
 ) {
+  assertTweakedObject(target, "target")
+
   const opts = {
     logArgsNearName: true,
     ...options,

--- a/packages/lib/src/snapshot/internal.ts
+++ b/packages/lib/src/snapshot/internal.ts
@@ -33,11 +33,6 @@ function getInternalSnapshotParent(
       return undefined
     }
 
-    if (sn === parentSn) {
-      // linked snapshot, skip
-      return getInternalSnapshotParent(parentSn, fastGetParentPath(parentPath.parent))
-    }
-
     return sn
       ? {
           parentSnapshot: parentSn,
@@ -113,20 +108,6 @@ export const setInternalSnapshot = action(
     }
   }
 )
-
-/**
- * @ignore
- */
-export function linkInternalSnapshot(value: object, snapshot: Readonly<SnapshotData<any>>) {
-  snapshots.set(value, snapshot)
-}
-
-/**
- * @ignore
- */
-export function unlinkInternalSnapshot(value: object) {
-  return snapshots.delete(value)
-}
 
 /**
  * @ignore

--- a/packages/lib/src/tweaker/tweak.ts
+++ b/packages/lib/src/tweaker/tweak.ts
@@ -15,7 +15,7 @@ import {
   isPrimitive,
   isSet,
 } from "../utils"
-import { isTreeNode, isTweakedObject, tweakedObjects } from "./core"
+import { isTweakedObject, tweakedObjects } from "./core"
 import { tweakArray } from "./tweakArray"
 import { tweakFrozen } from "./tweakFrozen"
 import { tweakModel } from "./tweakModel"
@@ -34,7 +34,7 @@ export function toTreeNode<T extends object>(value: T): T {
     throw failure("only objects can be turned into tree nodes")
   }
 
-  if (!isTreeNode(value)) {
+  if (!isTweakedObject(value, true)) {
     return tweak(value, undefined)
   }
   return value
@@ -48,7 +48,7 @@ function internalTweak<T>(value: T, parentPath: ParentPath<any> | undefined): T 
     return value
   }
 
-  if (isTweakedObject(value as any)) {
+  if (isTweakedObject(value as any, true)) {
     setParent(value, parentPath, false, false)
     return value
   }

--- a/packages/lib/src/tweaker/tweakPlainObject.ts
+++ b/packages/lib/src/tweaker/tweakPlainObject.ts
@@ -8,6 +8,7 @@ import {
   set,
 } from "mobx"
 import { modelTypeKey } from "../model/metadata"
+import { dataToModelNode } from "../parent/core"
 import { ParentPath } from "../parent/path"
 import { setParent } from "../parent/setParent"
 import { InternalPatchRecorder } from "../patch/emitPatch"
@@ -78,7 +79,7 @@ export function tweakPlainObject<T>(
     standardSn[modelTypeKey] = snapshotModelType
   }
 
-  setInternalSnapshot(tweakedObj, standardSn)
+  setInternalSnapshot(isDataObject ? dataToModelNode(tweakedObj) : tweakedObj, standardSn)
 
   interceptDisposer = intercept(tweakedObj, interceptObjectMutation)
   observeDisposer = observe(tweakedObj, objectDidChange)
@@ -92,7 +93,8 @@ const observableOptions = {
 
 function objectDidChange(change: IObjectDidChange): void {
   const obj = change.object
-  let { standard: standardSn } = getInternalSnapshot(obj)!
+  const actualNode = dataToModelNode(obj)
+  let { standard: standardSn } = getInternalSnapshot(actualNode)!
 
   const patchRecorder = new InternalPatchRecorder()
 
@@ -180,8 +182,8 @@ function objectDidChange(change: IObjectDidChange): void {
   runTypeCheckingAfterChange(obj, patchRecorder)
 
   if (!runningWithoutSnapshotOrPatches) {
-    setInternalSnapshot(obj, standardSn)
-    patchRecorder.emit(obj)
+    setInternalSnapshot(actualNode, standardSn)
+    patchRecorder.emit(actualNode)
   }
 }
 

--- a/packages/lib/src/tweaker/typeChecking.ts
+++ b/packages/lib/src/tweaker/typeChecking.ts
@@ -2,6 +2,7 @@ import { isModelAutoTypeCheckingEnabled } from "../globalConfig/globalConfig"
 import { AnyModel } from "../model/BaseModel"
 import { getModelDataType } from "../model/getModelDataType"
 import { isModel } from "../model/utils"
+import { dataToModelNode } from "../parent/core"
 import { findParent } from "../parent/findParent"
 import { internalApplyPatches } from "../patch/applyPatches"
 import { InternalPatchRecorder } from "../patch/emitPatch"
@@ -40,6 +41,16 @@ export function runTypeCheckingAfterChange(obj: object, patchRecorder: InternalP
  * @returns
  */
 function findNearestParentModelWithTypeChecker(child: object): AnyModel | undefined {
+  // child might be .$, so we need to check the parent model in that case
+  const actualChild = dataToModelNode(child)
+
+  if (child !== actualChild) {
+    child = actualChild
+    if (isModel(child) && !!getModelDataType(child)) {
+      return child
+    }
+  }
+
   return findParent(child, parent => {
     return isModel(parent) && !!getModelDataType(parent)
   })

--- a/packages/lib/src/typeChecking/TypeCheckError.ts
+++ b/packages/lib/src/typeChecking/TypeCheckError.ts
@@ -1,5 +1,5 @@
 import { getRootPath } from "../parent/path"
-import { isTreeNode } from "../tweaker/core"
+import { isTweakedObject } from "../tweaker/core"
 import { failure } from "../utils"
 
 /**
@@ -26,11 +26,11 @@ export class TypeCheckError {
   throw(typeCheckedValue: any): never {
     let msg = "TypeCheckError: "
     let rootPath: ReadonlyArray<string | number> = []
-    if (isTreeNode(typeCheckedValue)) {
+    if (isTweakedObject(typeCheckedValue, true)) {
       rootPath = getRootPath(typeCheckedValue).path
     }
 
-    msg += "[" + [...rootPath, ...this.path].join("/") + "] "
+    msg += "[/" + [...rootPath, ...this.path].join("/") + "] "
 
     msg += "Expected: " + this.expectedTypeName
 

--- a/packages/lib/src/typeChecking/TypeChecker.ts
+++ b/packages/lib/src/typeChecking/TypeChecker.ts
@@ -1,5 +1,5 @@
-import { fastGetParent } from "../parent/path"
-import { isTreeNode } from "../tweaker/core"
+import { fastGetParentIncludingDataObjects } from "../parent/path"
+import { isTweakedObject } from "../tweaker/core"
 import { failure } from "../utils"
 import { TypeCheckError } from "./TypeCheckError"
 
@@ -27,7 +27,7 @@ export function invalidateCachedTypeCheckerResult(obj: object) {
       typeCheckersWithCachedResultsOfObject.delete(current)
     }
 
-    current = fastGetParent(current)
+    current = fastGetParentIncludingDataObjects(current)
   }
 }
 
@@ -74,7 +74,7 @@ export class TypeChecker {
       return null
     }
 
-    if (!isTreeNode(value)) {
+    if (!isTweakedObject(value, true)) {
       return this._check!(value, path)
     }
 

--- a/packages/lib/src/typeChecking/arraySet.ts
+++ b/packages/lib/src/typeChecking/arraySet.ts
@@ -34,7 +34,7 @@ export function typesArraySet<T extends AnyType>(values: T): IdentityType<ArrayS
       }))
 
       const resolvedTc = resolveTypeChecker(dataTypeChecker)
-      return resolvedTc.check(obj.$, [...path, "$"])
+      return resolvedTc.check(obj.$, path)
     }, getTypeName)
 
     return thisTc

--- a/packages/lib/src/typeChecking/model.ts
+++ b/packages/lib/src/typeChecking/model.ts
@@ -62,7 +62,7 @@ export function typesModel<M = never>(modelClass: object): IdentityType<M> {
 
         const resolvedTc = resolveTypeChecker(dataTypeChecker)
         if (!resolvedTc.unchecked) {
-          return resolvedTc.check(value.$, [...path, "$"])
+          return resolvedTc.check(value.$, path)
         }
 
         return null

--- a/packages/lib/src/typeChecking/objectMap.ts
+++ b/packages/lib/src/typeChecking/objectMap.ts
@@ -36,7 +36,7 @@ export function typesObjectMap<T extends AnyType>(
       }))
 
       const resolvedTc = resolveTypeChecker(dataTypeChecker)
-      return resolvedTc.check(obj.$, [...path, "$"])
+      return resolvedTc.check(obj.$, path)
     }, getTypeName)
 
     return thisTc

--- a/packages/lib/src/typeChecking/ref.ts
+++ b/packages/lib/src/typeChecking/ref.ts
@@ -33,7 +33,7 @@ const refTypeChecker = new TypeChecker(
     }
 
     const resolvedTc = resolveTypeChecker(refDataTypeChecker)
-    return resolvedTc.check(value.$, [...path, "$"])
+    return resolvedTc.check(value.$, path)
   },
   () => typeName
 )

--- a/packages/lib/src/typeChecking/refinement.ts
+++ b/packages/lib/src/typeChecking/refinement.ts
@@ -22,7 +22,7 @@ import { TypeCheckError } from "./TypeCheckError"
  *   return rightResult
  *
  *   // this will return that the result field is wrong
- *   return rightResult ? null : new TypeCheckError(["$", "result"], "a+b", sum.result)
+ *   return rightResult ? null : new TypeCheckError(["result"], "a+b", sum.result)
  * })
  * ```
  *

--- a/packages/lib/test/action/action.test.ts
+++ b/packages/lib/test/action/action.test.ts
@@ -606,7 +606,7 @@ test("applyAction", () => {
   {
     const ra = pa.p2.addY(15)
     const rb = applyAction(pb, {
-      targetPath: ["$", "p2"],
+      targetPath: ["p2"],
       actionName: "addY",
       args: [15],
     })
@@ -620,7 +620,7 @@ test("applyAction", () => {
     y: 100,
   })
   applyAction(pb, {
-    targetPath: ["$", "p2"],
+    targetPath: ["p2"],
     actionName: "$$applySnapshot",
     args: [{ ...getSnapshot(pb.p2), y: 100 }],
   })

--- a/packages/lib/test/actionMiddleware/onActionMiddleware.test.ts
+++ b/packages/lib/test/actionMiddleware/onActionMiddleware.test.ts
@@ -67,46 +67,46 @@ test("onActionMiddleware", () => {
   p1.addX(1)
   p2.addX(1)
   expect(events).toMatchInlineSnapshot(`
-    Array [
-      Array [
-        Object {
-          "actionName": "addX",
-          "args": Array [
-            1,
-          ],
-          "targetPath": Array [],
-        },
-        Object {
-          "actionName": "addX",
-          "args": Array [
-            1,
-          ],
-          "data": Object {
-            Symbol(simpleDataContext): [Circular],
-            Symbol(actionTrackingMiddlewareData): Object {
-              "startAccepted": true,
-              "state": "finished",
+        Array [
+          Array [
+            Object {
+              "actionName": "addX",
+              "args": Array [
+                1,
+              ],
+              "targetPath": Array [],
             },
-          },
-          "parentContext": undefined,
-          "rootContext": [Circular],
-          "target": P {
-            "$": Object {
-              "p2": P2 {
-                "$": Object {
-                  "y": 0,
+            Object {
+              "actionName": "addX",
+              "args": Array [
+                1,
+              ],
+              "data": Object {
+                Symbol(simpleDataContext): [Circular],
+                Symbol(actionTrackingMiddlewareData): Object {
+                  "startAccepted": true,
+                  "state": "finished",
                 },
-                "$modelType": "P2",
               },
-              "x": 1,
+              "parentContext": undefined,
+              "rootContext": [Circular],
+              "target": P {
+                "$": Object {
+                  "p2": P2 {
+                    "$": Object {
+                      "y": 0,
+                    },
+                    "$modelType": "P2",
+                  },
+                  "x": 1,
+                },
+                "$modelType": "P",
+              },
+              "type": "sync",
             },
-            "$modelType": "P",
-          },
-          "type": "sync",
-        },
-      ],
-    ]
-  `)
+          ],
+        ]
+    `)
 
   // action on the child
   reset()
@@ -121,7 +121,6 @@ test("onActionMiddleware", () => {
             2,
           ],
           "targetPath": Array [
-            "$",
             "p2",
           ],
         },
@@ -156,48 +155,48 @@ test("onActionMiddleware", () => {
   p1.addXY(3, 4)
   p2.addXY(3, 4)
   expect(events).toMatchInlineSnapshot(`
-    Array [
-      Array [
-        Object {
-          "actionName": "addXY",
-          "args": Array [
-            3,
-            4,
-          ],
-          "targetPath": Array [],
-        },
-        Object {
-          "actionName": "addXY",
-          "args": Array [
-            3,
-            4,
-          ],
-          "data": Object {
-            Symbol(simpleDataContext): [Circular],
-            Symbol(actionTrackingMiddlewareData): Object {
-              "startAccepted": true,
-              "state": "finished",
+        Array [
+          Array [
+            Object {
+              "actionName": "addXY",
+              "args": Array [
+                3,
+                4,
+              ],
+              "targetPath": Array [],
             },
-          },
-          "parentContext": undefined,
-          "rootContext": [Circular],
-          "target": P {
-            "$": Object {
-              "p2": P2 {
-                "$": Object {
-                  "y": 6,
+            Object {
+              "actionName": "addXY",
+              "args": Array [
+                3,
+                4,
+              ],
+              "data": Object {
+                Symbol(simpleDataContext): [Circular],
+                Symbol(actionTrackingMiddlewareData): Object {
+                  "startAccepted": true,
+                  "state": "finished",
                 },
-                "$modelType": "P2",
               },
-              "x": 4,
+              "parentContext": undefined,
+              "rootContext": [Circular],
+              "target": P {
+                "$": Object {
+                  "p2": P2 {
+                    "$": Object {
+                      "y": 6,
+                    },
+                    "$modelType": "P2",
+                  },
+                  "x": 4,
+                },
+                "$modelType": "P",
+              },
+              "type": "sync",
             },
-            "$modelType": "P",
-          },
-          "type": "sync",
-        },
-      ],
-    ]
-  `)
+          ],
+        ]
+    `)
 
   // unserializable args
   reset()
@@ -207,166 +206,166 @@ test("onActionMiddleware", () => {
   p1.other(rc)
   p2.other(rc)
   expect(events).toMatchInlineSnapshot(`
-    Array [
-      Array [
-        Object {
-          "actionName": "other",
-          "args": Array [
-            RandomClass {},
-          ],
-          "targetPath": Array [],
-        },
-        Object {
-          "actionName": "other",
-          "args": Array [
-            RandomClass {},
-          ],
-          "data": Object {
-            Symbol(simpleDataContext): [Circular],
-            Symbol(actionTrackingMiddlewareData): Object {
-              "startAccepted": true,
-              "state": "finished",
+        Array [
+          Array [
+            Object {
+              "actionName": "other",
+              "args": Array [
+                RandomClass {},
+              ],
+              "targetPath": Array [],
             },
-          },
-          "parentContext": undefined,
-          "rootContext": [Circular],
-          "target": P {
-            "$": Object {
-              "p2": P2 {
-                "$": Object {
-                  "y": 6,
+            Object {
+              "actionName": "other",
+              "args": Array [
+                RandomClass {},
+              ],
+              "data": Object {
+                Symbol(simpleDataContext): [Circular],
+                Symbol(actionTrackingMiddlewareData): Object {
+                  "startAccepted": true,
+                  "state": "finished",
                 },
-                "$modelType": "P2",
               },
-              "x": 4,
+              "parentContext": undefined,
+              "rootContext": [Circular],
+              "target": P {
+                "$": Object {
+                  "p2": P2 {
+                    "$": Object {
+                      "y": 6,
+                    },
+                    "$modelType": "P2",
+                  },
+                  "x": 4,
+                },
+                "$modelType": "P",
+              },
+              "type": "sync",
             },
-            "$modelType": "P",
-          },
-          "type": "sync",
-        },
-      ],
-    ]
-  `)
+          ],
+        ]
+    `)
 
   // array, obs array
   reset()
   p1.other([1, 2, 3], observable([4, 5, 6]))
   p2.other([1, 2, 3], observable([4, 5, 6]))
   expect(events).toMatchInlineSnapshot(`
-    Array [
-      Array [
-        Object {
-          "actionName": "other",
-          "args": Array [
-            Array [
-              1,
-              2,
-              3,
-            ],
-            Array [
-              4,
-              5,
-              6,
-            ],
-          ],
-          "targetPath": Array [],
-        },
-        Object {
-          "actionName": "other",
-          "args": Array [
-            Array [
-              1,
-              2,
-              3,
-            ],
-            Array [
-              4,
-              5,
-              6,
-            ],
-          ],
-          "data": Object {
-            Symbol(simpleDataContext): [Circular],
-            Symbol(actionTrackingMiddlewareData): Object {
-              "startAccepted": true,
-              "state": "finished",
+        Array [
+          Array [
+            Object {
+              "actionName": "other",
+              "args": Array [
+                Array [
+                  1,
+                  2,
+                  3,
+                ],
+                Array [
+                  4,
+                  5,
+                  6,
+                ],
+              ],
+              "targetPath": Array [],
             },
-          },
-          "parentContext": undefined,
-          "rootContext": [Circular],
-          "target": P {
-            "$": Object {
-              "p2": P2 {
-                "$": Object {
-                  "y": 6,
+            Object {
+              "actionName": "other",
+              "args": Array [
+                Array [
+                  1,
+                  2,
+                  3,
+                ],
+                Array [
+                  4,
+                  5,
+                  6,
+                ],
+              ],
+              "data": Object {
+                Symbol(simpleDataContext): [Circular],
+                Symbol(actionTrackingMiddlewareData): Object {
+                  "startAccepted": true,
+                  "state": "finished",
                 },
-                "$modelType": "P2",
               },
-              "x": 4,
+              "parentContext": undefined,
+              "rootContext": [Circular],
+              "target": P {
+                "$": Object {
+                  "p2": P2 {
+                    "$": Object {
+                      "y": 6,
+                    },
+                    "$modelType": "P2",
+                  },
+                  "x": 4,
+                },
+                "$modelType": "P",
+              },
+              "type": "sync",
             },
-            "$modelType": "P",
-          },
-          "type": "sync",
-        },
-      ],
-    ]
-  `)
+          ],
+        ]
+    `)
 
   // obj, obs obj
   reset()
   p1.other({ a: 5 }, observable({ a: 5 }))
   p2.other({ a: 5 }, observable({ a: 5 }))
   expect(events).toMatchInlineSnapshot(`
-    Array [
-      Array [
-        Object {
-          "actionName": "other",
-          "args": Array [
+        Array [
+          Array [
             Object {
-              "a": 5,
-            },
-            Object {
-              "a": 5,
-            },
-          ],
-          "targetPath": Array [],
-        },
-        Object {
-          "actionName": "other",
-          "args": Array [
-            Object {
-              "a": 5,
-            },
-            Object {
-              "a": 5,
-            },
-          ],
-          "data": Object {
-            Symbol(simpleDataContext): [Circular],
-            Symbol(actionTrackingMiddlewareData): Object {
-              "startAccepted": true,
-              "state": "finished",
-            },
-          },
-          "parentContext": undefined,
-          "rootContext": [Circular],
-          "target": P {
-            "$": Object {
-              "p2": P2 {
-                "$": Object {
-                  "y": 6,
+              "actionName": "other",
+              "args": Array [
+                Object {
+                  "a": 5,
                 },
-                "$modelType": "P2",
-              },
-              "x": 4,
+                Object {
+                  "a": 5,
+                },
+              ],
+              "targetPath": Array [],
             },
-            "$modelType": "P",
-          },
-          "type": "sync",
-        },
-      ],
-    ]
-  `)
+            Object {
+              "actionName": "other",
+              "args": Array [
+                Object {
+                  "a": 5,
+                },
+                Object {
+                  "a": 5,
+                },
+              ],
+              "data": Object {
+                Symbol(simpleDataContext): [Circular],
+                Symbol(actionTrackingMiddlewareData): Object {
+                  "startAccepted": true,
+                  "state": "finished",
+                },
+              },
+              "parentContext": undefined,
+              "rootContext": [Circular],
+              "target": P {
+                "$": Object {
+                  "p2": P2 {
+                    "$": Object {
+                      "y": 6,
+                    },
+                    "$modelType": "P2",
+                  },
+                  "x": 4,
+                },
+                "$modelType": "P",
+              },
+              "type": "sync",
+            },
+          ],
+        ]
+    `)
 
   // applySnapshot
   reset()
@@ -390,7 +389,6 @@ test("onActionMiddleware", () => {
             },
           ],
           "targetPath": Array [
-            "$",
             "p2",
           ],
         },

--- a/packages/lib/test/actionMiddleware/undoMiddleware.test.ts
+++ b/packages/lib/test/actionMiddleware/undoMiddleware.test.ts
@@ -130,7 +130,6 @@ test("undoMiddleware - sync", () => {
             },
           ],
           "targetPath": Array [
-            "$",
             "p",
           ],
         },
@@ -157,7 +156,6 @@ test("undoMiddleware - sync", () => {
             },
           ],
           "targetPath": Array [
-            "$",
             "p",
           ],
         },
@@ -186,9 +184,7 @@ test("undoMiddleware - sync", () => {
             },
           ],
           "targetPath": Array [
-            "$",
             "p",
-            "$",
             "p2",
           ],
         },
@@ -233,7 +229,6 @@ test("undoMiddleware - sync", () => {
             },
           ],
           "targetPath": Array [
-            "$",
             "p",
           ],
         },
@@ -411,7 +406,6 @@ test("undoMiddleware - async", async () => {
             },
           ],
           "targetPath": Array [
-            "$",
             "p",
           ],
         },
@@ -438,7 +432,6 @@ test("undoMiddleware - async", async () => {
             },
           ],
           "targetPath": Array [
-            "$",
             "p",
           ],
         },
@@ -467,9 +460,7 @@ test("undoMiddleware - async", async () => {
             },
           ],
           "targetPath": Array [
-            "$",
             "p",
-            "$",
             "p2",
           ],
         },
@@ -514,7 +505,6 @@ test("undoMiddleware - async", async () => {
             },
           ],
           "targetPath": Array [
-            "$",
             "p",
           ],
         },

--- a/packages/lib/test/frozen/frozen.test.ts
+++ b/packages/lib/test/frozen/frozen.test.ts
@@ -39,7 +39,7 @@ describe("frozen", () => {
       const p = new P({ frozenStuff: fr })
 
       expect(getSnapshot(p).frozenStuff).toBe(sn)
-      expect(getParent(fr)).toBe(p.$)
+      expect(getParent(fr)).toBe(p)
       expect(getRoot(fr)).toBe(p)
 
       runUnprotected(() => {

--- a/packages/lib/test/model/__snapshots__/onChildAttachedTo.test.ts.snap
+++ b/packages/lib/test/model/__snapshots__/onChildAttachedTo.test.ts.snap
@@ -21,82 +21,82 @@ Array [
 
 exports[`onChildAttachedTo (deep: false): initial 1`] = `
 Array [
-  "attached to B-deep:false <- Array at [$/arr]",
-  "attached to A-deep:false <- B-deep:false at [$/b]",
-  "attached to R-deep:false <- A-deep:false at [$/a]",
+  "attached to B-deep:false <- Array at [arr]",
+  "attached to A-deep:false <- B-deep:false at [b]",
+  "attached to R-deep:false <- A-deep:false at [a]",
 ]
 `;
 
 exports[`onChildAttachedTo (deep: false): new A 1`] = `
 Array [
-  "attached to B-deep:false <- Array at [$/arr]",
-  "attached to A-deep:false <- B-deep:false at [$/b]",
-  "detached from R-deep:false <- A-deep:false at [$/a]",
-  "attached to R-deep:false <- A-deep:false at [$/a]",
+  "attached to B-deep:false <- Array at [arr]",
+  "attached to A-deep:false <- B-deep:false at [b]",
+  "detached from R-deep:false <- A-deep:false at [a]",
+  "attached to R-deep:false <- A-deep:false at [a]",
 ]
 `;
 
 exports[`onChildAttachedTo (deep: false): new B 1`] = `
 Array [
-  "attached to B-deep:false <- Array at [$/arr]",
-  "detached from A-deep:false <- B-deep:false at [$/b]",
-  "attached to A-deep:false <- B-deep:false at [$/b]",
+  "attached to B-deep:false <- Array at [arr]",
+  "detached from A-deep:false <- B-deep:false at [b]",
+  "attached to A-deep:false <- B-deep:false at [b]",
 ]
 `;
 
 exports[`onChildAttachedTo (deep: false): new arr 1`] = `
 Array [
-  "detached from B-deep:false <- Array at [$/arr]",
-  "attached to B-deep:false <- Array at [$/arr]",
+  "detached from B-deep:false <- Array at [arr]",
+  "attached to B-deep:false <- Array at [arr]",
 ]
 `;
 
 exports[`onChildAttachedTo (deep: true): initial 1`] = `
 Array [
-  "attached to B-deep:true <- Array at [$/arr]",
-  "attached to A-deep:true <- B-deep:true at [$/b]",
-  "attached to A-deep:true <- Array at [$/b/$/arr]",
-  "attached to R-deep:true <- A-deep:true at [$/a]",
-  "attached to R-deep:true <- B-deep:true at [$/a/$/b]",
-  "attached to R-deep:true <- Array at [$/a/$/b/$/arr]",
+  "attached to B-deep:true <- Array at [arr]",
+  "attached to A-deep:true <- B-deep:true at [b]",
+  "attached to A-deep:true <- Array at [b/arr]",
+  "attached to R-deep:true <- A-deep:true at [a]",
+  "attached to R-deep:true <- B-deep:true at [a/b]",
+  "attached to R-deep:true <- Array at [a/b/arr]",
 ]
 `;
 
 exports[`onChildAttachedTo (deep: true): new A 1`] = `
 Array [
-  "attached to B-deep:true <- Array at [$/arr]",
-  "attached to A-deep:true <- B-deep:true at [$/b]",
-  "attached to A-deep:true <- Array at [$/b/$/arr]",
-  "detached from R-deep:true <- Array at [$/a/$/b/$/arr]",
-  "detached from R-deep:true <- B-deep:true at [$/a/$/b]",
-  "detached from R-deep:true <- A-deep:true at [$/a]",
-  "attached to R-deep:true <- A-deep:true at [$/a]",
-  "attached to R-deep:true <- B-deep:true at [$/a/$/b]",
-  "attached to R-deep:true <- Array at [$/a/$/b/$/arr]",
+  "attached to B-deep:true <- Array at [arr]",
+  "attached to A-deep:true <- B-deep:true at [b]",
+  "attached to A-deep:true <- Array at [b/arr]",
+  "detached from R-deep:true <- Array at [a/b/arr]",
+  "detached from R-deep:true <- B-deep:true at [a/b]",
+  "detached from R-deep:true <- A-deep:true at [a]",
+  "attached to R-deep:true <- A-deep:true at [a]",
+  "attached to R-deep:true <- B-deep:true at [a/b]",
+  "attached to R-deep:true <- Array at [a/b/arr]",
 ]
 `;
 
 exports[`onChildAttachedTo (deep: true): new B 1`] = `
 Array [
-  "attached to B-deep:true <- Array at [$/arr]",
-  "detached from A-deep:true <- Array at [$/b/$/arr]",
-  "detached from A-deep:true <- B-deep:true at [$/b]",
-  "attached to A-deep:true <- B-deep:true at [$/b]",
-  "attached to A-deep:true <- Array at [$/b/$/arr]",
-  "detached from R-deep:true <- Array at [$/a/$/b/$/arr]",
-  "detached from R-deep:true <- B-deep:true at [$/a/$/b]",
-  "attached to R-deep:true <- B-deep:true at [$/a/$/b]",
-  "attached to R-deep:true <- Array at [$/a/$/b/$/arr]",
+  "attached to B-deep:true <- Array at [arr]",
+  "detached from A-deep:true <- Array at [b/arr]",
+  "detached from A-deep:true <- B-deep:true at [b]",
+  "attached to A-deep:true <- B-deep:true at [b]",
+  "attached to A-deep:true <- Array at [b/arr]",
+  "detached from R-deep:true <- Array at [a/b/arr]",
+  "detached from R-deep:true <- B-deep:true at [a/b]",
+  "attached to R-deep:true <- B-deep:true at [a/b]",
+  "attached to R-deep:true <- Array at [a/b/arr]",
 ]
 `;
 
 exports[`onChildAttachedTo (deep: true): new arr 1`] = `
 Array [
-  "detached from B-deep:true <- Array at [$/arr]",
-  "attached to B-deep:true <- Array at [$/arr]",
-  "detached from A-deep:true <- Array at [$/b/$/arr]",
-  "attached to A-deep:true <- Array at [$/b/$/arr]",
-  "detached from R-deep:true <- Array at [$/a/$/b/$/arr]",
-  "attached to R-deep:true <- Array at [$/a/$/b/$/arr]",
+  "detached from B-deep:true <- Array at [arr]",
+  "attached to B-deep:true <- Array at [arr]",
+  "detached from A-deep:true <- Array at [b/arr]",
+  "attached to A-deep:true <- Array at [b/arr]",
+  "detached from R-deep:true <- Array at [a/b/arr]",
+  "attached to R-deep:true <- Array at [a/b/arr]",
 ]
 `;

--- a/packages/lib/test/model/subclassing.test.ts
+++ b/packages/lib/test/model/subclassing.test.ts
@@ -262,11 +262,11 @@ test("three level subclassing", () => {
   // type checking must still work
   expect(() => {
     p2.setX("10" as any)
-  }).toThrow("TypeCheckError: [$/x] Expected: number")
+  }).toThrow("TypeCheckError: [/x] Expected: number")
 
   expect(() => {
     p2.setB("10" as any)
-  }).toThrow("TypeCheckError: [$/b] Expected: number")
+  }).toThrow("TypeCheckError: [/b] Expected: number")
 })
 
 test("abstract-ish model classes with factory", () => {

--- a/packages/lib/test/model/tweak.test.ts
+++ b/packages/lib/test/model/tweak.test.ts
@@ -41,10 +41,10 @@ test("initial data must be tweaked", () => {
   expect(isTreeNodeAndObs(a.arr[0])).toBeTruthy()
   expect(isTreeNodeAndObs(a.arr[1])).toBeTruthy()
 
-  expect(getParent(a.map)).toBe(a.$)
+  expect(getParent(a.map)).toBe(a)
   expect(getParent(a.map.obj1)).toBe(a.map)
   expect(getParent(a.map.obj2)).toBe(a.map)
-  expect(getParent(a.arr)).toBe(a.$)
+  expect(getParent(a.arr)).toBe(a)
   expect(getParent(a.arr[0])).toBe(a.arr)
   expect(getParent(a.arr[1])).toBe(a.arr)
 })
@@ -78,10 +78,10 @@ test("data added after intial data must be tweaked", () => {
     expect(isTreeNodeAndObs(a.arr![0])).toBeTruthy()
     expect(isTreeNodeAndObs(a.arr![1])).toBeTruthy()
 
-    expect(getParent(a.map!)).toBe(a.$)
+    expect(getParent(a.map!)).toBe(a)
     expect(getParent(a.map!.obj1!)).toBe(a.map)
     expect(getParent(a.map!.obj2!)).toBe(a.map)
-    expect(getParent(a.arr!)).toBe(a.$)
+    expect(getParent(a.arr!)).toBe(a)
     expect(getParent(a.arr![0])).toBe(a.arr)
     expect(getParent(a.arr![1])).toBe(a.arr)
   }
@@ -100,10 +100,10 @@ test("data added after intial data must be tweaked", () => {
     expect(isTreeNodeAndObs(a.arr![0])).toBeTruthy()
     expect(isTreeNodeAndObs(a.arr![1])).toBeTruthy()
 
-    expect(getParent(a.map!)).toBe(a.$)
+    expect(getParent(a.map!)).toBe(a)
     expect(getParent(a.map!.obj1!)).toBe(a.map)
     expect(getParent(a.map!.obj2!)).toBe(a.map)
-    expect(getParent(a.arr!)).toBe(a.$)
+    expect(getParent(a.arr!)).toBe(a)
     expect(getParent(a.arr![0])).toBe(a.arr)
     expect(getParent(a.arr![1])).toBe(a.arr)
   }

--- a/packages/lib/test/patch/patch.test.ts
+++ b/packages/lib/test/patch/patch.test.ts
@@ -1,4 +1,14 @@
-import { applyPatches, getSnapshot, onPatches, Patch, runUnprotected } from "../../src"
+import {
+  applyPatches,
+  getSnapshot,
+  model,
+  Model,
+  modelAction,
+  onPatches,
+  Patch,
+  prop,
+  runUnprotected,
+} from "../../src"
 import "../commonSetup"
 import { createP } from "../testbed"
 import { autoDispose } from "../utils"
@@ -59,80 +69,80 @@ test("onPatches and applyPatches", () => {
   })
 
   expect(pPatches).toMatchInlineSnapshot(`
-                                                    Array [
-                                                      Array [
-                                                        Object {
-                                                          "op": "replace",
-                                                          "path": Array [
-                                                            "x",
+                                                        Array [
+                                                          Array [
+                                                            Object {
+                                                              "op": "replace",
+                                                              "path": Array [
+                                                                "x",
+                                                              ],
+                                                              "value": 6,
+                                                            },
                                                           ],
-                                                          "value": 6,
-                                                        },
-                                                      ],
-                                                      Array [
-                                                        Object {
-                                                          "op": "replace",
-                                                          "path": Array [
-                                                            "p2",
-                                                            "y",
+                                                          Array [
+                                                            Object {
+                                                              "op": "replace",
+                                                              "path": Array [
+                                                                "p2",
+                                                                "y",
+                                                              ],
+                                                              "value": 13,
+                                                            },
                                                           ],
-                                                          "value": 13,
-                                                        },
-                                                      ],
-                                                    ]
-                          `)
+                                                        ]
+                            `)
 
   expect(pInvPatches).toMatchInlineSnapshot(`
-                                                    Array [
-                                                      Array [
-                                                        Object {
-                                                          "op": "replace",
-                                                          "path": Array [
-                                                            "x",
+                                                        Array [
+                                                          Array [
+                                                            Object {
+                                                              "op": "replace",
+                                                              "path": Array [
+                                                                "x",
+                                                              ],
+                                                              "value": 5,
+                                                            },
                                                           ],
-                                                          "value": 5,
-                                                        },
-                                                      ],
-                                                      Array [
-                                                        Object {
-                                                          "op": "replace",
-                                                          "path": Array [
-                                                            "p2",
-                                                            "y",
+                                                          Array [
+                                                            Object {
+                                                              "op": "replace",
+                                                              "path": Array [
+                                                                "p2",
+                                                                "y",
+                                                              ],
+                                                              "value": 12,
+                                                            },
                                                           ],
-                                                          "value": 12,
-                                                        },
-                                                      ],
-                                                    ]
-                          `)
+                                                        ]
+                            `)
 
   expect(p2Patches).toMatchInlineSnapshot(`
-                                                    Array [
-                                                      Array [
-                                                        Object {
-                                                          "op": "replace",
-                                                          "path": Array [
-                                                            "y",
+                                                        Array [
+                                                          Array [
+                                                            Object {
+                                                              "op": "replace",
+                                                              "path": Array [
+                                                                "y",
+                                                              ],
+                                                              "value": 13,
+                                                            },
                                                           ],
-                                                          "value": 13,
-                                                        },
-                                                      ],
-                                                    ]
-                          `)
+                                                        ]
+                            `)
 
   expect(p2InvPatches).toMatchInlineSnapshot(`
-                                                    Array [
-                                                      Array [
-                                                        Object {
-                                                          "op": "replace",
-                                                          "path": Array [
-                                                            "y",
+                                                        Array [
+                                                          Array [
+                                                            Object {
+                                                              "op": "replace",
+                                                              "path": Array [
+                                                                "y",
+                                                              ],
+                                                              "value": 12,
+                                                            },
                                                           ],
-                                                          "value": 12,
-                                                        },
-                                                      ],
-                                                    ]
-                          `)
+                                                        ]
+                            `)
 
   expectSameSnapshotOnceReverted()
 
@@ -143,35 +153,35 @@ test("onPatches and applyPatches", () => {
   })
 
   expect(pPatches).toMatchInlineSnapshot(`
-                                                    Array [
-                                                      Array [
-                                                        Object {
-                                                          "op": "replace",
-                                                          "path": Array [
-                                                            "p2",
+                                                        Array [
+                                                          Array [
+                                                            Object {
+                                                              "op": "replace",
+                                                              "path": Array [
+                                                                "p2",
+                                                              ],
+                                                              "value": undefined,
+                                                            },
                                                           ],
-                                                          "value": undefined,
-                                                        },
-                                                      ],
-                                                    ]
-                          `)
+                                                        ]
+                            `)
 
   expect(pInvPatches).toMatchInlineSnapshot(`
-    Array [
-      Array [
-        Object {
-          "op": "replace",
-          "path": Array [
-            "p2",
+        Array [
+          Array [
+            Object {
+              "op": "replace",
+              "path": Array [
+                "p2",
+              ],
+              "value": Object {
+                "$modelType": "P2",
+                "y": 12,
+              },
+            },
           ],
-          "value": Object {
-            "$modelType": "P2",
-            "y": 12,
-          },
-        },
-      ],
-    ]
-  `)
+        ]
+    `)
 
   expect(p2Patches).toMatchInlineSnapshot(`Array []`)
 
@@ -186,40 +196,40 @@ test("onPatches and applyPatches", () => {
   })
 
   expect(pPatches).toMatchInlineSnapshot(`
-                                                    Array [
-                                                      Array [
-                                                        Object {
-                                                          "op": "replace",
-                                                          "path": Array [
-                                                            "arr",
+                                                        Array [
+                                                          Array [
+                                                            Object {
+                                                              "op": "replace",
+                                                              "path": Array [
+                                                                "arr",
+                                                              ],
+                                                              "value": Array [
+                                                                3,
+                                                                2,
+                                                                1,
+                                                              ],
+                                                            },
                                                           ],
-                                                          "value": Array [
-                                                            3,
-                                                            2,
-                                                            1,
-                                                          ],
-                                                        },
-                                                      ],
-                                                    ]
-                          `)
+                                                        ]
+                            `)
 
   expect(pInvPatches).toMatchInlineSnapshot(`
-                                                    Array [
-                                                      Array [
-                                                        Object {
-                                                          "op": "replace",
-                                                          "path": Array [
-                                                            "arr",
+                                                        Array [
+                                                          Array [
+                                                            Object {
+                                                              "op": "replace",
+                                                              "path": Array [
+                                                                "arr",
+                                                              ],
+                                                              "value": Array [
+                                                                1,
+                                                                2,
+                                                                3,
+                                                              ],
+                                                            },
                                                           ],
-                                                          "value": Array [
-                                                            1,
-                                                            2,
-                                                            3,
-                                                          ],
-                                                        },
-                                                      ],
-                                                    ]
-                          `)
+                                                        ]
+                            `)
 
   expect(p2Patches).toMatchInlineSnapshot(`Array []`)
 
@@ -231,6 +241,64 @@ test("onPatches and applyPatches", () => {
   reset()
   runUnprotected(() => {
     p.arr.splice(1, 2, 5) // [1, 5]
+  })
+
+  expect(pPatches).toMatchInlineSnapshot(`
+                                Array [
+                                  Array [
+                                    Object {
+                                      "op": "replace",
+                                      "path": Array [
+                                        "arr",
+                                        1,
+                                      ],
+                                      "value": 5,
+                                    },
+                                    Object {
+                                      "op": "replace",
+                                      "path": Array [
+                                        "arr",
+                                        "length",
+                                      ],
+                                      "value": 2,
+                                    },
+                                  ],
+                                ]
+                `)
+
+  expect(pInvPatches).toMatchInlineSnapshot(`
+                                Array [
+                                  Array [
+                                    Object {
+                                      "op": "replace",
+                                      "path": Array [
+                                        "arr",
+                                        1,
+                                      ],
+                                      "value": 2,
+                                    },
+                                    Object {
+                                      "op": "add",
+                                      "path": Array [
+                                        "arr",
+                                        2,
+                                      ],
+                                      "value": 3,
+                                    },
+                                  ],
+                                ]
+                `)
+
+  expect(p2Patches).toMatchInlineSnapshot(`Array []`)
+
+  expect(p2InvPatches).toMatchInlineSnapshot(`Array []`)
+
+  expectSameSnapshotOnceReverted()
+
+  // splice items (more items)
+  reset()
+  runUnprotected(() => {
+    p.arr.splice(1, 2, 5, 6, 7) // [1, 5, 6, 7]
   })
 
   expect(pPatches).toMatchInlineSnapshot(`
@@ -248,9 +316,17 @@ test("onPatches and applyPatches", () => {
                                   "op": "replace",
                                   "path": Array [
                                     "arr",
-                                    "length",
+                                    2,
                                   ],
-                                  "value": 2,
+                                  "value": 6,
+                                },
+                                Object {
+                                  "op": "add",
+                                  "path": Array [
+                                    "arr",
+                                    3,
+                                  ],
+                                  "value": 7,
                                 },
                               ],
                             ]
@@ -268,90 +344,24 @@ test("onPatches and applyPatches", () => {
                                   "value": 2,
                                 },
                                 Object {
-                                  "op": "add",
+                                  "op": "replace",
                                   "path": Array [
                                     "arr",
                                     2,
                                   ],
                                   "value": 3,
                                 },
+                                Object {
+                                  "op": "replace",
+                                  "path": Array [
+                                    "arr",
+                                    "length",
+                                  ],
+                                  "value": 3,
+                                },
                               ],
                             ]
               `)
-
-  expect(p2Patches).toMatchInlineSnapshot(`Array []`)
-
-  expect(p2InvPatches).toMatchInlineSnapshot(`Array []`)
-
-  expectSameSnapshotOnceReverted()
-
-  // splice items (more items)
-  reset()
-  runUnprotected(() => {
-    p.arr.splice(1, 2, 5, 6, 7) // [1, 5, 6, 7]
-  })
-
-  expect(pPatches).toMatchInlineSnapshot(`
-                        Array [
-                          Array [
-                            Object {
-                              "op": "replace",
-                              "path": Array [
-                                "arr",
-                                1,
-                              ],
-                              "value": 5,
-                            },
-                            Object {
-                              "op": "replace",
-                              "path": Array [
-                                "arr",
-                                2,
-                              ],
-                              "value": 6,
-                            },
-                            Object {
-                              "op": "add",
-                              "path": Array [
-                                "arr",
-                                3,
-                              ],
-                              "value": 7,
-                            },
-                          ],
-                        ]
-            `)
-
-  expect(pInvPatches).toMatchInlineSnapshot(`
-                        Array [
-                          Array [
-                            Object {
-                              "op": "replace",
-                              "path": Array [
-                                "arr",
-                                1,
-                              ],
-                              "value": 2,
-                            },
-                            Object {
-                              "op": "replace",
-                              "path": Array [
-                                "arr",
-                                2,
-                              ],
-                              "value": 3,
-                            },
-                            Object {
-                              "op": "replace",
-                              "path": Array [
-                                "arr",
-                                "length",
-                              ],
-                              "value": 3,
-                            },
-                          ],
-                        ]
-            `)
 
   expect(p2Patches).toMatchInlineSnapshot(`Array []`)
 
@@ -366,38 +376,116 @@ test("onPatches and applyPatches", () => {
   })
 
   expect(pPatches).toMatchInlineSnapshot(`
-            Array [
-              Array [
-                Object {
-                  "op": "replace",
-                  "path": Array [
-                    "arr",
-                    1,
+                Array [
+                  Array [
+                    Object {
+                      "op": "replace",
+                      "path": Array [
+                        "arr",
+                        1,
+                      ],
+                      "value": 5,
+                    },
                   ],
-                  "value": 5,
-                },
-              ],
-            ]
-      `)
+                ]
+        `)
 
   expect(pInvPatches).toMatchInlineSnapshot(`
-            Array [
-              Array [
-                Object {
-                  "op": "replace",
-                  "path": Array [
-                    "arr",
-                    1,
+                Array [
+                  Array [
+                    Object {
+                      "op": "replace",
+                      "path": Array [
+                        "arr",
+                        1,
+                      ],
+                      "value": 2,
+                    },
                   ],
-                  "value": 2,
-                },
-              ],
-            ]
-      `)
+                ]
+        `)
 
   expect(p2Patches).toMatchInlineSnapshot(`Array []`)
 
   expect(p2InvPatches).toMatchInlineSnapshot(`Array []`)
+
+  expectSameSnapshotOnceReverted()
+})
+
+test("patches with reserved prop names", () => {
+  @model("test/patchesWithReservedPropNames")
+  class M extends Model({ onInit: prop(4) }) {
+    @modelAction
+    setOnInit(n: number) {
+      this.$.onInit = n
+    }
+  }
+
+  const p = new M({})
+  const sn = getSnapshot(p)
+
+  const pPatches: Patch[][] = []
+  const pInvPatches: Patch[][] = []
+  autoDispose(
+    onPatches(p, (ptchs, iptchs) => {
+      pPatches.push(ptchs)
+      pInvPatches.push(iptchs)
+    })
+  )
+
+  function reset() {
+    pPatches.length = 0
+    pInvPatches.length = 0
+  }
+
+  function expectSameSnapshotOnceReverted() {
+    runUnprotected(() => {
+      pInvPatches.forEach(invpatches => applyPatches(p, invpatches))
+    })
+    expect(getSnapshot(p)).toStrictEqual(sn)
+  }
+
+  // no changes should result in no patches
+  reset()
+  runUnprotected(() => {
+    p.$.onInit = p.$.onInit + 0
+  })
+
+  expect(pPatches).toMatchInlineSnapshot(`Array []`)
+  expect(pInvPatches).toMatchInlineSnapshot(`Array []`)
+
+  reset()
+  runUnprotected(() => {
+    p.$.onInit++
+  })
+
+  expect(pPatches).toMatchInlineSnapshot(`
+    Array [
+      Array [
+        Object {
+          "op": "replace",
+          "path": Array [
+            "onInit",
+          ],
+          "value": 5,
+        },
+      ],
+    ]
+  `)
+
+  expect(pInvPatches).toMatchInlineSnapshot(`
+    Array [
+      Array [
+        Object {
+          "op": "replace",
+          "path": Array [
+            "onInit",
+          ],
+          "value": 4,
+        },
+      ],
+    ]
+  `)
 
   expectSameSnapshotOnceReverted()
 })

--- a/packages/lib/test/redux/__snapshots__/connectReduxDevTools.test.ts.snap
+++ b/packages/lib/test/redux/__snapshots__/connectReduxDevTools.test.ts.snap
@@ -113,11 +113,10 @@ Array [
     Object {
       "args": Array [],
       "path": Array [
-        "$",
         "array",
         0,
       ],
-      "type": "[/$/array/0] setA() (id 1)",
+      "type": "[/array/0] setA() (id 1)",
     },
     Object {
       "$modelType": "TestModel",

--- a/packages/lib/test/snapshot/snapshot.test.ts
+++ b/packages/lib/test/snapshot/snapshot.test.ts
@@ -4,12 +4,17 @@ import {
   ArraySet,
   BaseModel,
   clone,
+  fromSnapshot,
   getSnapshot,
+  Model,
+  model,
+  modelAction,
   modelTypeKey,
   ObjectMap,
   onPatches,
   onSnapshot,
   Patch,
+  prop,
   runUnprotected,
   SnapshotInOf,
   SnapshotOutOf,
@@ -40,33 +45,33 @@ test("onSnapshot and applySnapshot", () => {
   })
 
   expect(sn).toMatchInlineSnapshot(`
-    Array [
-      Array [
-        Object {
-          "$modelType": "P",
-          "arr": Array [
-            1,
-            2,
-            3,
+        Array [
+          Array [
+            Object {
+              "$modelType": "P",
+              "arr": Array [
+                1,
+                2,
+                3,
+              ],
+              "p2": Object {
+                "$modelType": "P2",
+                "y": 13,
+              },
+              "x": 6,
+            },
+            Object {
+              "$modelType": "P",
+              "arr": Array [],
+              "p2": Object {
+                "$modelType": "P2",
+                "y": 12,
+              },
+              "x": 5,
+            },
           ],
-          "p2": Object {
-            "$modelType": "P2",
-            "y": 13,
-          },
-          "x": 6,
-        },
-        Object {
-          "$modelType": "P",
-          "arr": Array [],
-          "p2": Object {
-            "$modelType": "P2",
-            "y": 12,
-          },
-          "x": 5,
-        },
-      ],
-    ]
-  `)
+        ]
+    `)
 
   reset()
   autoDispose(
@@ -80,118 +85,118 @@ test("onSnapshot and applySnapshot", () => {
   expect(getSnapshot(p)).toStrictEqual(originalSn)
 
   expect(sn).toMatchInlineSnapshot(`
-    Array [
-      Array [
-        Object {
-          "$modelType": "P",
-          "arr": Array [],
-          "p2": Object {
-            "$modelType": "P2",
-            "y": 12,
-          },
-          "x": 5,
-        },
-        Object {
-          "$modelType": "P",
-          "arr": Array [
-            1,
-            2,
-            3,
+        Array [
+          Array [
+            Object {
+              "$modelType": "P",
+              "arr": Array [],
+              "p2": Object {
+                "$modelType": "P2",
+                "y": 12,
+              },
+              "x": 5,
+            },
+            Object {
+              "$modelType": "P",
+              "arr": Array [
+                1,
+                2,
+                3,
+              ],
+              "p2": Object {
+                "$modelType": "P2",
+                "y": 13,
+              },
+              "x": 6,
+            },
           ],
-          "p2": Object {
-            "$modelType": "P2",
-            "y": 13,
-          },
-          "x": 6,
-        },
-      ],
-    ]
-  `)
+        ]
+    `)
 
   expect(patches).toMatchInlineSnapshot(`
-            Array [
-              Array [
-                Array [
-                  Object {
-                    "op": "replace",
-                    "path": Array [
-                      "p2",
-                      "y",
-                    ],
-                    "value": 12,
-                  },
-                ],
-                Array [
-                  Object {
-                    "op": "replace",
-                    "path": Array [
-                      "p2",
-                      "y",
-                    ],
-                    "value": 13,
-                  },
-                ],
-              ],
-              Array [
-                Array [
-                  Object {
-                    "op": "replace",
-                    "path": Array [
-                      "arr",
-                      "length",
-                    ],
-                    "value": 0,
-                  },
-                ],
-                Array [
-                  Object {
-                    "op": "add",
-                    "path": Array [
-                      "arr",
-                      0,
-                    ],
-                    "value": 1,
-                  },
-                  Object {
-                    "op": "add",
-                    "path": Array [
-                      "arr",
-                      1,
-                    ],
-                    "value": 2,
-                  },
-                  Object {
-                    "op": "add",
-                    "path": Array [
-                      "arr",
-                      2,
-                    ],
-                    "value": 3,
-                  },
-                ],
-              ],
-              Array [
-                Array [
-                  Object {
-                    "op": "replace",
-                    "path": Array [
-                      "x",
-                    ],
-                    "value": 5,
-                  },
-                ],
-                Array [
-                  Object {
-                    "op": "replace",
-                    "path": Array [
-                      "x",
-                    ],
-                    "value": 6,
-                  },
-                ],
-              ],
-            ]
-      `)
+                        Array [
+                          Array [
+                            Array [
+                              Object {
+                                "op": "replace",
+                                "path": Array [
+                                  "p2",
+                                  "y",
+                                ],
+                                "value": 12,
+                              },
+                            ],
+                            Array [
+                              Object {
+                                "op": "replace",
+                                "path": Array [
+                                  "p2",
+                                  "y",
+                                ],
+                                "value": 13,
+                              },
+                            ],
+                          ],
+                          Array [
+                            Array [
+                              Object {
+                                "op": "replace",
+                                "path": Array [
+                                  "arr",
+                                  "length",
+                                ],
+                                "value": 0,
+                              },
+                            ],
+                            Array [
+                              Object {
+                                "op": "add",
+                                "path": Array [
+                                  "arr",
+                                  0,
+                                ],
+                                "value": 1,
+                              },
+                              Object {
+                                "op": "add",
+                                "path": Array [
+                                  "arr",
+                                  1,
+                                ],
+                                "value": 2,
+                              },
+                              Object {
+                                "op": "add",
+                                "path": Array [
+                                  "arr",
+                                  2,
+                                ],
+                                "value": 3,
+                              },
+                            ],
+                          ],
+                          Array [
+                            Array [
+                              Object {
+                                "op": "replace",
+                                "path": Array [
+                                  "x",
+                                ],
+                                "value": 5,
+                              },
+                            ],
+                            Array [
+                              Object {
+                                "op": "replace",
+                                "path": Array [
+                                  "x",
+                                ],
+                                "value": 6,
+                              },
+                            ],
+                          ],
+                        ]
+            `)
 })
 
 test("applySnapshot can create a new submodel", () => {
@@ -227,52 +232,52 @@ test("applySnapshot can create a new submodel", () => {
   expect(p.p2 instanceof BaseModel).toBe(true)
 
   expect(patches).toMatchInlineSnapshot(`
-    Array [
-      Array [
-        Array [
-          Object {
-            "op": "replace",
-            "path": Array [
-              "p2",
-            ],
-            "value": Object {
-              "$modelType": "P2",
-              "y": 12,
-            },
-          },
-        ],
-        Array [
-          Object {
-            "op": "replace",
-            "path": Array [
-              "p2",
-            ],
-            "value": undefined,
-          },
-        ],
-      ],
-      Array [
-        Array [
-          Object {
-            "op": "replace",
-            "path": Array [
-              "x",
-            ],
-            "value": 5,
-          },
-        ],
-        Array [
-          Object {
-            "op": "replace",
-            "path": Array [
-              "x",
-            ],
-            "value": 6,
-          },
-        ],
-      ],
-    ]
-  `)
+                Array [
+                  Array [
+                    Array [
+                      Object {
+                        "op": "replace",
+                        "path": Array [
+                          "p2",
+                        ],
+                        "value": Object {
+                          "$modelType": "P2",
+                          "y": 12,
+                        },
+                      },
+                    ],
+                    Array [
+                      Object {
+                        "op": "replace",
+                        "path": Array [
+                          "p2",
+                        ],
+                        "value": undefined,
+                      },
+                    ],
+                  ],
+                  Array [
+                    Array [
+                      Object {
+                        "op": "replace",
+                        "path": Array [
+                          "x",
+                        ],
+                        "value": 5,
+                      },
+                    ],
+                    Array [
+                      Object {
+                        "op": "replace",
+                        "path": Array [
+                          "x",
+                        ],
+                        "value": 6,
+                      },
+                    ],
+                  ],
+                ]
+        `)
 
   // swap the model for a clone, it should still be patched and create a snapshot,
   // but it should have a different id
@@ -286,60 +291,60 @@ test("applySnapshot can create a new submodel", () => {
   expect(getSnapshot(p.p2)).not.toBe(getSnapshot(oldP2))
 
   expect(patches).toMatchInlineSnapshot(`
-    Array [
-      Array [
-        Array [
-          Object {
-            "op": "replace",
-            "path": Array [
-              "p2",
-            ],
-            "value": Object {
-              "$modelType": "P2",
-              "y": 12,
-            },
-          },
-        ],
-        Array [
-          Object {
-            "op": "replace",
-            "path": Array [
-              "p2",
-            ],
-            "value": Object {
-              "$modelType": "P2",
-              "y": 12,
-            },
-          },
-        ],
-      ],
-    ]
-  `)
+                Array [
+                  Array [
+                    Array [
+                      Object {
+                        "op": "replace",
+                        "path": Array [
+                          "p2",
+                        ],
+                        "value": Object {
+                          "$modelType": "P2",
+                          "y": 12,
+                        },
+                      },
+                    ],
+                    Array [
+                      Object {
+                        "op": "replace",
+                        "path": Array [
+                          "p2",
+                        ],
+                        "value": Object {
+                          "$modelType": "P2",
+                          "y": 12,
+                        },
+                      },
+                    ],
+                  ],
+                ]
+        `)
 
   expect(sn).toMatchInlineSnapshot(`
-    Array [
-      Array [
-        Object {
-          "$modelType": "P",
-          "arr": Array [],
-          "p2": Object {
-            "$modelType": "P2",
-            "y": 12,
-          },
-          "x": 5,
-        },
-        Object {
-          "$modelType": "P",
-          "arr": Array [],
-          "p2": Object {
-            "$modelType": "P2",
-            "y": 12,
-          },
-          "x": 5,
-        },
-      ],
-    ]
-  `)
+                Array [
+                  Array [
+                    Object {
+                      "$modelType": "P",
+                      "arr": Array [],
+                      "p2": Object {
+                        "$modelType": "P2",
+                        "y": 12,
+                      },
+                      "x": 5,
+                    },
+                    Object {
+                      "$modelType": "P",
+                      "arr": Array [],
+                      "p2": Object {
+                        "$modelType": "P2",
+                        "y": 12,
+                      },
+                      "x": 5,
+                    },
+                  ],
+                ]
+        `)
 })
 
 test("undefined should not be allowed in arrays, but null should", () => {
@@ -434,4 +439,36 @@ test("types", () => {
       [modelTypeKey]: string
     })
   )
+})
+
+test("snapshot with reserved property names", () => {
+  @model("test/snapshotWithReservedPropNames")
+  class M extends Model({ onInit: prop(4) }) {
+    @modelAction
+    setOnInit(n: number) {
+      this.$.onInit = n
+    }
+  }
+
+  const p = new M({})
+  const sn = getSnapshot(p)
+  expect(p.onInit).toBeUndefined()
+
+  expect(sn).toMatchInlineSnapshot(`
+    Object {
+      "$modelType": "test/snapshotWithReservedPropNames",
+      "onInit": 4,
+    }
+  `)
+
+  const p2 = fromSnapshot<M>(sn)
+  expect(p2.onInit).toBeUndefined()
+  expect(p2.$.onInit).toBe(p.$.onInit)
+
+  applySnapshot(p2, {
+    ...sn,
+    onInit: 10,
+  })
+  expect(p2.$.onInit).toBe(10)
+  expect(p2.onInit).toBeUndefined()
 })

--- a/packages/lib/test/typeChecking/typeChecking.test.ts
+++ b/packages/lib/test/typeChecking/typeChecking.test.ts
@@ -265,8 +265,8 @@ test("model", () => {
   expectTypeCheckFail(type, "ho", [], `Model(${m.$modelType})`)
   expectTypeCheckFail(type, new MR({}), [], `Model(${m.$modelType})`)
   m.setX("10" as any)
-  expectTypeCheckFail(type, m, ["$", "x"], "number")
-  expect(m.typeCheck()).toEqual(new TypeCheckError(["$", "x"], "number", "10"))
+  expectTypeCheckFail(type, m, ["x"], "number")
+  expect(m.typeCheck()).toEqual(new TypeCheckError(["x"], "number", "10"))
 })
 
 test("model typechecking", () => {
@@ -314,7 +314,7 @@ test("new model with typechecking enabled", () => {
     modelAutoTypeChecking: ModelAutoTypeCheckingMode.AlwaysOn,
   })
 
-  expect(() => new M({ x: 10, y: 20 as any })).toThrow("TypeCheckError: [$/y] Expected: string")
+  expect(() => new M({ x: 10, y: 20 as any })).toThrow("TypeCheckError: [/y] Expected: string")
 })
 
 test("model", () => {
@@ -326,7 +326,7 @@ test("model", () => {
 
   expectTypeCheckFail(type, "ho", [], `Model(${m.$modelType})`)
   m.setX("10" as any)
-  expectTypeCheckFail(type, m, ["$", "x"], "number")
+  expectTypeCheckFail(type, m, ["x"], "number")
 })
 
 test("array - complex types", () => {
@@ -497,7 +497,7 @@ test("recursive model", () => {
   expectTypeCheckOk(type, mr)
 
   mr.setRec("5" as any)
-  expectTypeCheckFail(type, mr, ["$", "rec"], "Model(MR) | undefined")
+  expectTypeCheckFail(type, mr, ["rec"], "Model(MR) | undefined")
 })
 
 @model("MA")
@@ -531,7 +531,7 @@ test("cross referenced model", () => {
   expectTypeCheckOk(type, ma)
 
   ma.b!.setA("5" as any)
-  expectTypeCheckFail(type, ma, ["$", "b"], "Model(MB) | undefined")
+  expectTypeCheckFail(type, ma, ["b"], "Model(MB) | undefined")
 })
 
 test("ref", () => {
@@ -675,7 +675,7 @@ test("objectMap", () => {
   assert(_ as TypeToData<typeof type>, _ as ObjectMap<number>)
 
   expectTypeCheckOk(type, objectMap<number>([["1", 10]]))
-  expectTypeCheckFail(type, objectMap<string>([["1", "10"]]), ["$", "items", "1"], "number")
+  expectTypeCheckFail(type, objectMap<string>([["1", "10"]]), ["items", "1"], "number")
 })
 
 test("arraySet", () => {
@@ -684,7 +684,7 @@ test("arraySet", () => {
   assert(_ as TypeToData<typeof type>, _ as ArraySet<number>)
 
   expectTypeCheckOk(type, arraySet<number>([1, 2, 3]))
-  expectTypeCheckFail(type, arraySet<string | number>([1, 2, "3"]), ["$", "items", 2], "number")
+  expectTypeCheckFail(type, arraySet<string | number>([1, 2, "3"]), ["items", 2], "number")
 })
 
 test("typing of optional values", () => {

--- a/packages/site/src/runtimeTypeChecking.mdx
+++ b/packages/site/src/runtimeTypeChecking.mdx
@@ -18,7 +18,7 @@ Type definitions are like the schemas for your data. They are usually associated
 @model("TodoApp/Todo")
 class Todo extends Model({
   text: tProp(types.string),
-  done: tProp(types.boolean, false)
+  done: tProp(types.boolean, false),
 }) {
   // ...
 }
@@ -259,7 +259,7 @@ const sumModelType = types.refinement(types.model<Sum>(Sum), sum => {
   return rightResult
 
   // this will return that the result field is wrong
-  return rightResult ? null : new TypeCheckError(["$", "result"], "a+b", sum.result)
+  return rightResult ? null : new TypeCheckError(["result"], "a+b", sum.result)
 })
 ```
 

--- a/packages/site/src/treeLikeStructure.mdx
+++ b/packages/site/src/treeLikeStructure.mdx
@@ -70,10 +70,9 @@ When a non-primitive value is turned into a tree node it gains access to certain
 
 Returns the parent of the target plus the path from the parent to the target, or `undefined` if it has no parent.
 
-### `getParent<T extends object = any>(value: object, skipModelDataObject = false): T | undefined`
+### `getParent<T extends object = any>(value: object): T | undefined`
 
 Returns the parent object of the target object, or `undefined` if there's no parent.
-Note that when using this function over model properties you will get as parent its interim data object (`$`). If you want to get the parent model directly in such cases you can pass `true` as the second parameter.
 
 ### `getParentToChildPath(fromParent: object, toChild: object): (string | number)[] | undefined`
 
@@ -120,7 +119,6 @@ A max depth of 0 is infinite, but another one can be given.
 Returns an observable set with all the children objects (this is, excluding primitives) of an object.
 
 Pass the options object with the `deep` option (defaults to `false`) set to `true` to get the children deeply or `false` to get them shallowly.
-Models will report their props as their children directly, so interim data objects (`$`) won't be returned.
 
 ### `walkTree<T = void>(target: object, predicate: (node: any) => T | undefined, mode: WalkTreeMode): T | undefined`
 


### PR DESCRIPTION
## 0.21.0

- [BREAKING CHANGE] Paths to model properties will no longer report interim data objects (`$`). This means that properties are now direct children of model objects, which should be cleaner and more understandable.

For example, now calling `getParent(model.model2.foo)` will return `model.model2` rather than `model.model2.$`, which was confusing.
`getRootPath(model.model2.foo)` will return `["model", "model2", "foo"]` rather than `["model", "$", "model2", "$", "foo"]`, which was even more confusing.

Also has the nice side effect that apparently made it faster (since trees are now shallower)

```
empty creation (type checking disabled) - mst is usually faster here due to lazy creation
mobx-keystone x 3,686 ops/sec ±4.67% (74 runs sampled)
mobx-state-tree x 6,678 ops/sec ±6.61% (75 runs sampled)
Fastest is mobx-state-tree by 1.81x

empty creation + access all simple props (type checking disabled)
mobx-keystone x 3,761 ops/sec ±4.62% (77 runs sampled)
mobx-state-tree x 2,696 ops/sec ±4.31% (76 runs sampled)
Fastest is mobx-keystone by 1.40x

already created, access all simple props (type checking disabled)
mobx-keystone x 340,961 ops/sec ±2.26% (89 runs sampled)
mobx-state-tree x 304,055 ops/sec ±2.38% (87 runs sampled)
Fastest is mobx-keystone by 1.12x

already created, change all simple props (type checking disabled)
mobx-keystone x 5,899 ops/sec ±7.35% (85 runs sampled)
mobx-state-tree x 2,010 ops/sec ±9.86% (85 runs sampled)
Fastest is mobx-keystone by 2.94x

already created, change one simple props + getSnapshot (type checking disabled)
mobx-keystone x 164,378 ops/sec ±3.78% (84 runs sampled)
mobx-state-tree x 57,170 ops/sec ±2.48% (90 runs sampled)
Fastest is mobx-keystone by 2.88x
```
