### PR TITLE
Sandbox function

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 # Change Log
 
+- Added `sandbox` to create a sandbox copy of the state for testing "what-if" scenarios; changes can be either committed to the original state or rejected (see Sandboxes section in the docs).
+
 ## 0.31.0
 
 - Added `deepEquals` to deeply check for equality standard values, observable values, and tree nodes.

--- a/packages/lib/src/actionMiddlewares/readonlyMiddleware.ts
+++ b/packages/lib/src/actionMiddlewares/readonlyMiddleware.ts
@@ -12,7 +12,7 @@ import {
  * Return type for readonly middleware.
  */
 export interface ReadonlyMiddlewareReturn {
-  allowWrite<FN extends () => R, R>(fn: FN): R
+  allowWrite<FN extends () => any>(fn: FN): ReturnType<FN>
 
   dispose: ActionMiddlewareDisposer
 }

--- a/packages/lib/src/treeUtils/index.ts
+++ b/packages/lib/src/treeUtils/index.ts
@@ -1,2 +1,3 @@
 export * from "./deepEquals"
 export * from "./draft"
+export * from "./sandbox"

--- a/packages/lib/src/treeUtils/sandbox.ts
+++ b/packages/lib/src/treeUtils/sandbox.ts
@@ -1,0 +1,197 @@
+import { reaction, runInAction } from "mobx"
+import { readonlyMiddleware, ReadonlyMiddlewareReturn } from "../actionMiddlewares"
+import { getParentToChildPath, resolvePath } from "../parent"
+import { applyPatches, onPatches, patchRecorder, PatchRecorder } from "../patch"
+import { isRootStore, registerRootStore, unregisterRootStore } from "../rootStore"
+import { clone } from "../snapshot"
+import { assertTweakedObject } from "../tweaker/core"
+import { assertIsFunction, failure } from "../utils"
+
+/**
+ * Callback function for `SandboxManager.withSandbox`.
+ */
+export type WithSandboxCallback<T extends object, R> = (
+  node: T
+) => boolean | { commit: boolean; return: R }
+
+/**
+ * Manager class returned by `sandbox` that allows you to make changes to a sandbox copy of the
+ * original subtree and apply them to the original subtree or reject them.
+ */
+export class SandboxManager {
+  /**
+   * The sandbox copy of the original subtree.
+   */
+  private readonly subtreeRootClone: object
+
+  /**
+   * The internal disposer.
+   */
+  private disposer: () => void
+
+  /**
+   * The internal `withSandbox` patch recorder. If `undefined`, no `withSandbox` call is being
+   * executed.
+   */
+  private withSandboxPatchRecorder: PatchRecorder | undefined
+
+  /**
+   * Function from `readonlyMiddleware` that will allow actions to be started inside the provided
+   * code block on a readonly node.
+   */
+  private allowWrite: ReadonlyMiddlewareReturn["allowWrite"]
+
+  /**
+   * Creates an instance of `SandboxManager`.
+   * Do not use directly, use `sandbox` instead.
+   *
+   * @param subtreeRoot Subtree root target object.
+   */
+  constructor(private readonly subtreeRoot: object) {
+    assertTweakedObject(subtreeRoot, "subtreeRoot")
+    this.subtreeRootClone = clone(subtreeRoot, { generateNewIds: false })
+
+    let wasRS = false
+    const disposeReactionRS = reaction(
+      () => isRootStore(subtreeRoot),
+      isRS => {
+        if (isRS !== wasRS) {
+          wasRS = isRS
+          if (isRS) {
+            registerRootStore(this.subtreeRootClone)
+          } else {
+            unregisterRootStore(this.subtreeRootClone)
+          }
+        }
+      },
+      { fireImmediately: true }
+    )
+
+    const disposeOnPatches = onPatches(subtreeRoot, patches => {
+      if (this.withSandboxPatchRecorder) {
+        throw failure("original subtree must not change while 'withSandbox' executes")
+      }
+      this.allowWrite(() => {
+        applyPatches(this.subtreeRootClone, patches)
+      })
+    })
+
+    const { allowWrite, dispose: disposeReadonlyMW } = readonlyMiddleware(this.subtreeRootClone)
+    this.allowWrite = allowWrite
+
+    this.disposer = () => {
+      disposeReactionRS()
+      disposeOnPatches()
+      disposeReadonlyMW()
+      if (isRootStore(this.subtreeRootClone)) {
+        unregisterRootStore(this.subtreeRootClone)
+      }
+      this.disposer = () => {}
+    }
+  }
+
+  /**
+   * Executes `fn` with a sandbox copy of `node`. The changes made to the sandbox in `fn` can be
+   * accepted, i.e. applied to the original subtree, or rejected.
+   *
+   * @typeparam T Object type.
+   * @typeparam R Return type.
+   * @param node Object for which to obtain a sandbox copy.
+   * @param fn Function that is called with a sandbox copy of `node`. Any changes made to the
+   * sandbox are applied to the original subtree when `fn` returns `true` or
+   * `{ commit: true, ... }`. When `fn` returns `false` or `{ commit: false, ... }` the changes made
+   * to the sandbox are rejected.
+   * @returns Value of type `R` when `fn` returns an object of type `{ commit: boolean; return: R }`
+   * or `void` when `fn` returns a boolean.
+   */
+  withSandbox<T extends object, R = void>(node: T, fn: WithSandboxCallback<T, R>): R {
+    assertIsFunction(fn, "fn")
+
+    const { sandboxNode, applyRecorderChanges } = this.prepareSandboxChanges(node)
+
+    let commit = false
+    try {
+      const returnValue = this.allowWrite(() => fn(sandboxNode))
+      if (typeof returnValue === "boolean") {
+        commit = returnValue
+        return undefined as any
+      } else {
+        commit = returnValue.commit
+        return returnValue.return
+      }
+    } finally {
+      applyRecorderChanges(commit)
+    }
+  }
+
+  /**
+   * Disposes of the sandbox.
+   */
+  dispose(): void {
+    this.disposer()
+  }
+
+  private prepareSandboxChanges<T extends object>(
+    node: T
+  ): { sandboxNode: T; applyRecorderChanges: (commit: boolean) => void } {
+    assertTweakedObject(node, "node")
+
+    const isNestedWithSandboxCall = !!this.withSandboxPatchRecorder
+
+    const path = getParentToChildPath(
+      isNestedWithSandboxCall ? this.subtreeRootClone : this.subtreeRoot,
+      node
+    )
+    if (!path) {
+      throw failure(`node is not a child of subtreeRoot${isNestedWithSandboxCall ? "Clone" : ""}`)
+    }
+
+    const sandboxNode = resolvePath<T>(this.subtreeRootClone, path).value
+    if (!sandboxNode) {
+      throw failure("path could not be resolved - sandbox may be out of sync with original tree")
+    }
+
+    if (!this.withSandboxPatchRecorder) {
+      this.withSandboxPatchRecorder = patchRecorder(this.subtreeRootClone)
+    }
+    const recorder = this.withSandboxPatchRecorder
+    const numRecorderEvents = recorder.events.length
+
+    const applyRecorderChanges = (commit: boolean): void => {
+      if (!isNestedWithSandboxCall) {
+        recorder.dispose()
+        this.withSandboxPatchRecorder = undefined
+      }
+      runInAction(() => {
+        if (commit) {
+          if (!isNestedWithSandboxCall) {
+            const len = recorder.events.length
+            for (let i = 0; i < len; i++) {
+              applyPatches(this.subtreeRoot, recorder.events[i].patches)
+            }
+          }
+        } else {
+          this.allowWrite(() => {
+            let i = recorder.events.length
+            while (i-- > numRecorderEvents) {
+              applyPatches(this.subtreeRootClone, recorder.events[i].inversePatches)
+            }
+          })
+        }
+      })
+    }
+
+    return { sandboxNode, applyRecorderChanges }
+  }
+}
+
+/**
+ * Creates a sandbox.
+ *
+ * @param subtreeRoot Subtree root target object.
+ * @returns A `SandboxManager` which allows you to manage the sandbox operations and dispose of the
+ * sandbox.
+ */
+export function sandbox(subtreeRoot: object): SandboxManager {
+  return new SandboxManager(subtreeRoot)
+}

--- a/packages/lib/test/treeUtils/sandbox.test.ts
+++ b/packages/lib/test/treeUtils/sandbox.test.ts
@@ -1,0 +1,287 @@
+import { assert, _ } from "spec.ts"
+import {
+  isRootStore,
+  model,
+  Model,
+  modelAction,
+  prop,
+  registerRootStore,
+  sandbox,
+  SandboxManager,
+  unregisterRootStore,
+} from "../../src"
+import "../commonSetup"
+import { autoDispose } from "../utils"
+
+@model("A")
+class A extends Model({
+  b: prop<B>(),
+}) {}
+
+@model("B")
+class B extends Model({
+  value: prop<number>(),
+}) {
+  @modelAction
+  setValue(value: number): void {
+    this.value = value
+  }
+}
+
+test("sandbox creates instance of SandboxManager", () => {
+  const a = new A({ b: new B({ value: 0 }) })
+  const manager = sandbox(a)
+  autoDispose(() => manager.dispose())
+  expect(manager instanceof SandboxManager).toBeTruthy()
+})
+
+test("withSandbox callback is called when node is a child of subtreeRoot", () => {
+  const a = new A({ b: new B({ value: 0 }) })
+  const manager = sandbox(a)
+  autoDispose(() => manager.dispose())
+
+  let called = false
+
+  manager.withSandbox(a, () => {
+    called = true
+    return false
+  })
+  expect(called).toBeTruthy()
+})
+
+test("withSandbox throws a failure when node is not a child of subtreeRoot", () => {
+  const a = new A({ b: new B({ value: 0 }) })
+  const manager = sandbox(a.b)
+  autoDispose(() => manager.dispose())
+
+  expect(() => {
+    manager.withSandbox(a, () => false)
+  }).toThrow("node is not a child of subtreeRoot")
+})
+
+test("sandbox copy reuses IDs from original tree", () => {
+  const a = new A({ b: new B({ value: 0 }) })
+  const manager = sandbox(a)
+  autoDispose(() => manager.dispose())
+
+  manager.withSandbox(a, node => {
+    expect(node.$modelId).toBe(a.$modelId)
+    expect(node.b.$modelId).toBe(a.b.$modelId)
+    return false
+  })
+})
+
+test("original tree must not be changed while withSandbox executes", () => {
+  const a = new A({ b: new B({ value: 0 }) })
+  const manager = sandbox(a)
+  autoDispose(() => manager.dispose())
+
+  expect(() =>
+    manager.withSandbox(a.b, () => {
+      a.b.setValue(2)
+      return false
+    })
+  ).toThrow("original subtree must not change while 'withSandbox' executes")
+})
+
+test.each<[boolean, boolean]>([
+  [false, false],
+  [true, false],
+  [false, true],
+  [true, true],
+])("withSandbox calls can be nested (%j - %j)", (commitInner, commitOuter) => {
+  const a = new A({ b: new B({ value: 0 }) })
+  const manager = sandbox(a)
+  autoDispose(() => manager.dispose())
+
+  manager.withSandbox(a.b, node1 => {
+    node1.setValue(1)
+    manager.withSandbox(node1, node2 => {
+      expect(node2.value).toBe(1)
+      node2.setValue(2)
+      return commitInner
+    })
+    expect(node1.value).toBe(commitInner ? 2 : 1)
+    return commitOuter
+  })
+
+  const expectedValue = commitOuter ? (commitInner ? 2 : 1) : 0
+
+  expect(a.b.value).toBe(expectedValue)
+  manager.withSandbox(a.b, node1 => {
+    expect(node1.value).toBe(expectedValue)
+    return false
+  })
+})
+
+test("nested withSandbox call requires sandbox node", () => {
+  const a = new A({ b: new B({ value: 0 }) })
+  const manager = sandbox(a)
+  autoDispose(() => manager.dispose())
+
+  manager.withSandbox(a.b, () => {
+    expect(() =>
+      manager.withSandbox(a.b, () => {
+        return false
+      })
+    ).toThrow("node is not a child of subtreeRootClone")
+    return false
+  })
+})
+
+test("sandbox node is a root store if original subtree root is a root store", () => {
+  const a = new A({ b: new B({ value: 0 }) })
+  autoDispose(() => {
+    if (isRootStore(a)) {
+      unregisterRootStore(a)
+    }
+  })
+  const manager = sandbox(a)
+  autoDispose(() => manager.dispose())
+
+  expect(isRootStore(a)).toBeFalsy()
+  manager.withSandbox(a, node => {
+    expect(isRootStore(node)).toBeFalsy()
+    return false
+  })
+
+  registerRootStore(a)
+
+  expect(isRootStore(a)).toBeTruthy()
+  manager.withSandbox(a, node => {
+    expect(isRootStore(node)).toBeTruthy()
+    return false
+  })
+
+  unregisterRootStore(a)
+
+  expect(isRootStore(a)).toBeFalsy()
+  manager.withSandbox(a, node => {
+    expect(isRootStore(node)).toBeFalsy()
+    return false
+  })
+})
+
+test("sandbox is patched when original tree changes", () => {
+  const a = new A({ b: new B({ value: 0 }) })
+  const manager = sandbox(a)
+  autoDispose(() => manager.dispose())
+
+  manager.withSandbox(a.b, node => {
+    expect(node.value).toBe(0)
+    return false
+  })
+
+  a.b.setValue(1)
+
+  manager.withSandbox(a.b, node => {
+    expect(node.value).toBe(1)
+    return false
+  })
+})
+
+test("changes in sandbox can be applied to original tree", () => {
+  const a = new A({ b: new B({ value: 0 }) })
+  const manager = sandbox(a)
+  autoDispose(() => manager.dispose())
+
+  manager.withSandbox(a.b, node => {
+    node.setValue(1)
+    expect(a.b.value).toBe(0)
+    expect(node.value).toBe(1)
+
+    node.setValue(2)
+    expect(a.b.value).toBe(0)
+    expect(node.value).toBe(2)
+
+    return true
+  })
+  expect(a.b.value).toBe(2)
+
+  manager.withSandbox(a.b, node => {
+    expect(node.value).toBe(2)
+    return false
+  })
+})
+
+test("changes in sandbox can be rejected", () => {
+  const a = new A({ b: new B({ value: 0 }) })
+  const manager = sandbox(a)
+  autoDispose(() => manager.dispose())
+
+  manager.withSandbox(a.b, node => {
+    node.setValue(1)
+    expect(a.b.value).toBe(0)
+    expect(node.value).toBe(1)
+
+    node.setValue(2)
+    expect(a.b.value).toBe(0)
+    expect(node.value).toBe(2)
+
+    return false
+  })
+  expect(a.b.value).toBe(0)
+
+  manager.withSandbox(a.b, node => {
+    expect(node.value).toBe(0)
+    return false
+  })
+})
+
+test("changes in sandbox are rejected when fn throws", () => {
+  const a = new A({ b: new B({ value: 0 }) })
+  const manager = sandbox(a)
+  autoDispose(() => manager.dispose())
+
+  expect(() => {
+    manager.withSandbox(a.b, node => {
+      node.setValue(1)
+      expect(a.b.value).toBe(0)
+      expect(node.value).toBe(1)
+      throw new Error()
+    })
+  }).toThrow()
+
+  expect(a.b.value).toBe(0)
+
+  manager.withSandbox(a.b, node => {
+    expect(node.value).toBe(0)
+    return false
+  })
+})
+
+test("withSandbox can return value from fn", () => {
+  const a = new A({ b: new B({ value: 0 }) })
+  const manager = sandbox(a)
+  autoDispose(() => manager.dispose())
+
+  const returnValue1 = manager.withSandbox(a.b, node => {
+    node.setValue(1)
+    return { commit: false, return: 123 }
+  })
+  assert(returnValue1, _ as number)
+  expect(returnValue1).toBe(123)
+  expect(a.b.value).toBe(0)
+
+  const returnValue2 = manager.withSandbox(a.b, node => {
+    node.setValue(1)
+    return { commit: true, return: { x: "x" } }
+  })
+  assert(returnValue2, _ as { x: string })
+  expect(returnValue2).toEqual({ x: "x" })
+  expect(a.b.value).toBe(1)
+})
+
+test("sandbox cannot be changed outside of fn", () => {
+  const a = new A({ b: new B({ value: 0 }) })
+  const manager = sandbox(a)
+  autoDispose(() => manager.dispose())
+
+  let n!: B
+  manager.withSandbox(a.b, node => {
+    n = node
+    return false
+  })
+
+  expect(() => n.setValue(1)).toThrow("tried to invoke action 'setValue' over a readonly node")
+})

--- a/packages/site/doczrc.js
+++ b/packages/site/doczrc.js
@@ -32,6 +32,7 @@ export default {
     "Runtime Type Checking",
     "Property Transforms",
     "Drafts",
+    "Sandboxes",
     "Redux Compatibility",
     { name: "Examples", menu: ["Todo List", "Client/Server"] },
   ],

--- a/packages/site/src/sandbox.mdx
+++ b/packages/site/src/sandbox.mdx
@@ -1,0 +1,208 @@
+---
+name: Sandboxes
+route: /sandboxes
+---
+
+import { FixStyle } from "./components/FixStyle.tsx"
+
+<FixStyle />
+
+# Sandboxes
+
+## Overview
+
+The sandbox utility allows you to make changes to a copy of an original subtree without actually changing the original state that drives UI rendering. Changes made in the sandbox can be committed to the original subtree or rejected. A common use case is testing of "what-if" scenarios.
+
+For example, consider this simple model:
+
+```ts
+@model("MyApp/EvenNumber")
+class EvenNumber extends Model({
+  value: prop<number>(),
+}) {
+  @computed
+  get isValid(): number {
+    return value % 2 === 0
+  }
+
+  @modelAction
+  setValue(value: number): void {
+    this.value = value
+  }
+}
+```
+
+We can create a sandbox for an instance of this model:
+
+```ts
+const num = new EvenNumber({ value: 0 })
+const numSandbox = sandbox(num)
+```
+
+The sandbox manager `numSandbox` can now be used to test assigning a new value by performing the `setValue` action on a copy of `num` and validating the result using the computed property `isValid`.
+
+```ts
+const isValid = numSandbox.withSandbox(num, numCopy => {
+  numCopy.setValue(2)
+  return { commit: false, return: numCopy.isValid }
+})
+```
+
+The callback passed to `withSandbox` supports two return types:
+
+- `boolean` - When `true` any changes made to the sandbox copy are applied to the original subtree. When `false` any changes made to the copy are rejected, i.e. rolled back.
+- `{ commit: boolean; return: R }` - The `commit` property is equivalent to the boolean return value described above. The value of the `return` property is also returned by `withSandbox`.
+
+`withSandbox` calls can be nested:
+
+```ts
+const isValid = numSandbox.withSandbox(num, numCopy1 => {
+  numCopy1.setValue(2)
+
+  const isValid1 = numCopy1.isValid
+  const isValid2 = numSandbox.withSandbox(numCopy1, numCopy2 => {
+    numCopy2.setValue(numCopy2.value * 2)
+    return { commit: false, return: numCopy2.isValid }
+  })
+
+  return { commit: false, return: isValid1 && isValid2 }
+})
+```
+
+When nesting `withSandbox` calls, the node for which the corresponding sandbox node is obtained must be a sandbox node itself, e.g.:
+
+```ts
+// good:
+numSandbox.withSandbox(num, numCopy1 => {
+  numSandbox.withSandbox(numCopy1, numCopy2 => {
+    // ...
+  })
+  // ...
+})
+
+// bad:
+numSandbox.withSandbox(num, numCopy1 => {
+  numSandbox.withSandbox(num, numCopy2 => {
+    // ...
+  })
+  // ...
+})
+```
+
+When changes made in nested `withSandbox` calls are to be committed, only the outermost `withSandbox` call commits changes to the original subtree. Changes made in any inner `withSandbox` call are either retained or rolled back depending on the commit flag. E.g.:
+
+```ts
+numSandbox.withSandbox(num, numCopy1 => {
+  // numCopy1.value => 0
+  numCopy1.setValue(1)
+  // numCopy1.value => 1
+  numSandbox.withSandbox(numCopy1, numCopy2 => {
+    // numCopy2.value => 1
+    numCopy2.setValue(2)
+    // numCopy2.value => 2
+    numSandbox.withSandbox(numCopy2, numCopy3 => {
+      // numCopy3.value => 2
+      numCopy3.setValue(3)
+      // numCopy3.value => 3
+      return true
+    })
+    // numCopy2.value => 3
+    return false
+  })
+  // numCopy1.value => 1
+  return true
+})
+// num.value => 1
+```
+
+The sandbox copy of a subtree root node tracks the [root store](../rootStores) state of the original subtree root node, i.e. when the original subtree root node is registered as a root store, its corresponding sandbox copy becomes a root store as well and vice versa.
+
+The `sandbox` function generates an instance with the following methods:
+
+- `withSandbox<T extends object, R = void>(node: T, fn: (node: T) => boolean | { commit: boolean; return: R }): R` - Executes `fn` with a sandbox copy of `node`. Any changes made to the sandbox are applied to the original subtree when `fn` returns `true` or `{ commit: true, ... }`. When `fn` returns `false` or `{ commit: false, ... }` the changes made to the sandbox are rejected. When `fn` returns an object of type `{ commit: boolean; return: R }` then `withSandbox` returns a value of type `R`.
+- `dispose()` - Disposes of the sandbox.
+
+## Examples
+
+### Store of polymorphic items
+
+Consider a store of polymorphic items which can generally co-exist in the same store, but each item type implements validation rules that determine whether the item is valid in the context of the other items currently present in the store.
+
+Let all items implement the following interface:
+
+```ts
+interface Item {
+  error: string | undefined
+}
+```
+
+Further, let the item store be a model which contains ...
+
+- an array of items currently present in the store,
+- a computed property which returns an array of errors accumulated from all items in the store,
+- a method (action) to add a new item, and
+- a method that assesses whether a new item can be added to the store without error.
+
+```ts
+const sandboxCtx = createContext<SandboxManager>()
+
+@model("MyApp/ItemStore")
+class ItemStore extends Model({
+  items: prop<Item[]>(() => []),
+}) {
+  @computed
+  get errors(): string[] {
+    return this.items.map(item => item.error).filter(error => error !== undefined) as string[]
+  }
+
+  @modelAction
+  addItem(item: Item): void {
+    this.items.push(item)
+  }
+
+  canAddItem(item: Item): boolean {
+    return !!sandboxCtx.get(this)?.withSandbox(this, node => {
+      node.addItem(item)
+      return { commit: false, return: node.errors.length === 0 }
+    })
+  }
+}
+```
+
+`canAddItem` requires access to the sandbox manager which is provided using a [context](../contexts).
+
+```ts
+const store = new ItemStore({})
+const storeSandbox = sandbox(store)
+sandboxCtx.setComputed(store, () => storeSandbox)
+```
+
+Now, consider the following item model which, in this example, may only exist once per item store:
+
+```ts
+@model("MyApp/ItemA")
+class ItemA extends Model({}) implements Item {
+  @computed
+  get error(): string | undefined {
+    return getParent<Item[]>(this)?.some(item => item !== this && item instanceof ItemA)
+      ? "only 1 instance of ItemA allowed"
+      : undefined
+  }
+}
+```
+
+When the store does not yet contain an item of type `ItemA`, `canAddItem` returns `true` when called with an instance of `ItemA` and, thus, this item can be added to the item store without error:
+
+```ts
+const item1 = new ItemA({})
+console.log(store.canAddItem(item1)) // => true
+store.addItem(item1)
+console.log(store.errors) // => []
+```
+
+However, adding a second item of type `ItemA` would incur an error:
+
+```ts
+const item2 = new ItemA({})
+console.log(store.canAddItem(item2)) // => ["only 1 instance of ItemA allowed"]
+```


### PR DESCRIPTION
In continuation of our discussion in #73, this is a first attempt at creating a middleware for managing a draft copy of a tree for efficient testing of changes that can be applied to the original tree or rejected.

In most cases, the middleware must be applied to the root of a tree, e.g. in order to support `rootRef` resolution in the draft as well. When the middleware is applied to a root store, the draft is also registered as a root store.

In order to access `withDraft` anywhere in a tree, I would provide `DraftManager` using a context.

What do you think?