### PR TITLE
Fixed an issue with back-references and `onResolvedValueChange` not working when references were being restored from a snapshot.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Change Log
 
+## 0.25.2
+
+- Fixed an issue with back-references and `onResolvedValueChange` not working when references were being restored from a snapshot.
+
 ## 0.25.1
 
 - Small optimization for `applySerializedActionAndTrackNewModelIds` so it doesn't traverse frozen values.

--- a/packages/lib/package.json
+++ b/packages/lib/package.json
@@ -1,6 +1,6 @@
 {
   "name": "mobx-keystone",
-  "version": "0.25.1",
+  "version": "0.25.2",
   "description": "A MobX powered state management solution based on data trees with first class support for Typescript, snapshots, patches and much more",
   "keywords": [
     "mobx",


### PR DESCRIPTION
Fixes #56 