### PR TITLE
tProp syntax sugar

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Change Log
 
+## 0.22.0
+
+- Added `tProp` syntax sugar for optional primitives with a default value.
+
 ## 0.21.0
 
 - [BREAKING CHANGE] Paths to model properties will no longer report interim data objects (`$`). This means that properties are now direct children of model objects, which should be cleaner and more understandable.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## 0.22.0
 
 - Added `tProp` syntax sugar for optional primitives with a default value.
+- Added `String`, `Number`, `Boolean`, `null`, `undefined` as aliases for primitive types.
 - Added `findParentPath`.
 
 ## 0.21.0

--- a/packages/lib/package.json
+++ b/packages/lib/package.json
@@ -1,6 +1,6 @@
 {
   "name": "mobx-keystone",
-  "version": "0.21.0",
+  "version": "0.22.0",
   "description": "A MobX powered state management solution based on data trees with first class support for Typescript, snapshots, patches and much more",
   "keywords": [
     "mobx",

--- a/packages/lib/package.json
+++ b/packages/lib/package.json
@@ -55,7 +55,7 @@
     "typescript": "^3.6.3"
   },
   "dependencies": {
-    "ts-toolbelt": "^3.14.0",
+    "ts-toolbelt": "^4.1.0",
     "tslib": "^1.10.0"
   },
   "directories": {

--- a/packages/lib/src/model/Model.ts
+++ b/packages/lib/src/model/Model.ts
@@ -16,7 +16,7 @@ import {
   modelInitializersSymbol,
   modelPropertiesSymbol,
 } from "./modelSymbols"
-import { ModelProps, ModelPropsToData, OptionalModelProps } from "./prop"
+import { ModelProps, ModelPropsToData, noTypeChecker, OptionalModelProps } from "./prop"
 import { assertIsModelClass } from "./utils"
 
 declare const propsDataSymbol: unique symbol
@@ -131,12 +131,12 @@ function internalModel<TProps extends ModelProps, TBaseModel extends AnyModel>(
 
   // create type checker if needed
   let dataTypeChecker: LateTypeChecker | undefined
-  if (Object.values(composedModelProps).some(mp => mp.typeChecker)) {
+  if (Object.values(composedModelProps).some(mp => mp.typeChecker !== noTypeChecker)) {
     const typeCheckerObj: {
       [k: string]: any
     } = {}
     for (const [k, mp] of Object.entries(composedModelProps)) {
-      typeCheckerObj[k] = mp.typeChecker || typesUnchecked()
+      typeCheckerObj[k] = mp.typeChecker === noTypeChecker ? typesUnchecked() : mp.typeChecker
     }
     dataTypeChecker = typesObject(() => typeCheckerObj) as any
   }

--- a/packages/lib/src/model/newModel.ts
+++ b/packages/lib/src/model/newModel.ts
@@ -103,7 +103,7 @@ export const internalNewModel = action(
       }
     }
 
-    return modelObj
+    return modelObj as M
   }
 )
 

--- a/packages/lib/src/model/prop.ts
+++ b/packages/lib/src/model/prop.ts
@@ -2,6 +2,11 @@ import { LateTypeChecker, TypeChecker } from "../typeChecking/TypeChecker"
 import { IsOptionalValue } from "../utils/types"
 
 /**
+ * @ignore
+ */
+export const noTypeChecker = Symbol("noTypeChecker")
+
+/**
  * A model property.
  */
 export interface ModelProp<TValue, THasDefault> {
@@ -9,7 +14,7 @@ export interface ModelProp<TValue, THasDefault> {
   $hasDefault: THasDefault
   defaultFn?: () => TValue
   defaultValue?: TValue
-  typeChecker: TypeChecker | LateTypeChecker | null
+  typeChecker: TypeChecker | LateTypeChecker | typeof noTypeChecker
 }
 
 /**
@@ -81,6 +86,6 @@ export function prop<TValue>(def?: any): ModelProp<TValue, any> {
     $hasDefault: null as any,
     defaultFn: isDefFn ? def : undefined,
     defaultValue: isDefFn ? undefined : def,
-    typeChecker: null,
+    typeChecker: noTypeChecker,
   }
 }

--- a/packages/lib/src/typeChecking/TypeChecker.ts
+++ b/packages/lib/src/typeChecking/TypeChecker.ts
@@ -116,22 +116,6 @@ export function assertIsTypeChecker(value: any) {
   }
 }
 
-/**
- * @ignore
- */
-export function resolveTypeChecker(v: any): TypeChecker {
-  let next: TypeChecker | LateTypeChecker = v
-  while (true) {
-    if (next instanceof TypeChecker) {
-      return next
-    } else if (isLateTypeChecker(next)) {
-      next = next()
-    } else {
-      throw failure("type checker could not be resolved")
-    }
-  }
-}
-
 const lateTypeCheckerSymbol = Symbol("lateTypeCheker")
 
 /**

--- a/packages/lib/src/typeChecking/array.ts
+++ b/packages/lib/src/typeChecking/array.ts
@@ -1,6 +1,7 @@
 import { isArray } from "../utils"
+import { resolveTypeChecker } from "./resolveTypeChecker"
 import { AnyType, ArrayType } from "./schemas"
-import { lateTypeChecker, resolveTypeChecker, TypeChecker } from "./TypeChecker"
+import { lateTypeChecker, TypeChecker } from "./TypeChecker"
 import { TypeCheckError } from "./TypeCheckError"
 
 /**

--- a/packages/lib/src/typeChecking/arraySet.ts
+++ b/packages/lib/src/typeChecking/arraySet.ts
@@ -1,8 +1,9 @@
 import { ArraySet } from "../wrappers/ArraySet"
 import { typesArray } from "./array"
 import { typesObject } from "./object"
+import { resolveTypeChecker } from "./resolveTypeChecker"
 import { AnyType, IdentityType, TypeToData } from "./schemas"
-import { lateTypeChecker, resolveTypeChecker, TypeChecker } from "./TypeChecker"
+import { lateTypeChecker, TypeChecker } from "./TypeChecker"
 import { TypeCheckError } from "./TypeCheckError"
 
 /**

--- a/packages/lib/src/typeChecking/model.ts
+++ b/packages/lib/src/typeChecking/model.ts
@@ -3,8 +3,9 @@ import { getModelDataType } from "../model/getModelDataType"
 import { modelInfoByClass } from "../model/modelInfo"
 import { assertIsModelClass, isModelClass } from "../model/utils"
 import { failure } from "../utils"
+import { resolveTypeChecker } from "./resolveTypeChecker"
 import { IdentityType } from "./schemas"
-import { lateTypeChecker, resolveTypeChecker, TypeChecker } from "./TypeChecker"
+import { lateTypeChecker, TypeChecker } from "./TypeChecker"
 import { TypeCheckError } from "./TypeCheckError"
 
 const cachedModelTypeChecker = new WeakMap<ModelClass<AnyModel>, TypeChecker>()

--- a/packages/lib/src/typeChecking/object.ts
+++ b/packages/lib/src/typeChecking/object.ts
@@ -1,7 +1,8 @@
 import { Frozen } from "../frozen/Frozen"
 import { assertIsFunction, assertIsObject, isObject } from "../utils"
+import { resolveTypeChecker } from "./resolveTypeChecker"
 import { AnyType, ObjectType } from "./schemas"
-import { lateTypeChecker, LateTypeChecker, resolveTypeChecker, TypeChecker } from "./TypeChecker"
+import { lateTypeChecker, LateTypeChecker, TypeChecker } from "./TypeChecker"
 import { TypeCheckError } from "./TypeCheckError"
 
 function typesObjectHelper<S>(objFn: S, frozen: boolean): S {

--- a/packages/lib/src/typeChecking/objectMap.ts
+++ b/packages/lib/src/typeChecking/objectMap.ts
@@ -1,8 +1,9 @@
 import { ObjectMap } from "../wrappers/ObjectMap"
 import { typesObject } from "./object"
 import { typesRecord } from "./record"
+import { resolveTypeChecker } from "./resolveTypeChecker"
 import { AnyType, IdentityType, TypeToData } from "./schemas"
-import { lateTypeChecker, resolveTypeChecker, TypeChecker } from "./TypeChecker"
+import { lateTypeChecker, TypeChecker } from "./TypeChecker"
 import { TypeCheckError } from "./TypeCheckError"
 
 /**

--- a/packages/lib/src/typeChecking/or.ts
+++ b/packages/lib/src/typeChecking/or.ts
@@ -1,5 +1,6 @@
+import { resolveTypeChecker } from "./resolveTypeChecker"
 import { AnyType, OrType } from "./schemas"
-import { lateTypeChecker, resolveTypeChecker, TypeChecker } from "./TypeChecker"
+import { lateTypeChecker, TypeChecker } from "./TypeChecker"
 import { TypeCheckError } from "./TypeCheckError"
 import { typesUnchecked } from "./unchecked"
 

--- a/packages/lib/src/typeChecking/record.ts
+++ b/packages/lib/src/typeChecking/record.ts
@@ -1,6 +1,7 @@
 import { isObject } from "../utils"
+import { resolveTypeChecker } from "./resolveTypeChecker"
 import { AnyType, RecordType } from "./schemas"
-import { lateTypeChecker, resolveTypeChecker, TypeChecker } from "./TypeChecker"
+import { lateTypeChecker, TypeChecker } from "./TypeChecker"
 import { TypeCheckError } from "./TypeCheckError"
 
 /**

--- a/packages/lib/src/typeChecking/ref.ts
+++ b/packages/lib/src/typeChecking/ref.ts
@@ -1,8 +1,9 @@
 import { Ref } from "../ref/Ref"
 import { typesObject } from "./object"
 import { typesString } from "./primitives"
+import { resolveTypeChecker } from "./resolveTypeChecker"
 import { IdentityType } from "./schemas"
-import { resolveTypeChecker, TypeChecker } from "./TypeChecker"
+import { TypeChecker } from "./TypeChecker"
 import { TypeCheckError } from "./TypeCheckError"
 
 /**

--- a/packages/lib/src/typeChecking/refinement.ts
+++ b/packages/lib/src/typeChecking/refinement.ts
@@ -1,5 +1,6 @@
+import { resolveTypeChecker } from "./resolveTypeChecker"
 import { AnyType, TypeToData } from "./schemas"
-import { lateTypeChecker, resolveTypeChecker, TypeChecker } from "./TypeChecker"
+import { lateTypeChecker, TypeChecker } from "./TypeChecker"
 import { TypeCheckError } from "./TypeCheckError"
 
 /**

--- a/packages/lib/src/typeChecking/resolveTypeChecker.ts
+++ b/packages/lib/src/typeChecking/resolveTypeChecker.ts
@@ -1,0 +1,29 @@
+import { failure } from "../utils"
+import { typesBoolean, typesNull, typesNumber, typesString, typesUndefined } from "./primitives"
+import { isLateTypeChecker, LateTypeChecker, TypeChecker } from "./TypeChecker"
+
+/**
+ * @ignore
+ */
+export function resolveTypeChecker(v: any): TypeChecker {
+  let next: TypeChecker | LateTypeChecker = v
+  while (true) {
+    if (next instanceof TypeChecker) {
+      return next
+    } else if (v === String) {
+      return typesString as any
+    } else if (v === Number) {
+      return typesNumber as any
+    } else if (v === Boolean) {
+      return typesBoolean as any
+    } else if (v === null) {
+      return typesNull as any
+    } else if (v === undefined) {
+      return typesUndefined as any
+    } else if (isLateTypeChecker(next)) {
+      next = next()
+    } else {
+      throw failure("type checker could not be resolved")
+    }
+  }
+}

--- a/packages/lib/src/typeChecking/schemas.ts
+++ b/packages/lib/src/typeChecking/schemas.ts
@@ -62,6 +62,11 @@ export interface OrType<S extends AnyType[]> {
 }
 
 export type AnyType =
+  | StringConstructor
+  | NumberConstructor
+  | BooleanConstructor
+  | null
+  | undefined
   | IdentityType<any>
   | ArrayType<any>
   | OrType<any>
@@ -95,7 +100,17 @@ export type TypeToData<S extends AnyType> = S extends ObjectTypeFunction<infer S
   ? S["$$identityType"] extends infer R
     ? R
     : never
-  : never
+  : S extends StringConstructor // String
+  ? string
+  : S extends NumberConstructor // Number
+  ? number
+  : S extends BooleanConstructor // Boolean
+  ? boolean
+  : S extends null // null
+  ? null
+  : S extends undefined // undefined
+  ? undefined
+  : never // anything else
 
 /** @ignore */
 export type TypeToDataOpt<S extends AnyType> = S extends OrType<any>

--- a/packages/lib/src/typeChecking/tProp.ts
+++ b/packages/lib/src/typeChecking/tProp.ts
@@ -1,6 +1,49 @@
 import { ModelProp } from "../model/prop"
 import { IsOptionalValue } from "../utils/types"
+import { typesBoolean, typesNumber, typesString } from "./primitives"
 import { AnyType, TypeToData, TypeToDataOpt } from "./schemas"
+
+/**
+ * Defines a string model property with a default value.
+ * Equivalent to `tProp(types.string, defaultValue)`.
+ *
+ * Example:
+ * ```ts
+ * x: tcProp("foo") // an optional string that will take the value `"foo"` when undefined.
+ * ```
+ *
+ * @param defaultValue Default value.
+ * @returns
+ */
+export function tProp(defaultValue: string): ModelProp<string, string>
+
+/**
+ * Defines a number model property with a default value.
+ * Equivalent to `tProp(types.number, defaultValue)`.
+ *
+ * Example:
+ * ```ts
+ * x: tcProp(42) // an optional number that will take the value `42` when undefined.
+ * ```
+ *
+ * @param defaultValue Default value.
+ * @returns
+ */
+export function tProp(defaultValue: number): ModelProp<number, string>
+
+/**
+ * Defines a boolean model property with a default value.
+ * Equivalent to `tProp(types.boolean, defaultValue)`.
+ *
+ * Example:
+ * ```ts
+ * x: tcProp(true) // an optional boolean that will take the value `true` when undefined.
+ * ```
+ *
+ * @param defaultValue Default value.
+ * @returns
+ */
+export function tProp(defaultValue: boolean): ModelProp<boolean, string>
 
 /**
  * Defines a model property with no default value and an associated type checker.
@@ -63,16 +106,22 @@ export function tProp<TType extends AnyType>(
   defaultValue: TypeToData<TType>
 ): ModelProp<TypeToData<TType>, string>
 
-export function tProp<TType extends AnyType>(
-  type: TType,
-  def?: any
-): ModelProp<TypeToData<TType>, any> {
+export function tProp(typeOrDefaultValue: any, def?: any): ModelProp<any, any> {
+  switch (typeof typeOrDefaultValue) {
+    case "string":
+      return tProp(typesString, typeOrDefaultValue)
+    case "number":
+      return tProp(typesNumber, typeOrDefaultValue)
+    case "boolean":
+      return tProp(typesBoolean, typeOrDefaultValue)
+  }
+
   const isDefFn = typeof def === "function"
   return {
     $valueType: null as any,
     $hasDefault: null as any,
     defaultFn: isDefFn ? def : undefined,
     defaultValue: isDefFn ? undefined : def,
-    typeChecker: type as any,
+    typeChecker: typeOrDefaultValue,
   }
 }

--- a/packages/lib/src/typeChecking/typeCheck.ts
+++ b/packages/lib/src/typeChecking/typeCheck.ts
@@ -1,6 +1,5 @@
-import { failure } from "../utils"
+import { resolveTypeChecker } from "./resolveTypeChecker"
 import { AnyType, TypeToData } from "./schemas"
-import { resolveTypeChecker } from "./TypeChecker"
 import { TypeCheckError } from "./TypeCheckError"
 
 /**
@@ -12,9 +11,6 @@ import { TypeCheckError } from "./TypeCheckError"
  * @returns A TypeError if the check fails or null if no error.
  */
 export function typeCheck<T extends AnyType>(type: T, value: TypeToData<T>): TypeCheckError | null {
-  if (!type) {
-    throw failure("a type must be passed")
-  }
   const typeChecker = resolveTypeChecker(type)
 
   if (typeChecker.unchecked) {

--- a/packages/lib/test/typeChecking/typeChecking.test.ts
+++ b/packages/lib/test/typeChecking/typeChecking.test.ts
@@ -731,3 +731,53 @@ test("typing of optional values", () => {
     }
   )
 })
+
+test("syntax sugar for primitives in tProp", () => {
+  @model("syntaxSugar")
+  class SS extends Model({
+    n: tProp(42),
+    s: tProp("foo"),
+    b: tProp(true),
+  }) {
+    @modelAction
+    setN(n: number) {
+      this.n = n
+    }
+
+    @modelAction
+    setS(s: string) {
+      this.s = s
+    }
+
+    @modelAction
+    setB(b: boolean) {
+      this.b = b
+    }
+  }
+
+  const ss = new SS({})
+  const type = types.model<SS>(SS)
+  assert(_ as TypeToData<typeof type>, _ as SS)
+
+  assert(ss.n, _ as number)
+  assert(ss.s, _ as string)
+  assert(ss.b, _ as boolean)
+
+  expect(ss.n).toBe(42)
+  expect(ss.s).toBe("foo")
+  expect(ss.b).toBe(true)
+
+  expectTypeCheckOk(type, ss)
+
+  ss.setN("10" as any)
+  expectTypeCheckFail(type, ss, ["n"], "number")
+  ss.setN(42)
+
+  ss.setS(10 as any)
+  expectTypeCheckFail(type, ss, ["s"], "string")
+  ss.setS("foo")
+
+  ss.setB("10" as any)
+  expectTypeCheckFail(type, ss, ["b"], "boolean")
+  ss.setB(true)
+})

--- a/packages/site/src/runtimeTypeChecking.mdx
+++ b/packages/site/src/runtimeTypeChecking.mdx
@@ -266,7 +266,7 @@ const sumModelType = types.refinement(types.model<Sum>(Sum), sum => {
 ### Syntax sugar for optional primitives with a default value
 
 You can also do `tProp(defaultValue: string | number | boolean)`, which is equivalent to `tProp(types.string|number|boolean, defaultValue)`.
-In other words, if you use `tProp(42)`, then the property will be a number that takes the value `42` when undefined.
+In other words, if you use `tProp(42)`, then the property will be a number and take the default value `42` when the value on the snapshot / model creation data is `undefined`.
 
 ### `TypeToData<type>`
 

--- a/packages/site/src/runtimeTypeChecking.mdx
+++ b/packages/site/src/runtimeTypeChecking.mdx
@@ -263,6 +263,11 @@ const sumModelType = types.refinement(types.model<Sum>(Sum), sum => {
 })
 ```
 
+### Syntax sugar for optional primitives with a default value
+
+You can also do `tProp(defaultValue: string | number | boolean)`, which is equivalent to `tProp(types.string|number|boolean, defaultValue)`.
+In other words, if you use `tProp(42)`, then the property will be a number that takes the value `42` when undefined.
+
 ### `TypeToData<type>`
 
 It is also possible to get the type represented by a type via `TypeToData`:

--- a/packages/site/src/runtimeTypeChecking.mdx
+++ b/packages/site/src/runtimeTypeChecking.mdx
@@ -81,19 +81,19 @@ const hiType = types.literal("hi") // the string with value "hi"
 const number5Type = types.literal(5) // the number with value 5
 ```
 
-### `types.undefined`
+### `types.undefined` / `undefined`
 
 A type that represents the value `undefined`.
 
-### `types.null`
+### `types.null` / `null`
 
 A type that represents the value `null`.
 
-### `types.boolean`
+### `types.boolean` / `Boolean`
 
 A type that represents any boolean value.
 
-### `types.number`
+### `types.number` / `Number`
 
 A type that represents any number value.
 
@@ -101,7 +101,7 @@ A type that represents any number value.
 
 A type that represents any integer number value.
 
-### `types.string`
+### `types.string` / `String`
 
 A type that represents any string value.
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -14348,10 +14348,10 @@ ts-node@^8.4.1:
     source-map-support "^0.5.6"
     yn "^3.0.0"
 
-ts-toolbelt@^3.14.0:
-  version "3.14.0"
-  resolved "https://registry.yarnpkg.com/ts-toolbelt/-/ts-toolbelt-3.14.0.tgz#f4c4984cf4e988915a0175fd6a8ded00bd1d23b0"
-  integrity sha512-DYjD8tL7M1kBogRd9UKg3bUP5yh69WWcMSaA3By8ATiJU9fgYudSYIe8tWD5cpPkrGCdGGnKXQHG+5IrjJ5uhQ==
+ts-toolbelt@^4.1.0:
+  version "4.1.0"
+  resolved "https://registry.yarnpkg.com/ts-toolbelt/-/ts-toolbelt-4.1.0.tgz#a35fedc9fcc1f731ab3dcfe9d8c380dd82121196"
+  integrity sha512-C7R81bOW5HZyTdK+13lZiu8CYibzcLNuQ5AGsCrT3IYS6hg0EGsxnUt4DI/C7AiqC2byRxoyQ3MotncKZxbytw==
 
 tsdx@^0.9.2:
   version "0.9.2"


### PR DESCRIPTION
Fixes #39 

### Syntax sugar for optional primitives with a default value

You can also do `tProp(defaultValue: string | number | boolean)`, which is equivalent to `tProp(types.string|number|boolean, defaultValue)`.
In other words, if you use `tProp(42)`, then the property will be a number that takes the value `42` when undefined.
