### PR TITLE
Apply inverse patches in reverse order

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Change Log
 
+- Added support to `applyPatches` for applying patches in reverse order.
+- Fixed applying inverse patches in reverse order.
+
 ## 0.32.0
 
 - Added `sandbox` to create a sandbox copy of the state for testing "what-if" scenarios; changes can be either committed to the original state or rejected (see Sandboxes section in the docs).

--- a/packages/lib/src/actionMiddlewares/transactionMiddleware.ts
+++ b/packages/lib/src/actionMiddlewares/transactionMiddleware.ts
@@ -70,7 +70,7 @@ export function transactionMiddleware<M extends AnyModel>(target: {
             const { events } = patchRecorder
             for (let i = events.length - 1; i >= 0; i--) {
               const event = events[i]
-              applyPatches(event.target, event.inversePatches)
+              applyPatches(event.target, event.inversePatches, true)
             }
           }
         } finally {

--- a/packages/lib/src/actionMiddlewares/undoMiddleware.ts
+++ b/packages/lib/src/actionMiddlewares/undoMiddleware.ts
@@ -189,7 +189,7 @@ export class UndoManager {
     const event = this.undoQueue[this.undoQueue.length - 1]
 
     withoutUndo(() => {
-      applyPatches(this.subtreeRoot, event.inversePatches)
+      applyPatches(this.subtreeRoot, event.inversePatches, true)
     })
 
     this.store._undo()

--- a/packages/lib/src/patch/applyPatches.ts
+++ b/packages/lib/src/patch/applyPatches.ts
@@ -15,23 +15,39 @@ import { failure, inDevMode, isArray } from "../utils"
  *
  * @param node Target object.
  * @param patches List of patches to apply.
+ * @param reverse Whether patches are applied in reverse order.
  */
-export function applyPatches(node: object, patches: ReadonlyArray<Patch>): void {
+export function applyPatches(
+  node: object,
+  patches: ReadonlyArray<Patch>,
+  reverse: boolean = false
+): void {
   assertTweakedObject(node, "node")
 
-  wrappedInternalApplyPatches.call(node, patches)
+  wrappedInternalApplyPatches.call(node, patches, reverse)
 }
 
 /**
  * @ignore
  * @internal
  */
-export function internalApplyPatches(this: object, patches: ReadonlyArray<Patch>): void {
+export function internalApplyPatches(
+  this: object,
+  patches: ReadonlyArray<Patch>,
+  reverse: boolean = false
+): void {
   const obj = this
 
-  const len = patches.length
-  for (let i = 0; i < len; i++) {
-    applySinglePatch(obj, patches[i])
+  if (reverse) {
+    let i = patches.length
+    while (i--) {
+      applySinglePatch(obj, patches[i])
+    }
+  } else {
+    const len = patches.length
+    for (let i = 0; i < len; i++) {
+      applySinglePatch(obj, patches[i])
+    }
   }
 }
 

--- a/packages/lib/src/treeUtils/sandbox.ts
+++ b/packages/lib/src/treeUtils/sandbox.ts
@@ -179,7 +179,7 @@ export class SandboxManager {
           this.allowWrite(() => {
             let i = recorder.events.length
             while (i-- > numRecorderEvents) {
-              applyPatches(this.subtreeRootClone, recorder.events[i].inversePatches)
+              applyPatches(this.subtreeRootClone, recorder.events[i].inversePatches, true)
             }
           })
         }

--- a/packages/lib/src/tweaker/typeChecking.ts
+++ b/packages/lib/src/tweaker/typeChecking.ts
@@ -23,7 +23,7 @@ export function runTypeCheckingAfterChange(obj: object, patchRecorder: InternalP
       if (err) {
         // quietly apply inverse patches (do not generate patches, snapshots, actions, etc)
         runWithoutSnapshotOrPatches(() => {
-          internalApplyPatches.call(obj, patchRecorder.invPatches)
+          internalApplyPatches.call(obj, patchRecorder.invPatches, true)
         })
         // at the end of apply patches it will be type checked again and its result cached once more
         err.throw(parentModelWithTypeChecker)

--- a/packages/lib/test/patch/applyPatches.test.ts
+++ b/packages/lib/test/patch/applyPatches.test.ts
@@ -50,6 +50,28 @@ describe("object property", () => {
     })
     expect(p2data.y).toBe(10)
   })
+
+  test.each([undefined, false, true])("replace (reverse=%j)", reverse => {
+    runUnprotected(() => {
+      applyPatches(
+        p,
+        [
+          {
+            op: "replace",
+            path: ["p2", "y"],
+            value: 10,
+          },
+          {
+            op: "replace",
+            path: ["p2", "y"],
+            value: 11,
+          },
+        ],
+        reverse
+      )
+    })
+    expect(p2data.y).toBe(reverse ? 10 : 11)
+  })
 })
 
 describe("array", () => {
@@ -64,6 +86,28 @@ describe("array", () => {
       ])
     })
     expect(p.arr).toEqual([1, 10, 2, 3])
+  })
+
+  test.each([undefined, false, true])("add (reverse=%j)", reverse => {
+    runUnprotected(() => {
+      applyPatches(
+        p,
+        [
+          {
+            op: "add",
+            path: ["arr", "1"],
+            value: 10,
+          },
+          {
+            op: "add",
+            path: ["arr", "1"],
+            value: 11,
+          },
+        ],
+        reverse
+      )
+    })
+    expect(p.arr).toEqual([1, reverse ? 10 : 11, !reverse ? 10 : 11, 2, 3])
   })
 
   test("remove", () => {
@@ -89,6 +133,28 @@ describe("array", () => {
       ])
     })
     expect(p.arr).toEqual([1, 10, 3])
+  })
+
+  test.each([undefined, false, true])("replace (reverse=%j)", reverse => {
+    runUnprotected(() => {
+      applyPatches(
+        p,
+        [
+          {
+            op: "replace",
+            path: ["arr", "1"],
+            value: 10,
+          },
+          {
+            op: "replace",
+            path: ["arr", "1"],
+            value: 11,
+          },
+        ],
+        reverse
+      )
+    })
+    expect(p.arr).toEqual([1, reverse ? 10 : 11, 3])
   })
 })
 
