### PR TITLE
add applySerializedAction methods

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## 0.25.0
 
 - Added `applySerializedActionAndTrackNewModelIds` and `applySerializedActionAndSyncNewModelIds`. Prefer those over `deserializeActionCall` plus `applyAction` when applying serialized (over the wire) actions in order to avoid \$modelId desynchronization.
+- Added a default implementation of `getRefId()` which returns `$modelId`.
 
 ## 0.24.1
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Change Log
 
+## 0.25.0
+
+- Added `applySerializedActionAndTrackNewModelIds` and `applySerializedActionAndSyncNewModelIds`. Prefer those over `deserializeActionCall` plus `applyAction` when applying serialized (over the wire) actions in order to avoid \$modelId desynchronization.
+
 ## 0.24.1
 
 - Fixed wrong patches being generated for array splices sometimes.

--- a/packages/lib/package.json
+++ b/packages/lib/package.json
@@ -1,6 +1,6 @@
 {
   "name": "mobx-keystone",
-  "version": "0.24.1",
+  "version": "0.25.0",
   "description": "A MobX powered state management solution based on data trees with first class support for Typescript, snapshots, patches and much more",
   "keywords": [
     "mobx",
@@ -33,7 +33,7 @@
   ],
   "scripts": {
     "start": "tsdx watch",
-    "build": "tsc -p . --noEmit && shx cp ../../README.md . && shx cp ../../LICENSE . && tsdx build --name mobxKeystone --format=cjs,esm,umd",
+    "build": "shx rm -rf dist && tsc -p . --noEmit && shx cp ../../README.md . && shx cp ../../LICENSE . && tsdx build --name mobxKeystone --format=cjs,esm,umd",
     "test": "tsdx test",
     "test:perf": "yarn build && yarn test:perf:run",
     "test:perf:run": "cd perf_bench && export NODE_ENV=production && /usr/bin/time node --expose-gc --require ts-node/register ./report.ts",

--- a/packages/lib/src/action/applyAction.ts
+++ b/packages/lib/src/action/applyAction.ts
@@ -39,15 +39,19 @@ export interface ActionCall {
 }
 
 /**
- * Applies (runs) a serialized action over a target object.
+ * Applies (runs) an action over a target object.
+ *
+ * If you intend to apply serialized actions check one of the `applySerializedAction` methods instead.
  *
  * @param subtreeRoot Subtree root target object to run the action over.
- * @param call The serialized action, usually as coming from `onActionMiddleware`.
+ * @param call The action, usually as coming from `onActionMiddleware`.
  * @returns The return value of the action, if any.
  */
 export function applyAction<TRet = any>(subtreeRoot: object, call: ActionCall): TRet {
   if (call.serialized) {
-    throw failure("cannot apply a serialized action call, deserialize it first")
+    throw failure(
+      "cannot apply a serialized action call, use one of the 'applySerializedAction' methods instead"
+    )
   }
 
   assertTweakedObject(subtreeRoot, "subtreeRoot")

--- a/packages/lib/src/actionMiddlewares/actionSerialization/applySerializedAction.ts
+++ b/packages/lib/src/actionMiddlewares/actionSerialization/applySerializedAction.ts
@@ -1,0 +1,148 @@
+import { runInAction } from "mobx"
+import { applyAction } from "../../action/applyAction"
+import { modelIdKey } from "../../model/metadata"
+import { applyPatches } from "../../patch/applyPatches"
+import { onPatches } from "../../patch/emitPatch"
+import { Patch } from "../../patch/Patch"
+import { assertTweakedObject } from "../../tweaker/core"
+import { failure, isObject } from "../../utils"
+import { deserializeActionCall, SerializedActionCall } from "./actionSerialization"
+
+/**
+ * Serialized action call with model ID overrides.
+ * Can be generated with `applySerializedActionAndTrackNewModelIds`.
+ * To be applied with `applySerializedActionAndSyncNewModelIds`.
+ */
+export interface SerializedActionCallWithModelIdOverrides extends SerializedActionCall {
+  /**
+   * Model Id overrides to be applied at the end of applying the action.
+   */
+  readonly modelIdOverrides: ReadonlyArray<Patch>
+}
+
+/**
+ * Applies (runs) a serialized action over a target object.
+ * In this mode newly generated / modified model IDs will be tracked
+ * so they can be later synchronized when applying it on another machine
+ * via `applySerializedActionAndSyncNewModelIds`.
+ * This means this method is usually used on the server side.
+ *
+ * If you intend to apply non serialized actions check `applyAction` instead.
+ *
+ * @param subtreeRoot Subtree root target object to run the action over.
+ * @param call The serialized action, usually as coming from the server/client.
+ * @returns The return value of the action, if any, plus a new serialized action
+ * with model overrides.
+ */
+export function applySerializedActionAndTrackNewModelIds<TRet = any>(
+  subtreeRoot: object,
+  call: SerializedActionCall
+): {
+  returnValue: TRet
+  serializedActionCall: SerializedActionCallWithModelIdOverrides
+} {
+  if (!call.serialized) {
+    throw failure("cannot apply a non serialized action call, use 'applyAction' instead")
+  }
+
+  assertTweakedObject(subtreeRoot, "subtreeRoot")
+
+  const deserializedCall = deserializeActionCall(call, subtreeRoot)
+
+  const modelIdOverrides: Patch[] = []
+
+  // set a patch listener to track changes to model ids
+  const patchDisposer = onPatches(subtreeRoot, patches => {
+    scanPatchesForModelIdChanges(modelIdOverrides, patches)
+  })
+
+  try {
+    const returnValue = applyAction(subtreeRoot, deserializedCall)
+
+    return {
+      returnValue,
+      serializedActionCall: {
+        ...call,
+        modelIdOverrides,
+      },
+    }
+  } finally {
+    patchDisposer()
+  }
+}
+
+function scanPatchesForModelIdChanges(modelIdOverrides: Patch[], patches: Patch[]) {
+  const len = patches.length
+  for (let i = 0; i < len; i++) {
+    const patch = patches[i]
+    if (patch.op === "replace" || patch.op === "add") {
+      deepScanValueForModelIdChanges(modelIdOverrides, patch.value, patch.path)
+    }
+  }
+}
+
+function deepScanValueForModelIdChanges(
+  modelIdOverrides: Patch[],
+  value: any,
+  path: (string | number)[]
+) {
+  if (path[path.length - 1] === modelIdKey && typeof value === "string") {
+    // found one
+    modelIdOverrides.push({
+      op: "replace",
+      path: path,
+      value: value,
+    })
+  } else if (Array.isArray(value)) {
+    const len = value.length
+    for (let i = 0; i < len; i++) {
+      deepScanValueForModelIdChanges(modelIdOverrides, value[i], [...path, i])
+    }
+  } else if (isObject(value)) {
+    const keys = Object.keys(value)
+    const len = keys.length
+    for (let i = 0; i < len; i++) {
+      const propName = keys[i]
+      const propValue = value[propName]
+
+      deepScanValueForModelIdChanges(modelIdOverrides, propValue, [...path, propName])
+    }
+  }
+}
+
+/**
+ * Applies (runs) a serialized action over a target object.
+ * In this mode newly generated / modified model IDs will be tracked
+ * so they can be later synchronized when applying it on another machine
+ * via `applySerializedActionAndSyncNewModelIds`.
+ * This means this method is usually used on the server side.
+ *
+ * If you intend to apply non serialized actions check `applyAction` instead.
+ *
+ * @param subtreeRoot Subtree root target object to run the action over.
+ * @param call The serialized action, usually as coming from the server/client.
+ * @returns The return value of the action, if any, plus a new serialized action
+ * with model overrides.
+ */
+export function applySerializedActionAndSyncNewModelIds<TRet = any>(
+  subtreeRoot: object,
+  call: SerializedActionCallWithModelIdOverrides
+): TRet {
+  if (!call.serialized) {
+    throw failure("cannot apply a non serialized action call, use 'applyAction' instead")
+  }
+
+  assertTweakedObject(subtreeRoot, "subtreeRoot")
+
+  const deserializedCall = deserializeActionCall(call, subtreeRoot)
+
+  let returnValue: any
+  runInAction(() => {
+    returnValue = applyAction(subtreeRoot, deserializedCall)
+
+    // apply model id overrides
+    applyPatches(subtreeRoot, call.modelIdOverrides)
+  })
+
+  return returnValue
+}

--- a/packages/lib/src/actionMiddlewares/actionSerialization/index.ts
+++ b/packages/lib/src/actionMiddlewares/actionSerialization/index.ts
@@ -1,0 +1,15 @@
+export {
+  deserializeActionCall,
+  deserializeActionCallArgument,
+  registerActionCallArgumentSerializer,
+  serializeActionCall,
+  serializeActionCallArgument,
+  SerializedActionCall,
+  SerializedActionCallArgument,
+} from "./actionSerialization"
+export {
+  applySerializedActionAndSyncNewModelIds,
+  applySerializedActionAndTrackNewModelIds,
+  SerializedActionCallWithModelIdOverrides,
+} from "./applySerializedAction"
+export { ActionCallArgumentSerializer } from "./core"

--- a/packages/lib/src/actionMiddlewares/index.ts
+++ b/packages/lib/src/actionMiddlewares/index.ts
@@ -1,13 +1,4 @@
-export {
-  deserializeActionCall,
-  deserializeActionCallArgument,
-  registerActionCallArgumentSerializer,
-  serializeActionCall,
-  serializeActionCallArgument,
-  SerializedActionCall,
-  SerializedActionCallArgument,
-} from "./actionSerialization/actionSerialization"
-export { ActionCallArgumentSerializer } from "./actionSerialization/core"
+export * from "./actionSerialization"
 export {
   ActionTrackingMiddleware,
   actionTrackingMiddleware,

--- a/packages/lib/src/globalConfig/globalConfig.ts
+++ b/packages/lib/src/globalConfig/globalConfig.ts
@@ -1,4 +1,4 @@
-import { v4 as uuidv4 } from "uuid"
+import uuidv4 from "uuid/v4"
 import { failure, inDevMode } from "../utils"
 
 /**

--- a/packages/lib/src/model/BaseModel.ts
+++ b/packages/lib/src/model/BaseModel.ts
@@ -47,8 +47,11 @@ export abstract class BaseModel<
 
   /**
    * Can be overriden to offer a reference id to be used in reference resolution.
+   * By default it will use `$modelId`.
    */
-  getRefId?(): string
+  getRefId(): string {
+    return this[modelIdKey]
+  }
 
   /**
    * Called after the model has been created.

--- a/packages/lib/test/actionMiddleware/applySerializedAction.test.ts
+++ b/packages/lib/test/actionMiddleware/applySerializedAction.test.ts
@@ -1,0 +1,147 @@
+import {
+  ActionTrackingResult,
+  applySerializedActionAndSyncNewModelIds,
+  applySerializedActionAndTrackNewModelIds,
+  clone,
+  getSnapshot,
+  model,
+  Model,
+  modelAction,
+  onActionMiddleware,
+  prop,
+  serializeActionCall,
+  SerializedActionCall,
+} from "../../src"
+import "../commonSetup"
+
+describe("concurrency", () => {
+  @model("Root")
+  class Root extends Model({
+    list: prop<ChildA[]>(() => []),
+  }) {
+    @modelAction
+    add() {
+      this.list.push(new ChildA({}))
+    }
+
+    @modelAction
+    addData(child: ChildA) {
+      this.list.push(child)
+    }
+
+    @modelAction
+    clone(index: number) {
+      this.list.push(clone(this.list[index]))
+    }
+
+    @modelAction
+    cloneData(data: ChildA) {
+      this.list.push(clone(data))
+    }
+
+    @modelAction
+    changeId(index: number, newId: string) {
+      this.list[index].$modelId = newId
+    }
+
+    @modelAction
+    changeDeepId(index: number, newId: string) {
+      this.list[index].childB.$modelId = newId
+    }
+  }
+
+  @model("ChildA")
+  class ChildA extends Model({
+    childB: prop(() => new ChildB({})),
+  }) {}
+
+  @model("ChildB")
+  class ChildB extends Model({}) {}
+
+  let rootClient!: Root
+  let rootServer!: Root
+  let capturing = true
+  let captured: SerializedActionCall[] = []
+  beforeEach(() => {
+    rootClient = new Root({})
+    rootServer = new Root({})
+    capturing = true
+    captured.length = 0
+
+    onActionMiddleware(rootClient, {
+      onStart(actionCall) {
+        if (capturing) {
+          captured.push(serializeActionCall(actionCall, rootClient))
+          return {
+            result: ActionTrackingResult.Return,
+            value: undefined,
+          }
+        }
+        return undefined
+      },
+    })
+  })
+
+  function replicate(actionCall: SerializedActionCall) {
+    // apply action on server, track model ids
+    const ret = applySerializedActionAndTrackNewModelIds(rootServer, actionCall)
+
+    // replicate on client, sync model ids
+    capturing = false
+    applySerializedActionAndSyncNewModelIds(rootClient, ret.serializedActionCall)
+  }
+
+  test("id replication", () => {
+    // capture events
+    rootClient.add()
+    rootClient.addData(new ChildA({}))
+    rootClient.clone(0)
+    rootClient.cloneData(new ChildA({}))
+    rootClient.changeId(0, "SOME ID")
+    rootClient.changeDeepId(0, "SOME ID 2")
+
+    expect(captured.length).toBe(6)
+
+    for (const capture of captured) {
+      replicate(capture)
+    }
+
+    expect(getSnapshot(rootClient.list)).toEqual(getSnapshot(rootServer.list))
+    expect(getSnapshot(rootClient.list)).toMatchInlineSnapshot(`
+      Array [
+        Object {
+          "$modelId": "SOME ID",
+          "$modelType": "ChildA",
+          "childB": Object {
+            "$modelId": "SOME ID 2",
+            "$modelType": "ChildB",
+          },
+        },
+        Object {
+          "$modelId": "id-3",
+          "$modelType": "ChildA",
+          "childB": Object {
+            "$modelId": "id-4",
+            "$modelType": "ChildB",
+          },
+        },
+        Object {
+          "$modelId": "id-11",
+          "$modelType": "ChildA",
+          "childB": Object {
+            "$modelId": "id-12",
+            "$modelType": "ChildB",
+          },
+        },
+        Object {
+          "$modelId": "id-15",
+          "$modelType": "ChildA",
+          "childB": Object {
+            "$modelId": "id-16",
+            "$modelType": "ChildB",
+          },
+        },
+      ]
+    `)
+  })
+})

--- a/packages/lib/test/model/ids.test.ts
+++ b/packages/lib/test/model/ids.test.ts
@@ -9,6 +9,7 @@ test("ids", () => {
   {
     const m1 = new M({})
     expect(m1.$modelId).toBe("id-1")
+    expect(m1.getRefId()).toBe(m1.$modelId)
     expect(getSnapshot(m1)).toEqual({
       $modelId: "id-1",
       $modelType: "ids",
@@ -19,6 +20,7 @@ test("ids", () => {
   {
     const m1 = new M({ $modelId: "MY_ID" })
     expect(m1.$modelId).toBe("MY_ID")
+    expect(m1.getRefId()).toBe(m1.$modelId)
     expect(getSnapshot(m1)).toEqual({
       $modelId: "MY_ID",
       $modelType: "ids",
@@ -29,6 +31,7 @@ test("ids", () => {
   {
     const m1 = fromSnapshot<M>({ $modelType: "ids", $modelId: "MY_ID2" })
     expect(m1.$modelId).toBe("MY_ID2")
+    expect(m1.getRefId()).toBe(m1.$modelId)
     expect(getSnapshot(m1)).toEqual({
       $modelId: "MY_ID2",
       $modelType: "ids",
@@ -36,6 +39,7 @@ test("ids", () => {
 
     const m2 = fromSnapshot<M>(getSnapshot(m1))
     expect(m2.$modelId).toBe("MY_ID2")
+    expect(m2.getRefId()).toBe(m2.$modelId)
     expect(getSnapshot(m2)).toEqual({
       $modelId: "MY_ID2",
       $modelType: "ids",
@@ -46,6 +50,7 @@ test("ids", () => {
   {
     const m1 = new M({})
     expect(m1.$modelId).toBe("id-2")
+    expect(m1.getRefId()).toBe(m1.$modelId)
     expect((m1.$ as any).$modelId).toBe("id-2")
     expect(getSnapshot(m1)).toEqual({
       $modelId: "id-2",
@@ -56,6 +61,7 @@ test("ids", () => {
       m1.$modelId = "MY_ID"
     })
     expect(m1.$modelId).toBe("MY_ID")
+    expect(m1.getRefId()).toBe(m1.$modelId)
     expect((m1.$ as any).$modelId).toBe("MY_ID")
     expect(getSnapshot(m1)).toEqual({
       $modelId: "MY_ID",

--- a/packages/site/package.json
+++ b/packages/site/package.json
@@ -11,13 +11,13 @@
   "dependencies": {
     "mobx": "^5.14.0",
     "mobx-react": "^6.1.1",
-    "react": "^16.10.1",
-    "react-dom": "^16.10.1",
+    "react": "^16.10.2",
+    "react-dom": "^16.10.2",
     "remotedev": "^0.2.9",
     "uuid": "^3.3.2"
   },
   "devDependencies": {
-    "@types/react": "^16.9.4",
+    "@types/react": "^16.9.5",
     "@types/react-dom": "^16.9.1",
     "@types/uuid": "^3.4.5",
     "docz": "^1.3.1",

--- a/packages/site/src/actionMiddlewares/onActionMiddleware.mdx
+++ b/packages/site/src/actionMiddlewares/onActionMiddleware.mdx
@@ -17,7 +17,7 @@ There are two kinds of possible listeners, `onStart` and `onFinish` listeners.
 - `onStart` listeners are called before the action executes and allow cancellation by returning a new return value (which might be a return or a throw).
 - `onFinish` listeners are called after the action executes, have access to the action's actual return value and allow overriding by returning a new return value (which might be a return or a throw).
 
-The actions passed as arguments to the listener are not in a serializable format. If you want to ensure that the actual action calls are serializable you should use either `serializeActionCallArgument` over the arguments or `serializeActionCall` over the whole action before sending the action call over the wire / storing them and likewise use `deserializeActionCallArgument` / `deserializeActionCall` before applying it (as seen in the [Client/Server Example](../examples/clientServer)).
+The actions passed as arguments to the listener are not in a serializable format. If you want to ensure that the actual action calls are serializable you should use `serializeActionCall` over the whole action before sending the action call over the wire / storing them and likewise use `applySerializedActionAndTrackNewModelIds` (for the server) / `applySerializedActionAndSyncNewModelIds` (for the clients) before applying it (as seen in the [Client/Server Example](../examples/clientServer)).
 
 It will return a disposer, which only needs to be called if you plan to early dispose of the middleware.
 
@@ -25,7 +25,7 @@ It will return a disposer, which only needs to be called if you plan to early di
 const disposer = onActionMiddleware(myTodoList, {
   onStart(actionCall, actionContext) {
     // we could serialize the action call and do something with it
-    const serializableActionCall = serializeActionCall(getRoot(actionContext.target), actionCall)
+    const serializableActionCall = serializeActionCall(myTodoList, actionCall)
 
     // optionally cancel the action by throwing something
     return {

--- a/packages/site/src/examples/clientServer/appInstance.tsx
+++ b/packages/site/src/examples/clientServer/appInstance.tsx
@@ -1,11 +1,10 @@
 import {
-  ActionCall,
   ActionTrackingResult,
-  applyAction,
-  deserializeActionCall,
+  applySerializedActionAndSyncNewModelIds,
   fromSnapshot,
   onActionMiddleware,
   serializeActionCall,
+  SerializedActionCallWithModelIdOverrides,
 } from "mobx-keystone"
 import { observer } from "mobx-react"
 import React, { useState } from "react"
@@ -22,13 +21,14 @@ function initAppInstance() {
   const rootStore = fromSnapshot<TodoList>(rootStoreSnapshot)
 
   let serverAction = false
-  const runServerActionLocally = (actionCall: ActionCall) => {
-    const deserializedActionCall = deserializeActionCall(actionCall, rootStore)
-
+  const runServerActionLocally = (actionCall: SerializedActionCallWithModelIdOverrides) => {
     let wasServerAction = serverAction
     serverAction = true
     try {
-      applyAction(rootStore, deserializedActionCall)
+      // in clients we use the sync new model ids version to make sure that
+      // any model ids that were generated in the server side end up being
+      // the same in the client side
+      applySerializedActionAndSyncNewModelIds(rootStore, actionCall)
     } finally {
       serverAction = wasServerAction
     }

--- a/packages/site/src/examples/clientServer/server.ts
+++ b/packages/site/src/examples/clientServer/server.ts
@@ -1,7 +1,12 @@
-import { ActionCall, applyAction, deserializeActionCall, getSnapshot } from "mobx-keystone"
+import {
+  applySerializedActionAndTrackNewModelIds,
+  getSnapshot,
+  SerializedActionCall,
+  SerializedActionCallWithModelIdOverrides,
+} from "mobx-keystone"
 import { createRootStore } from "../todoList/store"
 
-type MsgListener = (actionCall: ActionCall) => void
+type MsgListener = (actionCall: SerializedActionCallWithModelIdOverrides) => void
 
 class Server {
   private serverRootStore = createRootStore()
@@ -11,30 +16,34 @@ class Server {
     return getSnapshot(this.serverRootStore)
   }
 
-  onMessage(listener: (actionCall: ActionCall) => void) {
+  onMessage(listener: (actionCall: SerializedActionCallWithModelIdOverrides) => void) {
     this.msgListeners.push(listener)
   }
 
-  sendMessage(actionCall: ActionCall) {
+  sendMessage(actionCall: SerializedActionCall) {
     // the timeouts are just to simulate network delays
     setTimeout(() => {
       // apply the action over the server root store
       // sometimes applying actions might fail (for example on invalid operations
       // such as when one client asks to delete a model from an array and other asks to mutate it)
       // so we try / catch it
-      let applyActionSucceeded = false
+      let serializedActionCallToReplicate: SerializedActionCallWithModelIdOverrides | undefined
       try {
-        const deserializedActionCall = deserializeActionCall(actionCall, this.serverRootStore)
-        applyAction(this.serverRootStore, deserializedActionCall)
-        applyActionSucceeded = true
+        // we use this to apply the action on the server side and keep track of new model IDs being
+        // generated, so the clients will have the chance to keep those in sync
+        const applyActionResult = applySerializedActionAndTrackNewModelIds(
+          this.serverRootStore,
+          actionCall
+        )
+        serializedActionCallToReplicate = applyActionResult.serializedActionCall
       } catch (err) {
         console.error("error applying action to server:", err)
       }
 
-      if (applyActionSucceeded) {
+      if (serializedActionCallToReplicate) {
         setTimeout(() => {
-          // and distribute message
-          this.msgListeners.forEach(listener => listener(actionCall))
+          // and distribute message, which includes new model IDs to keep them in sync
+          this.msgListeners.forEach(listener => listener(serializedActionCallToReplicate!))
         }, 500)
       }
     }, 500)

--- a/packages/site/src/references.mdx
+++ b/packages/site/src/references.mdx
@@ -31,7 +31,7 @@ const myRef = rootRef<T>("some unique model type id", {
 })
 ```
 
-Note that if the reference points to a model and that model class specifies a method named `getRefId()` then `getId` can be omitted.
+Note that if the reference points to a model and that model class specifies a custom method named `getRefId()` (or you want to use `$modelId` as reference ID, which is the default implementation of `getRefId()`) then `getId` can be omitted.
 
 Reference objects can then be created using `myRef(target: T)` or `myRef(id: string)` and offer the following properties:
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -2356,10 +2356,10 @@
   dependencies:
     "@types/react" "*"
 
-"@types/react@*", "@types/react@^16.9.4":
-  version "16.9.4"
-  resolved "https://registry.yarnpkg.com/@types/react/-/react-16.9.4.tgz#de8cf5e5e2838659fb78fa93181078469eeb19fc"
-  integrity sha512-ItGNmJvQ0IvWt8rbk5PLdpdQhvBVxAaXI9hDlx7UMd8Ie1iMIuwMNiKeTfmVN517CdplpyXvA22X4zm4jGGZnw==
+"@types/react@*", "@types/react@^16.9.5":
+  version "16.9.5"
+  resolved "https://registry.yarnpkg.com/@types/react/-/react-16.9.5.tgz#079dabd918b19b32118c25fd00a786bb6d0d5e51"
+  integrity sha512-jQ12VMiFOWYlp+j66dghOWcmDDwhca0bnlcTxS4Qz/fh5gi6wpaZDthPEu/Gc/YlAuO87vbiUXL8qKstFvuOaA==
   dependencies:
     "@types/prop-types" "*"
     csstype "^2.2.0"
@@ -11995,15 +11995,15 @@ react-docgen@^4.1.1:
     node-dir "^0.1.10"
     recast "^0.17.3"
 
-react-dom@^16.10.1, react-dom@^16.8.6:
-  version "16.10.1"
-  resolved "https://registry.yarnpkg.com/react-dom/-/react-dom-16.10.1.tgz#479a6511ba34a429273c213cbc2a9ac4d296dac1"
-  integrity sha512-SmM4ZW0uug0rn95U8uqr52I7UdNf6wdGLeXDmNLfg3y5q5H9eAbdjF5ubQc3bjDyRrvdAB2IKG7X0GzSpnn5Mg==
+react-dom@^16.10.2, react-dom@^16.8.6:
+  version "16.10.2"
+  resolved "https://registry.yarnpkg.com/react-dom/-/react-dom-16.10.2.tgz#4840bce5409176bc3a1f2bd8cb10b92db452fda6"
+  integrity sha512-kWGDcH3ItJK4+6Pl9DZB16BXYAZyrYQItU4OMy0jAkv5aNqc+mAKb4TpFtAteI6TJZu+9ZlNhaeNQSVQDHJzkw==
   dependencies:
     loose-envify "^1.1.0"
     object-assign "^4.1.1"
     prop-types "^15.6.2"
-    scheduler "^0.16.1"
+    scheduler "^0.16.2"
 
 react-error-overlay@^6.0.1:
   version "6.0.1"
@@ -12066,10 +12066,10 @@ react-simple-code-editor@^0.9.0:
   resolved "https://registry.yarnpkg.com/react-simple-code-editor/-/react-simple-code-editor-0.9.14.tgz#5b8fdc36a975cbf02fdafa2597398d8e212afebc"
   integrity sha512-doNaIIt4w7QIiB6ysWHMtYL4M3xOGPvZJH8vGq3W/hGk43pn25RDA27IS8GkbfhA1eLX72CWDhuC7KmDKax13g==
 
-react@^16.10.1, react@^16.8.6:
-  version "16.10.1"
-  resolved "https://registry.yarnpkg.com/react/-/react-16.10.1.tgz#967c1e71a2767dfa699e6ba702a00483e3b0573f"
-  integrity sha512-2bisHwMhxQ3XQz4LiJJwG3360pY965pTl/MRrZYxIBKVj4fOHoDs5aZAkYXGxDRO1Li+SyjTAilQEbOmtQJHzA==
+react@^16.10.2, react@^16.8.6:
+  version "16.10.2"
+  resolved "https://registry.yarnpkg.com/react/-/react-16.10.2.tgz#a5ede5cdd5c536f745173c8da47bda64797a4cf0"
+  integrity sha512-MFVIq0DpIhrHFyqLU0S3+4dIcBhhOvBE8bJ/5kHPVOVaGdo0KuiQzpcjCPsf585WvhypqtrMILyoE2th6dT+Lw==
   dependencies:
     loose-envify "^1.1.0"
     object-assign "^4.1.1"
@@ -12975,10 +12975,10 @@ sc-formatter@^3.0.1:
   resolved "https://registry.yarnpkg.com/sc-formatter/-/sc-formatter-3.0.2.tgz#9abdb14e71873ce7157714d3002477bbdb33c4e6"
   integrity sha512-9PbqYBpCq+OoEeRQ3QfFIGE6qwjjBcd2j7UjgDlhnZbtSnuGgHdcRklPKYGuYFH82V/dwd+AIpu8XvA1zqTd+A==
 
-scheduler@^0.16.1:
-  version "0.16.1"
-  resolved "https://registry.yarnpkg.com/scheduler/-/scheduler-0.16.1.tgz#a6fb6ddec12dc2119176e6eb54ecfe69a9eba8df"
-  integrity sha512-MIuie7SgsqMYOdCXVFZa8SKoNorJZUWHW8dPgto7uEHn1lX3fg2Gu0TzgK8USj76uxV7vB5eRMnZs/cdEHg+cg==
+scheduler@^0.16.2:
+  version "0.16.2"
+  resolved "https://registry.yarnpkg.com/scheduler/-/scheduler-0.16.2.tgz#f74cd9d33eff6fc554edfb79864868e4819132c1"
+  integrity sha512-BqYVWqwz6s1wZMhjFvLfVR5WXP7ZY32M/wYPo04CcuPM7XZEbV2TBNW7Z0UkguPTl0dWMA59VbNXxK6q+pHItg==
   dependencies:
     loose-envify "^1.1.0"
     object-assign "^4.1.1"


### PR DESCRIPTION
- Added `applySerializedActionAndTrackNewModelIds` and `applySerializedActionAndSyncNewModelIds`. Prefer those over `deserializeActionCall` plus `applyAction` when applying serialized (over the wire) actions in order to avoid \$modelId desynchronization.
- Added a default implementation of `getRefId()` which returns `$modelId`.

*This only affects people using action serialization+replication between different machines. If just using actions locally `applyAction` is still very much ok*

Basically after adding model ids + checks on apply action to make sure the path ids are applied over the proper I realized that:
- if models get created inside an action being run on the server, then these models would get ids A, B, C
- if action then gets replicated on client, models get created as well, but they would get ids 1, 2, 3
- the model ids between server and client would be out of sync

This PR offers two new APIs to apply *serialized* actions:
- `applySerializedActionAndTrackNewModelIds` is meant to be used on the server and will track any new model IDs that get added to the root store while the action is being run
- `applySerializedActionAndSyncNewModelIds` is meant to be used on the clients and will override / sync previously tracked model IDs on the server to ensure they are in sync