### PR TITLE
better abstract model class support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Change Log
 
+## 0.28.0
+
+- [BREAKING CHANGE] If you want to use `ExtendsModel` over an abstract class now it must be done like `ExtendsModel(abstractModelClass(SomeAbstractClass), { ... })`.
+
 ## 0.27.0
 
 - Added `getTypeInfo(type: AnyType): TypeInfo` to get runtime reflection info about types.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## 0.28.0
 
-- [BREAKING CHANGE] If you want to use `ExtendsModel` over an abstract class now it must be done like `ExtendsModel(abstractModelClass(SomeAbstractClass), { ... })`.
+- [BREAKING CHANGE] If you want to use `ExtendedModel` over an abstract class now it must be done like `ExtendedModel(abstractModelClass(SomeAbstractClass), { ... })`.
 
 ## 0.27.0
 
@@ -161,7 +161,7 @@
 
 ## 0.13.1
 
-- Fixed an issue with ExtendsModel when user library was compiled using ES6 classes.
+- Fixed an issue with ExtendedModel when user library was compiled using ES6 classes.
 
 ## 0.13.0
 
@@ -185,7 +185,7 @@
 
 ## 0.12.0
 
-- Added `ExtendsModel` and a doc section about subclassing.
+- Added `ExtendedModel` and a doc section about subclassing.
 
 ## 0.11.4
 

