### PR TITLE
`onAttachedToRootStore` and its disposer will be called right after a change is made rather than after a whole action is finished (restores behaviour of version <= 0.28.1).

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Change Log
 
+## 0.28.4
+
+- `onAttachedToRootStore` and its disposer will be called right after a change is made rather than after a whole action is finished (restores behaviour of version <= 0.28.1).
+
 ## 0.28.3
 
 - Improve a bit the atomicity of `modelAction` / `runUnprotected`.

--- a/packages/lib/package.json
+++ b/packages/lib/package.json
@@ -1,6 +1,6 @@
 {
   "name": "mobx-keystone",
-  "version": "0.28.3",
+  "version": "0.28.4",
   "description": "A MobX powered state management solution based on data trees with first class support for Typescript, snapshots, patches and much more",
   "keywords": [
     "mobx",

--- a/packages/lib/src/action/pendingActions.ts
+++ b/packages/lib/src/action/pendingActions.ts
@@ -1,23 +1,17 @@
-import { canWrite } from "./protection"
-
 const pendingActions: Array<() => void> = []
 
 /**
  * @ignore
  */
-export function enqueueOrRunPendingAction(action: () => void): void {
-  if (!canWrite()) {
-    action()
-  } else {
-    pendingActions.push(action)
-  }
+export function enqueuePendingAction(action: () => void): void {
+  pendingActions.push(action)
 }
 
 /**
  * @ignore
  */
 export function runPendingActions(): void {
-  while (pendingActions.length > 0 && !canWrite()) {
+  while (pendingActions.length > 0) {
     const pendingAction = pendingActions.shift()!
     pendingAction()
   }

--- a/packages/lib/src/action/protection.ts
+++ b/packages/lib/src/action/protection.ts
@@ -1,7 +1,6 @@
 import { runInAction } from "mobx"
 import { failure } from "../utils"
 import { getCurrentActionContext } from "./context"
-import { runPendingActions } from "./pendingActions"
 
 /**
  * @ignore
@@ -69,9 +68,6 @@ export function runUnprotected<T>(arg1: any, arg2?: any): T {
       return fn()
     } finally {
       actionProtection = oldActionProtection
-
-      // execute pending actions (attach/detach from root store events)
-      runPendingActions()
     }
   }
 

--- a/packages/lib/src/action/wrapInAction.ts
+++ b/packages/lib/src/action/wrapInAction.ts
@@ -12,7 +12,6 @@ import {
 import { getActionMiddlewares } from "./middleware"
 import { isModelAction } from "./modelAction"
 import { FlowFinisher } from "./modelFlow"
-import { runPendingActions } from "./pendingActions"
 
 /**
  * @ignore
@@ -91,9 +90,6 @@ export function wrapInAction<T extends Function>(
       }
     } finally {
       setCurrentActionContext(context.parentContext)
-
-      // execute pending actions (attach/detach from root store events)
-      runPendingActions()
     }
   })
   ;(wrappedAction as any)[modelActionSymbol] = true

--- a/packages/lib/src/parent/setParent.ts
+++ b/packages/lib/src/parent/setParent.ts
@@ -1,4 +1,5 @@
 import { action } from "mobx"
+import { enqueuePendingAction } from "../action/pendingActions"
 import { BaseModel } from "../model/BaseModel"
 import { attachToRootStore, detachFromRootStore } from "../rootStore/attachDetach"
 import { isRootStore } from "../rootStore/rootStore"
@@ -108,10 +109,14 @@ export const setParent = action(
       // invoke model root store events
       if (oldRootStore !== newRootStore) {
         if (oldRootStore) {
-          detachFromRootStore(value)
+          enqueuePendingAction(() => {
+            detachFromRootStore(value)
+          })
         }
         if (newRootStore) {
-          attachToRootStore(newRootStore, value)
+          enqueuePendingAction(() => {
+            attachToRootStore(newRootStore, value)
+          })
         }
       }
     } else {

--- a/packages/lib/src/rootStore/attachDetach.ts
+++ b/packages/lib/src/rootStore/attachDetach.ts
@@ -1,6 +1,5 @@
 import { ActionContextActionType } from "../action/context"
 import { HookAction } from "../action/hookActions"
-import { enqueueOrRunPendingAction } from "../action/pendingActions"
 import { wrapInAction, wrapModelMethodInActionIfNeeded } from "../action/wrapInAction"
 import { BaseModel } from "../model/BaseModel"
 import { walkTree, WalkTreeMode } from "../parent/walkTree"
@@ -21,12 +20,10 @@ export function attachToRootStore(rootStore: object, child: object): void {
           HookAction.OnAttachedToRootStore
         )
 
-        enqueueOrRunPendingAction(() => {
-          const disposer = ch.onAttachedToRootStore!(rootStore)
-          if (disposer) {
-            onAttachedDisposers.set(ch, disposer)
-          }
-        })
+        const disposer = ch.onAttachedToRootStore!(rootStore)
+        if (disposer) {
+          onAttachedDisposers.set(ch, disposer)
+        }
       }
     },
     WalkTreeMode.ParentFirst
@@ -50,9 +47,7 @@ export function detachFromRootStore(child: object): void {
         )
         onAttachedDisposers.delete(ch)
 
-        enqueueOrRunPendingAction(() => {
-          disposerAction.call(ch)
-        })
+        disposerAction.call(ch)
       }
     },
     WalkTreeMode.ChildrenFirst

--- a/packages/lib/src/tweaker/tweakArray.ts
+++ b/packages/lib/src/tweaker/tweakArray.ts
@@ -10,6 +10,7 @@ import {
   observe,
   set,
 } from "mobx"
+import { runPendingActions } from "../action/pendingActions"
 import { assertCanWrite } from "../action/protection"
 import { ParentPath } from "../parent/path"
 import { setParent } from "../parent/setParent"
@@ -213,6 +214,9 @@ function arrayDidChange(change: IArrayChange | IArraySplice) {
       }
       break
   }
+
+  // execute pending actions (attach/detach from root store events)
+  runPendingActions()
 
   runTypeCheckingAfterChange(arr, patchRecorder)
 

--- a/packages/lib/src/tweaker/tweakPlainObject.ts
+++ b/packages/lib/src/tweaker/tweakPlainObject.ts
@@ -7,6 +7,7 @@ import {
   observe,
   set,
 } from "mobx"
+import { runPendingActions } from "../action/pendingActions"
 import { assertCanWrite } from "../action/protection"
 import { modelTypeKey } from "../model/metadata"
 import { dataToModelNode } from "../parent/core"
@@ -179,6 +180,9 @@ function objectDidChange(change: IObjectDidChange): void {
       }
       break
   }
+
+  // execute pending actions (attach/detach from root store events)
+  runPendingActions()
 
   runTypeCheckingAfterChange(obj, patchRecorder)
 

--- a/packages/lib/test/snapshot/getSnapshot.test.ts
+++ b/packages/lib/test/snapshot/getSnapshot.test.ts
@@ -178,7 +178,7 @@ test("reactive snapshots", () => {
 })
 
 test("issue #74 - with action", () => {
-  @model("#74/A")
+  @model("#74-1/A")
   class A extends Model({
     value: prop<number>(),
   }) {
@@ -191,20 +191,20 @@ test("issue #74 - with action", () => {
     }
   }
 
-  @model("#74/Store")
+  @model("#74-1/Store")
   class Store extends Model({
     all: prop<A[]>(() => []),
   }) {
     @modelAction
     public add(a: A): void {
       this.all.push(a)
-      expect(a.value).toBe(0) // will be changed after the action is finished
+      expect(a.value).toBe(1)
     }
 
     @modelAction
     public remove(index: number): void {
       const removed = this.all.splice(index, 1)
-      expect(removed[0].value).toBe(1) // will be changed after the action is finished
+      expect(removed[0].value).toBe(2)
     }
   }
 
@@ -223,7 +223,7 @@ test("issue #74 - with action", () => {
 })
 
 test("issue #74 - with runUnprotected", () => {
-  @model("#74/A")
+  @model("#74-2/A")
   class A extends Model({
     value: prop<number>(),
   }) {
@@ -236,7 +236,7 @@ test("issue #74 - with runUnprotected", () => {
     }
   }
 
-  @model("#74/Store")
+  @model("#74-2/Store")
   class Store extends Model({
     all: prop<A[]>(() => []),
   }) {}
@@ -246,7 +246,7 @@ test("issue #74 - with runUnprotected", () => {
 
   runUnprotected(() => {
     store.all.push(newA)
-    expect(newA.value).toBe(0) // will be changed after the action is finished
+    expect(newA.value).toBe(1)
   })
 
   expect(getSnapshot(store).all).toHaveLength(store.all.length)
@@ -255,7 +255,7 @@ test("issue #74 - with runUnprotected", () => {
 
   runUnprotected(() => {
     const removed = store.all.splice(0, 1)
-    expect(removed[0].value).toBe(1) // will be changed after the action is finished
+    expect(removed[0].value).toBe(2)
   })
 
   expect(getSnapshot(store).all).toHaveLength(store.all.length)


### PR DESCRIPTION
`onAttachedToRootStore` and its disposer will be called right after a change is made rather than after a whole action is finished (restores behaviour of version <= 0.28.1).