### PR TITLE
Require Typescript 3.7 to support new assertion syntax

### DIFF
--- a/packages/lib/package.json
+++ b/packages/lib/package.json
@@ -53,7 +53,7 @@
     "ts-node": "^8.4.1",
     "tsdx": "^0.11.0",
     "typedoc": "^0.15.0",
-    "typescript": "^3.6.4"
+    "typescript": "^3.7.3"
   },
   "dependencies": {
     "ts-toolbelt": "^4.8.8",

--- a/yarn.lock
+++ b/yarn.lock
@@ -17895,7 +17895,7 @@ typescript@3.5.3:
   resolved "https://registry.yarnpkg.com/typescript/-/typescript-3.5.3.tgz#c830f657f93f1ea846819e929092f5fe5983e977"
   integrity sha512-ACzBtm/PhXBDId6a6sDJfroT2pOWt/oOnk4/dElG5G33ZL776N3Y6/6bKZJBFpd+b05F3Ct9qDjMeJmRWtE2/g==
 
-typescript@3.7.x, typescript@^3.6.3, typescript@^3.6.4:
+typescript@3.7.x, typescript@^3.6.3, typescript@^3.6.4, typescript@^3.7.3:
   version "3.7.3"
   resolved "https://registry.yarnpkg.com/typescript/-/typescript-3.7.3.tgz#b36840668a16458a7025b9eabfad11b66ab85c69"
   integrity sha512-Mcr/Qk7hXqFBXMN7p7Lusj1ktCBydylfQM/FZCk5glCNQJrCUKPkMHdo9R0MTFWsC/4kPFvDS0fDPvukfCkFsw==


### PR DESCRIPTION
In 575bac559f3065a6fd86cabf8f2b153649bb1e7e the new assertion syntax introduced in TS 3.7 is used, but `packages/lib/package.json` still requires only [`^3.6.4`](https://github.com/xaviergonz/mobx-keystone/blob/376aa2df28b3272a0652a6ba545e70066f279e67/packages/lib/package.json#L56). The error hasn't surfaced because TS 3.7 is locked in `yarn.lock`.