### PR TITLE
Fixes issue #92

### DIFF
--- a/packages/lib/src/model/modelDecorator.ts
+++ b/packages/lib/src/model/modelDecorator.ts
@@ -61,7 +61,7 @@ export const model = (name: string) => (clazz: ModelClass<AnyModel>) => {
     ...Object.getOwnPropertyDescriptor(newClazz, "name"),
     value: clazz.name,
   })
-  newClazz.__proto__ = clazz
+  Object.setPrototypeOf(newClazz, clazz)
   newClazz.prototype = clazz.prototype
   newClazz[modelInitializersSymbol] = (clazz as any)[modelInitializersSymbol]
   newClazz[modelPropertiesSymbol] = (clazz as any)[modelPropertiesSymbol]

--- a/packages/lib/src/model/modelDecorator.ts
+++ b/packages/lib/src/model/modelDecorator.ts
@@ -61,6 +61,7 @@ export const model = (name: string) => (clazz: ModelClass<AnyModel>) => {
     ...Object.getOwnPropertyDescriptor(newClazz, "name"),
     value: clazz.name,
   })
+  newClazz.__proto__ = clazz
   newClazz.prototype = clazz.prototype
   newClazz[modelInitializersSymbol] = (clazz as any)[modelInitializersSymbol]
   newClazz[modelPropertiesSymbol] = (clazz as any)[modelPropertiesSymbol]

--- a/packages/lib/test/model/modelDecorator.test.ts
+++ b/packages/lib/test/model/modelDecorator.test.ts
@@ -1,0 +1,41 @@
+import { model, Model } from "../../src"
+
+test("model decorator preserves static properties", () => {
+  @model("BarSimple")
+  class Bar extends Model({}) {
+    static foo = "foo"
+  }
+
+  expect(Bar.foo).toBe("foo")
+})
+
+test("model decorator preserves static property getters", () => {
+  @model("BarWithGetter")
+  class Bar extends Model({}) {
+    static sideEffectCount = 0
+    static get foo() {
+      return Bar.sideEffectCount++
+    }
+  }
+
+  expect(Bar.foo).toBe(0)
+  expect(Bar.foo).toBe(1)
+})
+
+test("model decorator works with static proxy gymnastics", () => {
+  class Bar extends Model({}) {}
+
+  // @ts-ignore
+  Bar = new Proxy(Bar, {
+    get: (target, key: keyof typeof Bar | "foo") => {
+      if (key === "foo") return "oof"
+      return target[key]
+    },
+  })
+
+  // @ts-ignore
+  Bar = model("BarWithProxyStuff")(Bar)
+
+  // @ts-ignore
+  expect(Bar.foo).toBe("oof")
+})


### PR DESCRIPTION
```typescript
Object.assign(newClazz, clazz)
// won't work with getters and proxy stuff

Object.defineProperties(
    newClazz,
    /* get property getters setters etc from clazz idk */
)
// still won't for proxy stuff

Object.setPrototypeOf(newClazz, clazz);
// only option left
/* ik `setPrototypeOf` isn't great (i read it's slow) but alternatives like `Object.create` probably won't work
and using proxy instead of `setPrototypeOf` will complicate stuff i guess */
```

Fixes #92 