@@ -131,5 +197,29 @@ describe("whole object", () => {
     })
     expect(p.p2).toBe(oldP2)
     expect(p.p2!.y).toBe(20)
+  })
+
+  test.each([undefined, false, true])("replace (same id, reverse=%j)", reverse => {
+    const oldP2 = p.p2!
+    runUnprotected(() => {
+      applyPatches(
+        p,
+        [
+          {
+            op: "replace",
+            path: ["p2"],
+            value: { ...getSnapshot(oldP2), y: 20 },
+          },
+          {
+            op: "replace",
+            path: ["p2"],
+            value: { ...getSnapshot(oldP2), y: 21 },
+          },
+        ],
+        reverse
+      )
+    })
+    expect(p.p2).toBe(oldP2)
+    expect(p.p2!.y).toBe(reverse ? 20 : 21)
   })
 })

--- a/packages/lib/test/patch/patch.test.ts
+++ b/packages/lib/test/patch/patch.test.ts
@@ -44,7 +44,10 @@ test("onPatches and applyPatches", () => {
 
   function expectSameSnapshotOnceReverted() {
     runUnprotected(() => {
-      pInvPatches.forEach(invpatches => applyPatches(p, invpatches))
+      pInvPatches
+        .slice()
+        .reverse()
+        .forEach(invpatches => applyPatches(p, invpatches, true))
     })
     expect(getSnapshot(p)).toStrictEqual(sn)
   }
@@ -583,7 +586,10 @@ test("patches with reserved prop names", () => {
 
   function expectSameSnapshotOnceReverted() {
     runUnprotected(() => {
-      pInvPatches.forEach(invpatches => applyPatches(p, invpatches))
+      pInvPatches
+        .slice()
+        .reverse()
+        .forEach(invpatches => applyPatches(p, invpatches, true))
     })
     expect(getSnapshot(p)).toStrictEqual(sn)
   }

--- a/packages/site/src/patches.mdx
+++ b/packages/site/src/patches.mdx
@@ -87,10 +87,16 @@ interface PatchRecorderEvent {
 
 ## Applying patches
 
-### `applyPatches(obj: object, patches: Patch[]): void`
+### `applyPatches(obj: object, patches: Patch[], reverse?: boolean): void`
 
 It is also possible to apply patches / inverse patches doing this:
 
 ```ts
 applyPatches(todo, patches)
+```
+
+Patches (especially inverse patches) can be applied in reverse order:
+
+```ts
+applyPatches(todo, patches, true)
 ```


### PR DESCRIPTION
I noticed that [inverse patches are recorded in the same order as patches](https://github.com/xaviergonz/mobx-keystone/blob/e701396b461498c0bae1894d39d39531143fb14f/packages/lib/src/tweaker/tweakArray.ts#L140-L144) which means in order to revert changes by applying inverse patches, inverse patches must be applied in reverse order. To avoid something like `applyPatches(node, inversePatches.slice().reverse())`, I added a third argument `reverse: boolean = false` to `applyPatches` which causes `applyPatches` to apply patches in reverse order when `reverse === true`. I also fixed all occurrences of inverse patching to use reverse order.

Unfortunately, I wasn't able to find an operation for a test case that results in multiple patches (with `onPatches`) where applying inverse patches in the original order is wrong. `Array.splice` can result in multiple patches, but in all cases I tried the inverse patches are invariant to order.