### PR TITLE
Optimize patches generated by Array.unshift

### DIFF
--- a/packages/lib/test/patch/patch.test.ts
+++ b/packages/lib/test/patch/patch.test.ts
@@ -713,6 +713,183 @@ describe("onPatches and applyPatches", () => {
 
     expectSameSnapshotOnceReverted()
   })
+
+  test("unshift items (empty array)", () => {
+    const {
+      p,
+      pPatches,
+      pInvPatches,
+      p2Patches,
+      p2InvPatches,
+      expectSameSnapshotOnceReverted,
+    } = setup(false)
+
+    runUnprotected(() => {
+      p.arr.unshift(10, 11) // [10, 11]
+    })
+
+    expect(pPatches).toMatchInlineSnapshot(`
+      Array [
+        Array [
+          Object {
+            "op": "add",
+            "path": Array [
+              "arr",
+              0,
+            ],
+            "value": 10,
+          },
+          Object {
+            "op": "add",
+            "path": Array [
+              "arr",
+              1,
+            ],
+            "value": 11,
+          },
+        ],
+      ]
+    `)
+
+    expect(pInvPatches).toMatchInlineSnapshot(`
+      Array [
+        Array [
+          Object {
+            "op": "replace",
+            "path": Array [
+              "arr",
+              "length",
+            ],
+            "value": 0,
+          },
+        ],
+      ]
+    `)
+
+    expect(p2Patches).toMatchInlineSnapshot(`Array []`)
+
+    expect(p2InvPatches).toMatchInlineSnapshot(`Array []`)
+
+    expectSameSnapshotOnceReverted()
+  })
+
+  test("push items", () => {
+    const {
+      p,
+      pPatches,
+      pInvPatches,
+      p2Patches,
+      p2InvPatches,
+      expectSameSnapshotOnceReverted,
+    } = setup(true)
+
+    runUnprotected(() => {
+      p.arr.push(10, 11) // [1, 2, 3, 10, 11]
+    })
+
+    expect(pPatches).toMatchInlineSnapshot(`
+      Array [
+        Array [
+          Object {
+            "op": "add",
+            "path": Array [
+              "arr",
+              3,
+            ],
+            "value": 10,
+          },
+          Object {
+            "op": "add",
+            "path": Array [
+              "arr",
+              4,
+            ],
+            "value": 11,
+          },
+        ],
+      ]
+    `)
+
+    expect(pInvPatches).toMatchInlineSnapshot(`
+      Array [
+        Array [
+          Object {
+            "op": "replace",
+            "path": Array [
+              "arr",
+              "length",
+            ],
+            "value": 3,
+          },
+        ],
+      ]
+    `)
+
+    expect(p2Patches).toMatchInlineSnapshot(`Array []`)
+
+    expect(p2InvPatches).toMatchInlineSnapshot(`Array []`)
+
+    expectSameSnapshotOnceReverted()
+  })
+
+  test("push items (empty array)", () => {
+    const {
+      p,
+      pPatches,
+      pInvPatches,
+      p2Patches,
+      p2InvPatches,
+      expectSameSnapshotOnceReverted,
+    } = setup(false)
+
+    runUnprotected(() => {
+      p.arr.push(10, 11) // [10, 11]
+    })
+
+    expect(pPatches).toMatchInlineSnapshot(`
+      Array [
+        Array [
+          Object {
+            "op": "add",
+            "path": Array [
+              "arr",
+              0,
+            ],
+            "value": 10,
+          },
+          Object {
+            "op": "add",
+            "path": Array [
+              "arr",
+              1,
+            ],
+            "value": 11,
+          },
+        ],
+      ]
+    `)
+
+    expect(pInvPatches).toMatchInlineSnapshot(`
+      Array [
+        Array [
+          Object {
+            "op": "replace",
+            "path": Array [
+              "arr",
+              "length",
+            ],
+            "value": 0,
+          },
+        ],
+      ]
+    `)
+
+    expect(p2Patches).toMatchInlineSnapshot(`Array []`)
+
+    expect(p2InvPatches).toMatchInlineSnapshot(`Array []`)
+
+    expectSameSnapshotOnceReverted()
+  })
 })
 
 test("patches with reserved prop names", () => {

--- a/packages/lib/test/patch/patch.test.ts
+++ b/packages/lib/test/patch/patch.test.ts
@@ -558,6 +558,104 @@ test("onPatches and applyPatches", () => {
   expect(p2InvPatches).toMatchInlineSnapshot(`Array []`)
 
   expectSameSnapshotOnceReverted()
+
+  // unshift items
+  reset()
+  runUnprotected(() => {
+    p.arr.unshift(10, 11) // [10, 11, 1, 2, 3]
+  })
+
+  expect(pPatches).toMatchInlineSnapshot(`
+    Array [
+      Array [
+        Object {
+          "op": "replace",
+          "path": Array [
+            "arr",
+            0,
+          ],
+          "value": 10,
+        },
+        Object {
+          "op": "replace",
+          "path": Array [
+            "arr",
+            1,
+          ],
+          "value": 11,
+        },
+        Object {
+          "op": "replace",
+          "path": Array [
+            "arr",
+            2,
+          ],
+          "value": 1,
+        },
+        Object {
+          "op": "add",
+          "path": Array [
+            "arr",
+            3,
+          ],
+          "value": 2,
+        },
+        Object {
+          "op": "add",
+          "path": Array [
+            "arr",
+            4,
+          ],
+          "value": 3,
+        },
+      ],
+    ]
+  `)
+
+  expect(pInvPatches).toMatchInlineSnapshot(`
+    Array [
+      Array [
+        Object {
+          "op": "replace",
+          "path": Array [
+            "arr",
+            0,
+          ],
+          "value": 1,
+        },
+        Object {
+          "op": "replace",
+          "path": Array [
+            "arr",
+            1,
+          ],
+          "value": 2,
+        },
+        Object {
+          "op": "replace",
+          "path": Array [
+            "arr",
+            2,
+          ],
+          "value": 3,
+        },
+        Object {
+          "op": "replace",
+          "path": Array [
+            "arr",
+            "length",
+          ],
+          "value": 3,
+        },
+      ],
+    ]
+  `)
+
+  expect(p2Patches).toMatchInlineSnapshot(`Array []`)
+
+  expect(p2InvPatches).toMatchInlineSnapshot(`Array []`)
+
+  expectSameSnapshotOnceReverted()
 })
 
 test("patches with reserved prop names", () => {

--- a/packages/lib/test/patch/patch.test.ts
+++ b/packages/lib/test/patch/patch.test.ts
@@ -569,44 +569,20 @@ test("onPatches and applyPatches", () => {
     Array [
       Array [
         Object {
-          "op": "replace",
+          "op": "add",
+          "path": Array [
+            "arr",
+            0,
+          ],
+          "value": 11,
+        },
+        Object {
+          "op": "add",
           "path": Array [
             "arr",
             0,
           ],
           "value": 10,
-        },
-        Object {
-          "op": "replace",
-          "path": Array [
-            "arr",
-            1,
-          ],
-          "value": 11,
-        },
-        Object {
-          "op": "replace",
-          "path": Array [
-            "arr",
-            2,
-          ],
-          "value": 1,
-        },
-        Object {
-          "op": "add",
-          "path": Array [
-            "arr",
-            3,
-          ],
-          "value": 2,
-        },
-        Object {
-          "op": "add",
-          "path": Array [
-            "arr",
-            4,
-          ],
-          "value": 3,
         },
       ],
     ]
@@ -616,36 +592,18 @@ test("onPatches and applyPatches", () => {
     Array [
       Array [
         Object {
-          "op": "replace",
+          "op": "remove",
           "path": Array [
             "arr",
             0,
           ],
-          "value": 1,
         },
         Object {
-          "op": "replace",
+          "op": "remove",
           "path": Array [
             "arr",
-            1,
+            0,
           ],
-          "value": 2,
-        },
-        Object {
-          "op": "replace",
-          "path": Array [
-            "arr",
-            2,
-          ],
-          "value": 3,
-        },
-        Object {
-          "op": "replace",
-          "path": Array [
-            "arr",
-            "length",
-          ],
-          "value": 3,
         },
       ],
     ]


### PR DESCRIPTION
`Array.unshift` was generating unnecessarily complex patches for non-empty arrays. I added a [test that shows the current state (before this PR)](d3dd8dfb70171b43c8de4cfef84b67b24232ff48) and an [optimization to create simpler patches](7b4de75d32addc8c6ca0a3bff4f0d1860776ad86). The diff of the optimization looks more invasive than it is - all I did was to add:

```ts
// optimization, if `splice` is equivalent to `unshift` on a non-empty array
if (change.index === 0 && addedCount !== 0 && change.removedCount === 0 && oldLen !== 0) {
  let i = addedCount
  const path = [0]
  while (i--) {
    patches.push({
      op: "add",
      path,
      value: addedItems[i],
    })
    invPatches.push({
      op: "remove",
      path,
    })
  }
} else {
  // everything as before
}
```

I also added tests to make sure patches are as expected for `Array.unshift` and `Array.push` with empty and non-empty arrays.