### PR TITLE
decoratedModel

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Change Log
 
+## 0.39.0
+
+- Added `decoratedModel` so the library can be used without decorators.
+
 ## 0.38.0
 
 - Fixes for `undoMiddleware`, where it wouldn't properly record changes outside a subaction after a subaction is performed.

--- a/packages/lib/package.json
+++ b/packages/lib/package.json
@@ -1,6 +1,6 @@
 {
   "name": "mobx-keystone",
-  "version": "0.38.0",
+  "version": "0.39.0",
   "description": "A MobX powered state management solution based on data trees with first class support for Typescript, snapshots, patches and much more",
   "keywords": [
     "mobx",

--- a/packages/lib/src/action/modelAction.ts
+++ b/packages/lib/src/action/modelAction.ts
@@ -9,8 +9,8 @@ import { modelActionSymbol, wrapInAction } from "./wrapInAction"
  * @param fn Function to check.
  * @returns
  */
-export function isModelAction(fn: any) {
-  return typeof fn === "function" && fn[modelActionSymbol]
+export function isModelAction(fn: any): fn is (...args: any[]) => any {
+  return typeof fn === "function" && !!fn[modelActionSymbol]
 }
 
 function checkModelActionArgs(target: any, propertyKey: string, value: any) {

--- a/packages/lib/src/model/Model.ts
+++ b/packages/lib/src/model/Model.ts
@@ -47,7 +47,7 @@ export interface _Model<SuperModel, TProps extends ModelProps> {
     : this[typeof creationDataSymbol]
 
   new (data: this[typeof composedCreationDataSymbol] & { [modelIdKey]?: string }): SuperModel &
-    BaseModel<this[typeof propsDataSymbol], this[typeof creationDataSymbol]> &
+    BaseModel<this[typeof propsDataSymbol], this[typeof composedCreationDataSymbol]> &
     Omit<this[typeof propsDataSymbol], keyof AnyModel>
 }
 

--- a/packages/lib/test/model/modelDecorator.test.ts
+++ b/packages/lib/test/model/modelDecorator.test.ts
@@ -1,4 +1,19 @@
-import { getSnapshot, model, Model, modelTypeKey, prop } from "../../src"
+import { computed, isComputedProp } from "mobx"
+import { assert, _ } from "spec.ts"
+import {
+  decoratedModel,
+  ExtendedModel,
+  getSnapshot,
+  isModelAction,
+  model,
+  Model,
+  modelAction,
+  modelIdKey,
+  modelTypeKey,
+  prop,
+  SnapshotInOf,
+  SnapshotOutOf,
+} from "../../src"
 import "../commonSetup"
 
 test("model decorator preserves static properties", () => {
@@ -62,4 +77,153 @@ test("model decorator sets model type static prop and toString methods", () => {
   const inst = new MyModel2({}) as MyModel
   expect(`${inst}`).toBe(`[MyModel#${type} ${JSON.stringify(getSnapshot(inst))}]`)
   expect(`${inst.toString({ withData: false })}`).toBe(`[MyModel#${type}]`)
+})
+
+test("decoratedModel", () => {
+  const Point = decoratedModel(
+    "decoratedModel/Point",
+    class Point<N> extends Model({
+      x: prop<number>(5),
+      y: prop<number>(),
+    }) {
+      setX(x: number) {
+        this.x = x
+      }
+
+      setY = (y: number) => {
+        this.y = y
+      }
+
+      setXY(x: number, y: number) {
+        this.setX(x)
+        this.setY(y)
+      }
+
+      get length() {
+        return this.x + this.y
+      }
+
+      volatile = "volatile"
+      volatile2!: N
+    },
+    {
+      setX: modelAction,
+      setY: modelAction,
+      setXY: [modelAction],
+      length: computed,
+    }
+  )
+  type Point = InstanceType<typeof Point>
+
+  {
+    expect(isModelAction(Point.prototype.setX)).toBeTruthy()
+    expect(Point.prototype.setY).toBeUndefined()
+    expect(isModelAction(Point.prototype.setXY)).toBeTruthy()
+
+    const p = new Point<number>({ x: 10, y: 20 })
+    expect(isModelAction(p.setX)).toBeTruthy()
+    expect(isModelAction(p.setY)).toBeTruthy()
+    expect(isModelAction(p.setXY)).toBeTruthy()
+    expect(isComputedProp(p, "length"))
+
+    expect(p.x).toBe(10)
+    expect(p.y).toBe(20)
+    expect(p.length).toBe(30)
+    expect(p.volatile).toBe("volatile")
+    assert(p.volatile2, _ as number)
+
+    p.setXY(20, 30)
+    expect(p.x).toBe(20)
+    expect(p.y).toBe(30)
+    expect(p.length).toBe(50)
+
+    assert(
+      _ as SnapshotInOf<Point>,
+      _ as { x?: number | null; y: number } & {
+        [modelTypeKey]: string
+        [modelIdKey]: string
+      }
+    )
+
+    assert(
+      _ as SnapshotOutOf<Point>,
+      _ as { x: number; y: number } & {
+        [modelTypeKey]: string
+        [modelIdKey]: string
+      }
+    )
+  }
+
+  // extension
+
+  const Point3d = decoratedModel(
+    "decoratedModel/Point3d",
+    class Point3d extends ExtendedModel(Point, {
+      z: prop<number>(),
+    }) {
+      setZ(z: number) {
+        this.z = z
+      }
+
+      setXYZ(x: number, y: number, z: number) {
+        super.setXY(x, y)
+        this.setZ(z)
+      }
+
+      get length() {
+        return this.x + this.y + this.z
+      }
+    },
+    {
+      setZ: modelAction,
+      setXYZ: modelAction,
+      length: computed,
+    }
+  )
+  type Point3d = InstanceType<typeof Point3d>
+
+  {
+    expect(isModelAction(Point3d.prototype.setX)).toBeTruthy()
+    expect(Point3d.prototype.setY).toBeUndefined()
+    expect(isModelAction(Point3d.prototype.setXY)).toBeTruthy()
+    expect(isModelAction(Point3d.prototype.setZ)).toBeTruthy()
+    expect(isModelAction(Point3d.prototype.setXYZ)).toBeTruthy()
+
+    const p2 = new Point3d({ x: 10, y: 20, z: 30 })
+    expect(isModelAction(p2.setX)).toBeTruthy()
+    expect(isModelAction(p2.setY)).toBeTruthy()
+    expect(isModelAction(p2.setXY)).toBeTruthy()
+    expect(isModelAction(p2.setZ)).toBeTruthy()
+    expect(isModelAction(p2.setXYZ)).toBeTruthy()
+    expect(isComputedProp(p2, "length"))
+
+    expect(p2.x).toBe(10)
+    expect(p2.y).toBe(20)
+    expect(p2.z).toBe(30)
+    expect(p2.length).toBe(60)
+    expect(p2.volatile).toBe("volatile")
+    assert(p2.volatile2, _ as unknown) // known issue, no way to specify generic for base class
+
+    p2.setXYZ(20, 30, 40)
+    expect(p2.x).toBe(20)
+    expect(p2.y).toBe(30)
+    expect(p2.z).toBe(40)
+    expect(p2.length).toBe(90)
+
+    assert(
+      _ as SnapshotInOf<Point3d>,
+      _ as { x?: number | null; y: number; z: number } & {
+        [modelTypeKey]: string
+        [modelIdKey]: string
+      }
+    )
+
+    assert(
+      _ as SnapshotOutOf<Point3d>,
+      _ as { x: number; y: number; z: number } & {
+        [modelTypeKey]: string
+        [modelIdKey]: string
+      }
+    )
+  }
 })

--- a/packages/lib/test/model/modelDecorator.test.ts
+++ b/packages/lib/test/model/modelDecorator.test.ts
@@ -80,6 +80,8 @@ test("model decorator sets model type static prop and toString methods", () => {
 })
 
 test("decoratedModel", () => {
+  let initCalls = 0
+
   const Point = decoratedModel(
     "decoratedModel/Point",
     class Point<N> extends Model({
@@ -105,6 +107,10 @@ test("decoratedModel", () => {
 
       volatile = "volatile"
       volatile2!: N
+
+      onInit() {
+        initCalls++
+      }
     },
     {
       setX: modelAction,
@@ -120,7 +126,9 @@ test("decoratedModel", () => {
     expect(Point.prototype.setY).toBeUndefined()
     expect(isModelAction(Point.prototype.setXY)).toBeTruthy()
 
+    expect(initCalls).toBe(0)
     const p = new Point<number>({ x: 10, y: 20 })
+    expect(initCalls).toBe(1)
     expect(isModelAction(p.setX)).toBeTruthy()
     expect(isModelAction(p.setY)).toBeTruthy()
     expect(isModelAction(p.setXY)).toBeTruthy()

--- a/packages/lib/test/model/subclassing.test.ts
+++ b/packages/lib/test/model/subclassing.test.ts
@@ -68,6 +68,9 @@ test("subclassing with additional props", () => {
   assert(
     _ as CD,
     _ as { x?: number | null; y?: number | null; z?: number | null } & {
+      x?: number | null
+      y?: number | null
+      z?: number | null
       a?: number | null
       b: number
     }
@@ -237,7 +240,15 @@ test("three level subclassing", () => {
   assert(_ as D, _ as { x: number; y: number; z: number } & { a: number } & { b: number })
   assert(
     _ as CD,
-    _ as { x?: number | null; y?: number | null; z?: number | null } & { a?: number | null } & {
+    _ as {
+      x?: number | null | undefined
+      y?: number | null | undefined
+      z?: number | null | undefined
+    } & { x?: number | null; y?: number | null; z?: number | null; a?: number | null } & {
+      x?: number | null
+      y?: number | null
+      z?: number | null
+      a?: number | null
       b: number
     }
   )

--- a/packages/site/src/models.mdx
+++ b/packages/site/src/models.mdx
@@ -351,3 +351,51 @@ class X extends ExtendedModel(modelClass<SomeGenericClass<string>>(SomeGenericCl
 ```
 
 If you don't it will still compile, but the generic will be assumed to have unknown for all its generic parameters.
+
+## Usage without decorators
+
+Although this library was primarily intented to be used with decorators it is also possible to use it without them.
+
+To do so you can use the `decoratedModel` method as shown below:
+
+```ts
+const Todo = decoratedModel(
+  // the string identifies this model type and must be unique across your whole application
+  // you may pass `undefined` if you don't want the model to be registered yet (e.g. for a base class)
+  "myCoolApp/Todo",
+  // note: although the name of class here is optional it is recommended when using Typescript to make
+  // the IDE show better typings and emit shorter declarations
+  class Todo extends Model({
+    text: prop<string>(), // a required string
+    done: prop(false), // an optional boolean that will default to false when the input is null or undefined
+  }) {
+    // note how here we don't decorate the method directly, but on the next parameter instead
+    // @modelAction
+    setDone(done: boolean) {
+      this.done = done
+    }
+
+    // @modelAction
+    setText(text: string) {
+      this.text = text
+    }
+
+    // @computed
+    get fullText() {
+      return `${this.done ? "DONE" : "TODO"} - ${this.text}`
+    }
+  },
+  // here we pass what we would use as decorators to the class methods/properties above
+  // if we want to use multiple chained decorators we can pass an array of them instead
+  // note that any kind of Typescript compatible decorator is supported, not only the built-in ones!
+  {
+    setDone: modelAction,
+    setText: modelAction,
+    fullText: computed,
+  }
+)
+// needed to be able to do SnapshotInOf<Todo>, etc
+type Todo = InstanceType<typeof Todo>
+
+const myTodo = new Todo({ done: false, text: "buy some milk" })
+```


### PR DESCRIPTION
Allows the usage of the lib without decorators

Example

```ts
  const Point = decoratedModel(
    "decoratedModel/Point",
    // although class could be anonymous, by giving it a name 
    // type declarations are shorter
    // and the IDE shows better typings if we do
    class Point extends Model({
      x: prop<number>(),
      y: prop<number>(),
    }) {
      setX(x: number) {
        this.x = x
      }

      setY = (y: number) => {
        this.y = y
      }

      setXY(x: number, y: number) {
        this.setX(x)
        this.setY(y)
      }

      get length() {
        return this.x + this.y
      }

      volatile = "volatile"
    },
    {
      setX: modelAction,
      setY: modelAction,
      setXY: modelAction,
      length: computed,
      // multiple decorators could be applied with xxx: [deco1, deco2...]
    }
  )
  type Point = InstanceType<typeof Point> // needed to be able to do SnapshotInOf<Point>, etc

  const p = new Point<number>({ x: 10, y: 20 })
```