### PR TITLE
Improve implicit properties collection speed, Date mutability

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Change Log
 
+- When using date transforms, mutation made by methods (`setTime`, etc.) are reflected in the backed property (string / timestamp), so it is no longer required to treat dates as immutable objects.
+- Performance improvements for implicit property transform collections.
+
 ## 0.40.0
 
 - [BREAKING CHANGE - types] Some type helpers have been renamed: `ModelData` -> `ModelPropsData` / `ModelInstanceData`, `ModelCreationData` -> `ModelPropsCreationData` / `ModelInstanceCreationData`.

--- a/packages/lib/src/model/BaseModel.ts
+++ b/packages/lib/src/model/BaseModel.ts
@@ -140,7 +140,7 @@ export abstract class BaseModel<
             propName,
             propTransform
           )
-          initialData[propName] = memoTransform.dataToProp(initialData[propName], undefined)
+          initialData[propName] = memoTransform.dataToProp(initialData[propName])
         }
       }
 

--- a/packages/lib/src/model/Model.ts
+++ b/packages/lib/src/model/Model.ts
@@ -241,8 +241,7 @@ function createModelPropDescriptor(
           modelPropName,
           transform
         )
-        const oldPropValue = this.$[modelPropName]
-        this.$[modelPropName] = memoTransform.dataToProp(v, oldPropValue)
+        this.$[modelPropName] = memoTransform.dataToProp(v)
       },
     }
   } else {

--- a/packages/lib/src/propTransform/DateBackedByProp.ts
+++ b/packages/lib/src/propTransform/DateBackedByProp.ts
@@ -1,0 +1,79 @@
+export class DateBackedByProp extends Date {
+  private _updateDate(method: string, superMethod: any, args: any[]): number {
+    // work over a copy
+    const date: any = new Date(this.getTime())
+    date[method].apply(date, args)
+
+    // update backed prop
+    this._updateBackedProp(date)
+
+    // if that succeeds apply over current date object
+    return superMethod.apply(this, args)
+  }
+
+  constructor(value: string | number, private readonly _updateBackedProp: (date: Date) => void) {
+    super(value)
+  }
+
+  // make mutable methods update the backed prop
+
+  setTime(...args: any[]): any {
+    return this._updateDate("setTime", super.setTime, args)
+  }
+
+  setMilliseconds(...args: any[]): any {
+    return this._updateDate("setMilliseconds", super.setMilliseconds, args)
+  }
+
+  setUTCMilliseconds(...args: any[]): any {
+    return this._updateDate("setUTCMilliseconds", super.setUTCMilliseconds, args)
+  }
+
+  setSeconds(...args: any[]): any {
+    return this._updateDate("setSeconds", super.setSeconds, args)
+  }
+
+  setUTCSeconds(...args: any[]): any {
+    return this._updateDate("setUTCSeconds", super.setUTCSeconds, args)
+  }
+
+  setMinutes(...args: any[]): any {
+    return this._updateDate("setMinutes", super.setMinutes, args)
+  }
+
+  setUTCMinutes(...args: any[]): any {
+    return this._updateDate("setUTCMinutes", super.setUTCMinutes, args)
+  }
+
+  setHours(...args: any[]): any {
+    return this._updateDate("setHours", super.setHours, args)
+  }
+
+  setUTCHours(...args: any[]): any {
+    return this._updateDate("setUTCHours", super.setUTCHours, args)
+  }
+
+  setDate(...args: any[]): any {
+    return this._updateDate("setDate", super.setDate, args)
+  }
+
+  setUTCDate(...args: any[]): any {
+    return this._updateDate("setUTCDate", super.setUTCDate, args)
+  }
+
+  setMonth(...args: any[]): any {
+    return this._updateDate("setMonth", super.setMonth, args)
+  }
+
+  setUTCMonth(...args: any[]): any {
+    return this._updateDate("setUTCMonth", super.setUTCMonth, args)
+  }
+
+  setFullYear(...args: any[]): any {
+    return this._updateDate("setFullYear", super.setFullYear, args)
+  }
+
+  setUTCFullYear(...args: any[]): any {
+    return this._updateDate("setUTCFullYear", super.setUTCFullYear, args)
+  }
+}

--- a/packages/lib/src/propTransform/transformArrayAsMap.ts
+++ b/packages/lib/src/propTransform/transformArrayAsMap.ts
@@ -1,28 +1,126 @@
+import {
+  action,
+  IArrayChange,
+  IArraySplice,
+  IMapWillChange,
+  intercept,
+  IObservableArray,
+  isObservableArray,
+  observable,
+  ObservableMap,
+  observe,
+} from "mobx"
 import { MaybeOptionalModelProp, OnlyPrimitives, OptionalModelProp, prop } from "../model/prop"
 import { AnyType, TypeToData } from "../typeChecking/schemas"
 import { tProp } from "../typeChecking/tProp"
-import { isArray, isMap } from "../utils"
-import { arrayAsMap } from "../wrappers"
+import { failure, inDevMode, isArray, isMap } from "../utils"
+import { Lock } from "../utils/lock"
 import { PropTransform, transformedProp } from "./propTransform"
 
-/**
- * A map expressed as an array.
- */
-export type TransformArrayAsMap<V> = [string, V][]
+const observableMapBackedByObservableArray = action(
+  <T>(array: IObservableArray<[string, T]>): ObservableMap<string, T> => {
+    if (inDevMode()) {
+      if (!isObservableArray(array)) {
+        throw failure("assertion failed: expected an observable array")
+      }
+    }
+
+    const map = observable.map(array)
+
+    if (map.size !== array.length) {
+      throw failure("arrays backing a map cannot contain duplicate keys")
+    }
+
+    const mutationLock = new Lock()
+
+    // for speed reasons we will just assume distinct values are only once in the array
+    // also we assume tuples themselves are immutable
+
+    // when the array changes the map changes
+    observe(
+      array,
+      action(
+        mutationLock.unlockedFn((change: IArrayChange<[string, T]> | IArraySplice<[string, T]>) => {
+          switch (change.type) {
+            case "splice": {
+              {
+                const removed = change.removed
+                for (let i = 0; i < removed.length; i++) {
+                  map.delete(removed[i][0])
+                }
+              }
+
+              {
+                const added = change.added
+                for (let i = 0; i < added.length; i++) {
+                  map.set(added[i][0], added[i][1])
+                }
+              }
+
+              break
+            }
+
+            case "update": {
+              map.delete(change.oldValue[0])
+              map.set(change.newValue[0], change.newValue[1])
+              break
+            }
+          }
+        })
+      )
+    )
+
+    // when the map changes also change the array
+    intercept(
+      map,
+      action((change: IMapWillChange<string, T>) => {
+        if (!mutationLock.isLocked) {
+          return null // already changed
+        }
+
+        switch (change.type) {
+          case "update": {
+            // replace the whole tuple to keep tuple immutability
+            const i = array.findIndex(i => i[0] === change.name)
+            array[i] = [change.name, change.newValue!]
+            break
+          }
+
+          case "add": {
+            array.push([change.name, change.newValue!])
+            break
+          }
+
+          case "delete": {
+            const i = array.findIndex(i => i[0] === change.name)
+            if (i >= 0) {
+              array.splice(i, 1)
+            }
+            break
+          }
+        }
+
+        return change
+      })
+    )
+
+    return map
+  }
+)
 
 const arrayAsMapInnerTransform: PropTransform<
   [string, any][] | unknown,
   Map<string, any> | unknown
 > = {
   propToData(arr) {
-    return isArray(arr) ? arrayAsMap(() => arr) : arr
+    return isArray(arr) ? observableMapBackedByObservableArray(arr as IObservableArray) : arr
   },
   dataToProp(newMap) {
     if (!isMap(newMap)) {
       return newMap
     }
 
-    const arr: TransformArrayAsMap<any> = []
+    const arr: [string, any][] = []
     for (const k of newMap.keys()) {
       arr.push([k, newMap.get(k)])
     }

--- a/packages/lib/src/propTransform/transformArrayAsSet.ts
+++ b/packages/lib/src/propTransform/transformArrayAsSet.ts
@@ -1,13 +1,108 @@
+import {
+  action,
+  IArrayChange,
+  IArraySplice,
+  intercept,
+  IObservableArray,
+  ISetWillChange,
+  isObservableArray,
+  observable,
+  ObservableSet,
+  observe,
+} from "mobx"
 import { MaybeOptionalModelProp, OnlyPrimitives, OptionalModelProp, prop } from "../model/prop"
 import { AnyType, TypeToData } from "../typeChecking/schemas"
 import { tProp } from "../typeChecking/tProp"
-import { isArray, isSet } from "../utils"
-import { arrayAsSet } from "../wrappers/arrayAsSetWrapper"
+import { failure, inDevMode, isArray, isSet } from "../utils"
+import { Lock } from "../utils/lock"
 import { PropTransform, transformedProp } from "./propTransform"
+
+const observableSetBackedByObservableArray = action(
+  <T>(array: IObservableArray<T>): ObservableSet<T> => {
+    if (inDevMode()) {
+      if (!isObservableArray(array)) {
+        throw failure("assertion failed: expected an observable array")
+      }
+    }
+
+    const set = observable.set(array)
+
+    if (set.size !== array.length) {
+      throw failure("arrays backing a set cannot contain duplicate values")
+    }
+
+    const mutationLock = new Lock()
+
+    // for speed reasons we will just assume distinct values are only once in the array
+
+    // when the array changes the set changes
+    observe(
+      array,
+      action(
+        mutationLock.unlockedFn((change: IArrayChange<T> | IArraySplice<T>) => {
+          switch (change.type) {
+            case "splice": {
+              {
+                const removed = change.removed
+                for (let i = 0; i < removed.length; i++) {
+                  set.delete(removed[i])
+                }
+              }
+
+              {
+                const added = change.added
+                for (let i = 0; i < added.length; i++) {
+                  set.add(added[i])
+                }
+              }
+
+              break
+            }
+
+            case "update": {
+              set.delete(change.oldValue)
+              set.add(change.newValue)
+              break
+            }
+          }
+        })
+      )
+    )
+
+    // when the set changes also change the array
+    intercept(
+      set,
+      action((change: ISetWillChange<T>) => {
+        if (!mutationLock.isLocked) {
+          return null // already changed
+        }
+
+        switch (change.type) {
+          case "add": {
+            array.push(change.newValue)
+            break
+          }
+
+          case "delete": {
+            const i = array.indexOf(change.oldValue)
+            if (i >= 0) {
+              array.splice(i, 1)
+            }
+            break
+          }
+        }
+
+        return change
+      })
+    )
+
+    return set
+  }
+)
 
 const arrayAsSetInnerTransform: PropTransform<any[] | unknown, Set<any> | unknown> = {
   propToData(arr) {
-    return isArray(arr) ? arrayAsSet(() => arr) : arr
+    return isArray(arr) ? observableSetBackedByObservableArray(arr as IObservableArray) : arr
   },
   dataToProp(newSet) {
     return isSet(newSet) ? [...newSet.values()] : newSet

--- a/packages/lib/src/propTransform/transformObjectAsMap.ts
+++ b/packages/lib/src/propTransform/transformObjectAsMap.ts
@@ -1,16 +1,97 @@
+import {
+  action,
+  IMapWillChange,
+  intercept,
+  IObjectDidChange,
+  IObservableObject,
+  isObservableObject,
+  observable,
+  ObservableMap,
+  observe,
+  remove,
+  set,
+} from "mobx"
 import { MaybeOptionalModelProp, OnlyPrimitives, OptionalModelProp, prop } from "../model/prop"
 import { AnyType, TypeToData } from "../typeChecking/schemas"
 import { tProp } from "../typeChecking/tProp"
-import { isMap, isObject } from "../utils"
-import { objectAsMap } from "../wrappers"
+import { failure, inDevMode, isMap, isObject } from "../utils"
+import { Lock } from "../utils/lock"
 import { PropTransform, transformedProp } from "./propTransform"
+
+const observableMapBackedByObservableObject = action(
+  <T>(obj: IObservableObject): ObservableMap<string, T> => {
+    if (inDevMode()) {
+      if (!isObservableObject(obj)) {
+        throw failure("assertion failed: expected an observable object")
+      }
+    }
+
+    const map = observable.map()
+
+    const keys = Object.keys(obj)
+    for (let i = 0; i < keys.length; i++) {
+      const k = keys[i]
+      map.set(k, (obj as any)[k])
+    }
+
+    const mutationLock = new Lock()
+
+    // when the object changes the map changes
+    observe(
+      obj,
+      action(
+        mutationLock.unlockedFn((change: IObjectDidChange) => {
+          switch (change.type) {
+            case "add":
+            case "update": {
+              map.set(change.name, change.newValue)
+              break
+            }
+
+            case "remove": {
+              map.delete(change.name)
+              break
+            }
+          }
+        })
+      )
+    )
+
+    // when the map changes also change the object
+    intercept(
+      map,
+      action((change: IMapWillChange<string, T>) => {
+        if (!mutationLock.isLocked) {
+          return null // already changed
+        }
+
+        switch (change.type) {
+          case "add":
+          case "update": {
+            set(obj, change.name, change.newValue)
+            break
+          }
+
+          case "delete": {
+            remove(obj, change.name)
+            break
+          }
+        }
+
+        return change
+      })
+    )
+
+    return map
+  }
+)
 
 const objectAsMapInnerTransform: PropTransform<
   Record<string, any> | unknown,
   Map<string, any> | unknown
 > = {
-  propToData(map) {
-    return isObject(map) ? objectAsMap(() => map as any) : map
+  propToData(obj) {
+    return isObject(obj) ? observableMapBackedByObservableObject(obj as IObservableObject) : obj
   },
   dataToProp(newMap) {
     if (!isMap(newMap)) {

--- a/packages/lib/src/propTransform/transformStringAsDate.ts
+++ b/packages/lib/src/propTransform/transformStringAsDate.ts
@@ -1,6 +1,7 @@
 import { MaybeOptionalModelProp, OnlyPrimitives, OptionalModelProp, prop } from "../model/prop"
 import { AnyType, TypeToData } from "../typeChecking/schemas"
 import { tProp } from "../typeChecking/tProp"
+import { DateBackedByProp } from "./DateBackedByProp"
 import { propTransform, transformedProp } from "./propTransform"
 
 /**
@@ -9,8 +10,17 @@ import { propTransform, transformedProp } from "./propTransform"
  * Decorator property transform for ISO date strings to Date objects and vice-versa.
  */
 export const stringAsDate = propTransform<string | null | undefined, Date | null | undefined>({
-  propToData(prop) {
-    return typeof prop === "string" ? new Date(prop) : prop
+  propToData(prop, setProp) {
+    if (typeof prop !== "string") {
+      return prop
+    }
+    if (setProp) {
+      return new DateBackedByProp(prop, date => {
+        setProp(date.toJSON())
+      })
+    } else {
+      return new Date(prop)
+    }
   },
   dataToProp(date) {
     return date instanceof Date ? date.toJSON() : date

--- a/packages/lib/src/propTransform/transformTimestampAsDate.ts
+++ b/packages/lib/src/propTransform/transformTimestampAsDate.ts
@@ -1,6 +1,7 @@
 import { MaybeOptionalModelProp, OnlyPrimitives, OptionalModelProp, prop } from "../model/prop"
 import { AnyType, TypeToData } from "../typeChecking/schemas"
 import { tProp } from "../typeChecking/tProp"
+import { DateBackedByProp } from "./DateBackedByProp"
 import { propTransform, transformedProp } from "./propTransform"
 
 /**
@@ -9,11 +10,20 @@ import { propTransform, transformedProp } from "./propTransform"
  * Decorator property transform for number timestamps to Date objects and vice-versa.
  */
 export const timestampAsDate = propTransform<number | null | undefined, Date | null | undefined>({
-  propToData(prop) {
-    return typeof prop === "number" ? new Date(prop) : prop
+  propToData(prop, setProp) {
+    if (typeof prop !== "number") {
+      return prop
+    }
+    if (setProp) {
+      return new DateBackedByProp(prop, date => {
+        setProp(date.getTime())
+      })
+    } else {
+      return new Date(prop)
+    }
   },
   dataToProp(date) {
-    return date instanceof Date ? +date : date
+    return date instanceof Date ? date.getTime() : date
   },
 })
 

--- a/packages/lib/src/utils/lock.ts
+++ b/packages/lib/src/utils/lock.ts
@@ -1,0 +1,31 @@
+export class Lock {
+  private _locked = true
+
+  get isLocked() {
+    return this._locked
+  }
+
+  unlockedFn<F extends (...args: any[]) => any>(fn: F): F {
+    const innerFn: any = (...args: any[]) => {
+      const oldLocked = this._locked
+      this._locked = false
+      try {
+        return fn(...args)
+      } finally {
+        this._locked = oldLocked
+      }
+    }
+
+    return innerFn
+  }
+
+  withUnlock<F extends () => any>(fn: F): ReturnType<F> {
+    const oldLocked = this._locked
+    this._locked = false
+    try {
+      return fn()
+    } finally {
+      this._locked = oldLocked
+    }
+  }
+}

--- a/packages/lib/test/propTransform/decorator/stringAsDate.test.ts
+++ b/packages/lib/test/propTransform/decorator/stringAsDate.test.ts
@@ -65,7 +65,7 @@ test("stringAsDate", () => {
 
   const dateNow2 = new Date(1569524561993)
   m.setDate(dateNow2)
-  expect(m.date).toBe(dateNow2)
+  expect(m.date).toEqual(dateNow2)
   expect(m.time).toBe(dateNow2.toJSON())
 
   expect(stringAsDate.propToData(m.time)).toStrictEqual(dateNow2)

--- a/packages/lib/test/propTransform/decorator/timestampAsDate.test.ts
+++ b/packages/lib/test/propTransform/decorator/timestampAsDate.test.ts
@@ -79,7 +79,7 @@ test("timestampAsDate", () => {
   expect(timestampAsDate.dataToProp(dateNow2)).toStrictEqual(now2)
 
   m.setDate(dateNow2)
-  expect(m.date).toBe(dateNow2)
+  expect(m.date).toEqual(dateNow2)
   expect(m.timestamp).toBe(now2)
 
   expect(actionCalls).toMatchInlineSnapshot(`
@@ -123,7 +123,7 @@ test("timestampAsDate", () => {
   // changing the date to be the same should keep the cached value intact
   reactions.length = 0
   m.setDate(dateNow)
-  expect(m.date).toBe(dateNow)
+  expect(m.date).toEqual(dateNow)
   expect(reactions).toHaveLength(0)
 
   // changing the backed value to be the same should keep the cached value intact

--- a/packages/lib/test/propTransform/implicit/transformArrayAsMap.test.ts
+++ b/packages/lib/test/propTransform/implicit/transformArrayAsMap.test.ts
@@ -1,9 +1,8 @@
-import { reaction } from "mobx"
+import { isObservableMap, reaction } from "mobx"
 import { assert, _ } from "spec.ts"
 import {
   ActionCall,
   applyAction,
-  ArrayAsMap,
   getSnapshot,
   model,
   Model,
@@ -57,7 +56,7 @@ test("transformArrayAsMap", () => {
   ])
 
   // getter
-  expect(m.map instanceof ArrayAsMap).toBeTruthy()
+  expect(isObservableMap(m.map)).toBeTruthy()
   expectSimilarMap(m.map, initialMap)
 
   // should be cached
@@ -105,7 +104,7 @@ test("transformArrayAsMap", () => {
   ])
   m.setMap(newMap)
   expect(m.map).not.toBe(newMap) // must be transformed
-  expect(m.map instanceof ArrayAsMap).toBeTruthy()
+  expect(isObservableMap(m.map)).toBeTruthy()
   expectSimilarMap(m.map, newMap)
 
   expect(m.$.map).toEqual([
@@ -145,10 +144,10 @@ test("transformArrayAsMap", () => {
 
   expect(reactions).toMatchInlineSnapshot(`
     Array [
-      Map {
-        "5" => 5,
-        "6" => 6,
-        "7" => 7,
+      Object {
+        "5": 5,
+        "6": 6,
+        "7": 7,
       },
     ]
   `)

--- a/packages/lib/test/propTransform/implicit/transformArrayAsMap.test.ts
+++ b/packages/lib/test/propTransform/implicit/transformArrayAsMap.test.ts
@@ -104,6 +104,8 @@ test("transformArrayAsMap", () => {
     ["7", 7],
   ])
   m.setMap(newMap)
+  expect(m.map).not.toBe(newMap) // must be transformed
+  expect(m.map instanceof ArrayAsMap).toBeTruthy()
   expectSimilarMap(m.map, newMap)
 
   expect(m.$.map).toEqual([

--- a/packages/lib/test/propTransform/implicit/transformArrayAsSet.test.ts
+++ b/packages/lib/test/propTransform/implicit/transformArrayAsSet.test.ts
@@ -97,6 +97,8 @@ test("transformArrayAsSet", () => {
 
   const newSet = new Set([5, 6, 7])
   m.setSet(newSet)
+  expect(m.set).not.toBe(newSet) // must be transformed
+  expect(m.set instanceof ArrayAsSet).toBeTruthy()
   expectSimilarSet(m.set, newSet)
 
   expect(m.$.set).toEqual([5, 6, 7])

--- a/packages/lib/test/propTransform/implicit/transformObjectAsMap.test.ts
+++ b/packages/lib/test/propTransform/implicit/transformObjectAsMap.test.ts
@@ -99,6 +99,8 @@ test("transformObjectAsMap", () => {
     ["7", 7],
   ])
   m.setMap(newMap)
+  expect(m.map).not.toBe(newMap) // must be transformed
+  expect(m.map instanceof ObjectAsMap).toBeTruthy()
   expectSimilarMap(m.map, newMap)
 
   expect(m.$.map).toEqual({ 5: 5, 6: 6, 7: 7 })

--- a/packages/lib/test/propTransform/implicit/transformObjectAsMap.test.ts
+++ b/packages/lib/test/propTransform/implicit/transformObjectAsMap.test.ts
@@ -1,4 +1,4 @@
-import { reaction } from "mobx"
+import { isObservableMap, reaction } from "mobx"
 import { assert, _ } from "spec.ts"
 import {
   ActionCall,
@@ -7,7 +7,6 @@ import {
   model,
   Model,
   modelAction,
-  ObjectAsMap,
   onActionMiddleware,
   SnapshotInOf,
   SnapshotOutOf,
@@ -52,7 +51,7 @@ test("transformObjectAsMap", () => {
   expect(getSnapshot(m).map).toEqual({ 1: 1, 2: 2, 3: 3 })
 
   // getter
-  expect(m.map instanceof ObjectAsMap).toBeTruthy()
+  expect(isObservableMap(m.map)).toBeTruthy()
   expectSimilarMap(m.map, initialMap)
 
   // should be cached
@@ -100,7 +99,7 @@ test("transformObjectAsMap", () => {
   ])
   m.setMap(newMap)
   expect(m.map).not.toBe(newMap) // must be transformed
-  expect(m.map instanceof ObjectAsMap).toBeTruthy()
+  expect(isObservableMap(m.map)).toBeTruthy()
   expectSimilarMap(m.map, newMap)
 
   expect(m.$.map).toEqual({ 5: 5, 6: 6, 7: 7 })
@@ -136,10 +135,10 @@ test("transformObjectAsMap", () => {
 
   expect(reactions).toMatchInlineSnapshot(`
     Array [
-      Map {
-        "5" => 5,
-        "6" => 6,
-        "7" => 7,
+      Object {
+        "5": 5,
+        "6": 6,
+        "7": 7,
       },
     ]
   `)

--- a/packages/lib/test/propTransform/implicit/transformStringAsDate.test.ts
+++ b/packages/lib/test/propTransform/implicit/transformStringAsDate.test.ts
@@ -26,6 +26,11 @@ test("transformStringAsDate", () => {
     setDate(date: Date) {
       this.date = date
     }
+
+    @modelAction
+    setDateTime(time: number) {
+      this.date.setTime(time)
+    }
   }
 
   assert(_ as SnapshotInOf<M>["date"], _ as string)
@@ -39,7 +44,7 @@ test("transformStringAsDate", () => {
 
   // getter
   expect(m.date instanceof Date).toBeTruthy()
-  expect(m.date).toBe(dateNow) // same instance
+  expect(m.date).toEqual(dateNow) // not same instance, transformation will generate a new one
 
   // should be cached
   expect(m.date).toBe(m.date)
@@ -72,7 +77,7 @@ test("transformStringAsDate", () => {
 
   const dateNow2 = new Date(1569524561993)
   m.setDate(dateNow2)
-  expect(m.date).toBe(dateNow2)
+  expect(m.date).toEqual(dateNow2)
   expect(m.$.date).toBe(dateNow2.toJSON())
 
   expect(actionCalls).toMatchInlineSnapshot(`
@@ -112,4 +117,8 @@ test("transformStringAsDate", () => {
 
   expect(m.date).toEqual(dateNow)
   expect(m.$.date).toBe(dateNow.toJSON())
+
+  // make sure mutations on the date object are picked up in the backed prop
+  m.setDateTime(10)
+  expect(m.$.date).toBe(new Date(10).toJSON())
 })

--- a/packages/lib/test/propTransform/implicit/transformTimestampAsDate.test.ts
+++ b/packages/lib/test/propTransform/implicit/transformTimestampAsDate.test.ts
@@ -32,6 +32,11 @@ test("transformTimestampAsDate", () => {
     setTimestamp(timestamp: number) {
       this.$.date = timestamp
     }
+
+    @modelAction
+    setDateTime(time: number) {
+      this.date.setTime(time)
+    }
   }
 
   assert(_ as SnapshotInOf<M>["date"], _ as number)
@@ -46,7 +51,7 @@ test("transformTimestampAsDate", () => {
 
   // getter
   expect(m.date instanceof Date).toBeTruthy()
-  expect(m.date).toBe(dateNow) // must be the same instance
+  expect(m.date).toEqual(dateNow) // not same instance, transformation will generate a new one
 
   // should be cached
   expect(m.date).toBe(m.date)
@@ -84,7 +89,7 @@ test("transformTimestampAsDate", () => {
   expect(timestampAsDate.dataToProp(dateNow2)).toStrictEqual(now2)
 
   m.setDate(dateNow2)
-  expect(m.date).toBe(dateNow2)
+  expect(m.date).toEqual(dateNow2)
   expect(m.$.date).toBe(now2)
 
   expect(actionCalls).toMatchInlineSnapshot(`
@@ -128,13 +133,13 @@ test("transformTimestampAsDate", () => {
   // changing the date to be the same should keep the cached value intact
   reactions.length = 0
   m.setDate(dateNow)
-  expect(m.date).toBe(dateNow)
+  expect(m.date).toEqual(dateNow)
   expect(reactions).toHaveLength(0)
 
   // changing the backed value to be the same should keep the cached value intact
   reactions.length = 0
   m.setTimestamp(now)
-  expect(m.date).toBe(dateNow)
+  expect(m.date).toEqual(dateNow)
   expect(reactions).toHaveLength(0)
 
   // changing the backed prop and trying to set the same data back should work
@@ -152,4 +157,8 @@ test("transformTimestampAsDate", () => {
       1970-01-01T00:00:10.000Z,
     ]
   `)
+
+  // make sure mutations on the date object are picked up in the backed prop
+  m.setDateTime(10)
+  expect(m.$.date).toBe(10)
 })

--- a/packages/site/src/mapsSetsDates.mdx
+++ b/packages/site/src/mapsSetsDates.mdx
@@ -49,7 +49,7 @@ model.$.myNumberMap // the backed Record<string, number>, same as in the snapsho
 
 ### `prop_mapArray` / `tProp_mapArray`
 
-A map backed by a [string, VALUE] array.
+A map backed by a [string, VALUE] array. The array must not include duplicate keys.
 
 Note that, currently, since the backed property is actually an array the following operations will be slower than usual:
 
@@ -75,7 +75,7 @@ model.$.myNumberMap // the backed [string, number][], same as in the snapshot
 
 ### `prop_setArray` / `tProp_setArray`
 
-A set backed by an array.
+A set backed by an array. The array must not include duplicate values.
 
 Note that, currently, since the backed property is actually an array the following operations will be slower than usual:
 

--- a/packages/site/src/mapsSetsDates.mdx
+++ b/packages/site/src/mapsSetsDates.mdx
@@ -28,6 +28,8 @@ Although `mobx-keystone` doesn't support properties which are Maps/Sets/Dates di
 
 A map backed by an object with string keys.
 
+Since the backed property is an object operations should be as fast as usual.
+
 ```ts
 class ... extends Model({
   // without type checking
@@ -47,7 +49,12 @@ model.$.myNumberMap // the backed Record<string, number>, same as in the snapsho
 
 ### `prop_mapArray` / `tProp_mapArray`
 
-A map backed by a [string, VALUE] array. Note that, currently, since the backed property is actually an array lookups will need to iterate over all array items.
+A map backed by a [string, VALUE] array.
+
+Note that, currently, since the backed property is actually an array the following operations will be slower than usual:
+
+- `set` operations will need to iterate the backed array until the item to update is found.
+- `delete` operations will need to iterate the backed array until the item to be deleted is found.
 
 ```ts
 class ... extends Model({
@@ -68,7 +75,11 @@ model.$.myNumberMap // the backed [string, number][], same as in the snapshot
 
 ### `prop_setArray` / `tProp_setArray`
 
-A set backed by an array. Note that, currently, since the backed property is actually an array lookups will need to iterate over all array items.
+A set backed by an array.
+
+Note that, currently, since the backed property is actually an array the following operations will be slower than usual:
+
+- `delete` operations will need to iterate the backed array until it finds the value to be deleted.
 
 ```ts
 class ... extends Model({


### PR DESCRIPTION
- When using date transforms, mutation made by methods (`setTime`, etc.) are reflected in the backed property (string / timestamp), so it is no longer required to treat dates as immutable objects.
- Performance improvements for implicit property transform collections.