--- a/packages/lib/package.json
+++ b/packages/lib/package.json
@@ -1,6 +1,6 @@
 {
   "name": "mobx-keystone",
-  "version": "0.27.0",
+  "version": "0.28.0",
   "description": "A MobX powered state management solution based on data trees with first class support for Typescript, snapshots, patches and much more",
   "keywords": [
     "mobx",

--- a/packages/lib/src/model/BaseModel.ts
+++ b/packages/lib/src/model/BaseModel.ts
@@ -151,16 +151,30 @@ export const baseModelPropNames = new Set<keyof AnyModel>([
 export type AnyModel = BaseModel<any, any>
 
 /**
- * Type of a model class.
+ * Extracts the instance type of a model class.
  */
 export type ModelClass<M extends AnyModel> = new (
   initialData: ModelCreationData<M> & { [modelIdKey]?: string }
 ) => M
 
+export declare const abstractModelClassSymbol: unique symbol
+
 /**
- * Type of an abstract model class.
+ * Extracts the instance type of a class marked with `abstractModelClass`.
  */
-export type AbstractModelClass<T extends AnyModel> = Function & { prototype: T }
+export type AbstractModelClass<T extends AnyModel> = { [abstractModelClassSymbol]: T }
+
+/**
+ * Tricks Typescript into accepting abstract classes as a parameter for `ExtendsModel`.
+ * Does nothing in runtime.
+ *
+ * @typeparam T Abstract model class type.
+ * @param type Abstract model class.
+ * @returns
+ */
+export function abstractModelClass<T>(type: T): T & { [abstractModelClassSymbol]: T } {
+  return type as any
+}
 
 /**
  * The data type of a model.

--- a/packages/lib/src/model/BaseModel.ts
+++ b/packages/lib/src/model/BaseModel.ts
@@ -165,7 +165,7 @@ export declare const abstractModelClassSymbol: unique symbol
 export type AbstractModelClass<T extends AnyModel> = { [abstractModelClassSymbol]: T }
 
 /**
- * Tricks Typescript into accepting abstract classes as a parameter for `ExtendsModel`.
+ * Tricks Typescript into accepting abstract classes as a parameter for `ExtendedModel`.
  * Does nothing in runtime.
  *
  * @typeparam T Abstract model class type.

--- a/packages/lib/test/model/subclassing.test.ts
+++ b/packages/lib/test/model/subclassing.test.ts
@@ -1,7 +1,7 @@
 import { computed } from "mobx"
 import { assert, _ } from "spec.ts"
 import {
-  AbstractModelClass,
+  abstractModelClass,
   ExtendedModel,
   fromSnapshot,
   getSnapshot,
@@ -350,7 +350,7 @@ test("abstract-ish model classes without factory", () => {
   abstract class StringA extends A<string> {}
 
   @model("B-abstractish")
-  class B extends ExtendedModel(StringA, {
+  class B extends ExtendedModel(abstractModelClass(StringA), {
     value: prop<string>(),
   }) {
     public validate(value: string): string | undefined {
@@ -392,14 +392,13 @@ test("abstract model classes with factory", () => {
       }
     }
 
-    // we need this weird trick to make value get the right type in this case
-    return A as AbstractModelClass<A>
+    return A
   }
 
   const StringA = createA<string>()
 
   @model("B-abstract-factory")
-  class B extends ExtendedModel(StringA, {}) {
+  class B extends ExtendedModel(abstractModelClass(StringA), {}) {
     public validate(value: string): string | undefined {
       return value.length < 3 ? "too short" : undefined
     }
@@ -441,7 +440,7 @@ test("abstract model classes without factory", () => {
   abstract class StringA extends A<string> {}
 
   @model("B-abstract")
-  class B extends ExtendedModel(StringA, {
+  class B extends ExtendedModel(abstractModelClass(StringA), {
     value: prop<string>(),
   }) {
     public validate(value: string): string | undefined {
@@ -475,7 +474,7 @@ test("issue #18", () => {
   }
 
   @model("B#18")
-  class B extends ExtendedModel(A, { value: prop<number>() }) {}
+  class B extends ExtendedModel(abstractModelClass(A), { value: prop<number>() }) {}
 
   // Error: data changes must be performed inside model actions
   const b = new B({ value: 1 }) // Instantiating the class inside `runUnprotected` works.
@@ -493,7 +492,7 @@ test("issue #2", () => {
     }
 
     // sadly we are forced to use the cast to keep the generic of the type
-    return class extends ExtendedModel(ExtendedBaseT as AbstractModelClass<ExtendedBaseT>, {
+    return class extends ExtendedModel(abstractModelClass(ExtendedBaseT), {
       value: prop<T>(() => defaultValue),
     }) {}
   }

--- a/packages/site/src/models.mdx
+++ b/packages/site/src/models.mdx
@@ -319,7 +319,7 @@ If you want to also make `BasePoint` a proper usable model you can use this tric
 
 ```ts
 @model("MyApp/Point")
-class Point extends ExtendsModel(BasePoint, {}) {}
+class Point extends ExtendedModel(BasePoint, {}) {}
 ```
 
 Also remember that if your base model has `onInit` / `onAttachedToRootStore` and you redeclare them in your extended model you will need to call `super.onInit(...)` / `super.onAttachedToRootStore(...)` in the extended model.
@@ -327,5 +327,5 @@ Also remember that if your base model has `onInit` / `onAttachedToRootStore` and
 If you are using Typescript and want to extend an abstract class you will need to use `abstractModelClass` like this:
 
 ```ts
-class X extends ExtendsModel(abstractModelClass(SomeAbstractClass), { ... }) { ... }
+class X extends ExtendedModel(abstractModelClass(SomeAbstractClass), { ... }) { ... }
 ```

--- a/packages/site/src/models.mdx
+++ b/packages/site/src/models.mdx
@@ -323,3 +323,9 @@ class Point extends ExtendsModel(BasePoint, {}) {}
 ```
 
 Also remember that if your base model has `onInit` / `onAttachedToRootStore` and you redeclare them in your extended model you will need to call `super.onInit(...)` / `super.onAttachedToRootStore(...)` in the extended model.
+
+If you are using Typescript and want to extend an abstract class you will need to use `abstractModelClass` like this:
+
+```ts
+class X extends ExtendsModel(abstractModelClass(SomeAbstractClass), { ... }) { ... }
+```

--- a/packages/site/src/models.mdx
+++ b/packages/site/src/models.mdx
@@ -324,7 +324,7 @@ class Point extends ExtendedModel(BasePoint, {}) {}
 
 Also remember that if your base model has `onInit` / `onAttachedToRootStore` and you redeclare them in your extended model you will need to call `super.onInit(...)` / `super.onAttachedToRootStore(...)` in the extended model.
 
-If you are using Typescript and want to extend an abstract class you will need to use `abstractModelClass` like this:
+Since Typescript sometimes is not able to infer abstract classes generics under some circumstances then if you want to extend an abstract class you will need to use `abstractModelClass` like this:
 
 ```ts
 class X extends ExtendedModel(abstractModelClass(SomeAbstractClass), { ... }) { ... }


### PR DESCRIPTION
- [BREAKING CHANGE] If you want to use `ExtendsModel` over an abstract class now it must be done like `ExtendsModel(abstractModelClass(SomeAbstractClass), { ... })`.
