### PR TITLE
setterAction, applySet, applyCall, applyDelete

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Change Log
 
+- Added the model property option `setterAction` so that it automatically implenents model prop setters wrapped in actions.
+- Added `applySet`, `applyDelete`, `applyCall` to be able manipulate data without the need to use `modelAction`.
+
 ## 0.41.0
 
 - When using date transforms, mutation made by methods (`setTime`, etc.) are reflected in the backed property (string / timestamp), so it is no longer required to treat dates as immutable objects.

--- a/packages/lib/package.json
+++ b/packages/lib/package.json
@@ -60,7 +60,7 @@
     "fast-deep-equal": "^3.1.1",
     "ts-toolbelt": "^6.1.4",
     "tslib": "^1.10.0",
-    "uuid": "^3.3.3"
+    "uuid": "^7.0.0"
   },
   "directories": {
     "test": "test"

--- a/packages/lib/src/action/applyCall.ts
+++ b/packages/lib/src/action/applyCall.ts
@@ -1,0 +1,35 @@
+import { assertTweakedObject } from "../tweaker/core"
+import { lazy } from "../utils"
+import { BuiltInAction } from "./builtInActions"
+import { ActionContextActionType } from "./context"
+import { wrapInAction } from "./wrapInAction"
+
+type AnyFunction = (...args: any[]) => any
+
+/**
+ * Calls an object method wrapped in an action.
+ *
+ * @param node  Target object.
+ * @param methodName Method name.
+ */
+export function applyCall<O extends object, K extends keyof O, FN extends O[K]>(
+  node: O,
+  methodName: K,
+  ...args: FN extends AnyFunction ? Parameters<FN> : never
+): FN extends AnyFunction ? ReturnType<FN> : never {
+  assertTweakedObject(node, "node")
+
+  return wrappedInternalApplyCall().call(node, methodName as string | number, args)
+}
+
+/**
+ * @ignore
+ * @internal
+ */
+export function internalApplyCall(this: any, methodName: string | number, args: any[]): any {
+  return this[methodName](...args)
+}
+
+const wrappedInternalApplyCall = lazy(() =>
+  wrapInAction(BuiltInAction.ApplyCall, internalApplyCall, ActionContextActionType.Sync)
+)

--- a/packages/lib/src/action/applyDelete.ts
+++ b/packages/lib/src/action/applyDelete.ts
@@ -1,0 +1,30 @@
+import { remove } from "mobx"
+import { assertTweakedObject } from "../tweaker/core"
+import { lazy } from "../utils"
+import { BuiltInAction } from "./builtInActions"
+import { ActionContextActionType } from "./context"
+import { wrapInAction } from "./wrapInAction"
+
+/**
+ * Deletes an object field wrapped in an action.
+ *
+ * @param node  Target object.
+ * @param fieldName Field name.
+ */
+export function applyDelete<O extends object, K extends keyof O>(node: O, fieldName: K): void {
+  assertTweakedObject(node, "node")
+
+  wrappedInternalApplyDelete().call(node, fieldName as string | number)
+}
+
+/**
+ * @ignore
+ * @internal
+ */
+export function internalApplyDelete<O extends object>(this: O, fieldName: string | number): void {
+  remove(this, "" + fieldName)
+}
+
+const wrappedInternalApplyDelete = lazy(() =>
+  wrapInAction(BuiltInAction.ApplyDelete, internalApplyDelete, ActionContextActionType.Sync)
+)

--- a/packages/lib/src/action/applySet.ts
+++ b/packages/lib/src/action/applySet.ts
@@ -1,0 +1,43 @@
+import { isObservable, set } from "mobx"
+import { assertTweakedObject } from "../tweaker/core"
+import { lazy } from "../utils"
+import { BuiltInAction } from "./builtInActions"
+import { ActionContextActionType } from "./context"
+import { wrapInAction } from "./wrapInAction"
+
+/**
+ * Sets an object field wrapped in an action.
+ *
+ * @param node  Target object.
+ * @param fieldName Field name.
+ * @param value Value to set.
+ */
+export function applySet<O extends object, K extends keyof O, V extends O[K]>(
+  node: O,
+  fieldName: K,
+  value: V
+): void {
+  assertTweakedObject(node, "node")
+
+  wrappedInternalApplySet().call(node, fieldName as string | number, value)
+}
+
+/**
+ * @ignore
+ * @internal
+ */
+export function internalApplySet<O extends object>(
+  this: O,
+  fieldName: string | number,
+  value: any
+): void {
+  if (isObservable(this)) {
+    set(this, fieldName, value)
+  } else {
+    ;(this as any)[fieldName] = value
+  }
+}
+
+const wrappedInternalApplySet = lazy(() =>
+  wrapInAction(BuiltInAction.ApplySet, internalApplySet, ActionContextActionType.Sync)
+)

--- a/packages/lib/src/action/builtInActions.ts
+++ b/packages/lib/src/action/builtInActions.ts
@@ -14,6 +14,18 @@ export enum BuiltInAction {
    * detach
    */
   Detach = "$$detach",
+  /**
+   * applySet
+   */
+  ApplySet = "$$applySet",
+  /**
+   * applyDelete
+   */
+  ApplyDelete = "$$applyDelete",
+  /**
+   * applyCall
+   */
+  ApplyCall = "$$applyCall",
 }
 
 const builtInActionValues = new Set(Object.values(BuiltInAction))

--- a/packages/lib/src/action/index.ts
+++ b/packages/lib/src/action/index.ts
@@ -1,4 +1,7 @@
 export * from "./applyAction"
+export * from "./applyCall"
+export * from "./applyDelete"
+export * from "./applySet"
 export * from "./builtInActions"
 export * from "./context"
 export * from "./hookActions"

--- a/packages/lib/src/actionMiddlewares/utils.ts
+++ b/packages/lib/src/actionMiddlewares/utils.ts
@@ -1,3 +1,4 @@
+import { modelIdKey } from "../model/metadata"
 import { isModel } from "../model/utils"
 import { RootPath } from "../parent/path"
 import { Path } from "../parent/pathTypes"
@@ -10,7 +11,7 @@ export function rootPathToTargetPathIds(rootPath: RootPath<any>): (string | null
 
   for (let i = 0; i < rootPath.path.length; i++) {
     const targetObj = rootPath.pathObjects[i + 1] // first is root, we don't care about its ID
-    const targetObjId = isModel(targetObj) ? targetObj.$modelId : null
+    const targetObjId = isModel(targetObj) ? targetObj[modelIdKey] : null
     targetPathIds.push(targetObjId)
   }
 
@@ -26,7 +27,7 @@ export function pathToTargetPathIds(root: any, path: Path): (string | null)[] {
 
   for (let i = 0; i < path.length; i++) {
     current = current[path[i]]
-    const targetObjId = isModel(current) ? current.$modelId : null
+    const targetObjId = isModel(current) ? current[modelIdKey] : null
     targetPathIds.push(targetObjId)
   }
 

--- a/packages/lib/src/globalConfig/globalConfig.ts
+++ b/packages/lib/src/globalConfig/globalConfig.ts
@@ -1,4 +1,4 @@
-import uuidv4 from "uuid/v4"
+import { v4 as uuidv4 } from "uuid"
 import { failure, inDevMode } from "../utils"
 import { toBase64 } from "../utils/toBase64"
 
@@ -101,7 +101,10 @@ function shortenUuid(uuid: string): string {
 
   // convert to base64
   const hexMatch = hex.match(/\w{2}/g)!
-  const str = String.fromCharCode.apply(null, hexMatch.map(a => parseInt(a, 16)))
+  const str = String.fromCharCode.apply(
+    null,
+    hexMatch.map(a => parseInt(a, 16))
+  )
 
   return toBase64(str)
 }

--- a/packages/lib/src/model/modelPropsInfo.ts
+++ b/packages/lib/src/model/modelPropsInfo.ts
@@ -1,0 +1,31 @@
+import { AnyModel, ModelClass } from "./BaseModel"
+import { ModelProps } from "./prop"
+
+const modelPropertiesSymbol = Symbol("modelProperties")
+
+/**
+ * @ignore
+ * @internal
+ *
+ * Gets the info related to a model class properties.
+ *
+ * @param modelClass
+ */
+export function getInternalModelClassPropsInfo(modelClass: ModelClass<AnyModel>): ModelProps {
+  return (modelClass as any)[modelPropertiesSymbol]
+}
+
+/**
+ * @ignore
+ * @internal
+ *
+ * Sets the info related to a model class properties.
+ *
+ * @param modelClass
+ */
+export function setInternalModelClassPropsInfo(
+  modelClass: ModelClass<AnyModel>,
+  props: ModelProps
+): void {
+  ;(modelClass as any)[modelPropertiesSymbol] = props
+}

--- a/packages/lib/src/model/modelSymbols.ts
+++ b/packages/lib/src/model/modelSymbols.ts
@@ -1,4 +1,3 @@
-export const modelPropertiesSymbol = Symbol("modelProperties")
 export const modelDataTypeCheckerSymbol = Symbol("modelDataTypeChecker")
 export const modelInitializersSymbol = Symbol("modelInitializers")
 export const modelUnwrappedClassSymbol = Symbol("modelUnwrappedClass")

--- a/packages/lib/src/model/newModel.ts
+++ b/packages/lib/src/model/newModel.ts
@@ -8,8 +8,9 @@ import { AnyModel, ModelClass, ModelPropsCreationData } from "./BaseModel"
 import { getModelDataType } from "./getModelDataType"
 import { modelIdKey, modelTypeKey } from "./metadata"
 import { modelInfoByClass } from "./modelInfo"
-import { modelInitializersSymbol, modelPropertiesSymbol } from "./modelSymbols"
-import { ModelProps, noDefaultValue } from "./prop"
+import { getInternalModelClassPropsInfo } from "./modelPropsInfo"
+import { modelInitializersSymbol } from "./modelSymbols"
+import { noDefaultValue } from "./prop"
 import { assertIsModelClass } from "./utils"
 
 /**
@@ -69,7 +70,7 @@ export const internalNewModel = action(
     modelObj[modelTypeKey] = modelInfo.name
 
     // fill in defaults in initial data
-    const modelProps: ModelProps = (modelClass as any)[modelPropertiesSymbol]
+    const modelProps = getInternalModelClassPropsInfo(modelClass)
     const modelPropsKeys = Object.keys(modelProps)
     for (let i = 0; i < modelPropsKeys.length; i++) {
       const k = modelPropsKeys[i]

--- a/packages/lib/src/parent/coreObjectChildren.ts
+++ b/packages/lib/src/parent/coreObjectChildren.ts
@@ -1,5 +1,6 @@
 import { action, createAtom, IAtom, observable, ObservableSet } from "mobx"
 import { AnyModel } from "../model/BaseModel"
+import { modelIdKey, modelTypeKey } from "../model/metadata"
 import { isModel } from "../model/utils"
 import { fastGetParent } from "./path"
 
@@ -58,7 +59,7 @@ function addNodeToDeepLists(
 ) {
   deep.add(node)
   if (isModel(node)) {
-    deepByModelTypeAndId.set(byModelTypeAndIdKey(node.$modelType, node.$modelId), node)
+    deepByModelTypeAndId.set(byModelTypeAndIdKey(node[modelTypeKey], node[modelIdKey]), node)
   }
 }
 

--- a/packages/lib/src/parent/detach.ts
+++ b/packages/lib/src/parent/detach.ts
@@ -3,7 +3,7 @@ import { BuiltInAction } from "../action/builtInActions"
 import { ActionContextActionType } from "../action/context"
 import { wrapInAction } from "../action/wrapInAction"
 import { assertTweakedObject } from "../tweaker/core"
-import { failure } from "../utils"
+import { failure, lazy } from "../utils"
 import { fastGetParentPathIncludingDataObjects } from "./path"
 
 /**
@@ -17,13 +17,11 @@ import { fastGetParentPathIncludingDataObjects } from "./path"
 export function detach(node: object): void {
   assertTweakedObject(node, "node")
 
-  wrappedInternalDetach.call(node)
+  wrappedInternalDetach().call(node)
 }
 
-const wrappedInternalDetach = wrapInAction(
-  BuiltInAction.Detach,
-  internalDetach,
-  ActionContextActionType.Sync
+const wrappedInternalDetach = lazy(() =>
+  wrapInAction(BuiltInAction.Detach, internalDetach, ActionContextActionType.Sync)
 )
 
 function internalDetach(this: object): void {

--- a/packages/lib/src/parent/path.ts
+++ b/packages/lib/src/parent/path.ts
@@ -1,4 +1,5 @@
 import { computed, IComputedValue } from "mobx"
+import { modelIdKey } from "../model/metadata"
 import { isModel } from "../model/utils"
 import { assertTweakedObject } from "../tweaker/core"
 import { isArray, isObject } from "../utils"
@@ -354,7 +355,7 @@ export function resolvePathCheckingIds<T = any>(
 
     const expectedId = pathIds[i]
     if (expectedId !== skipIdChecking) {
-      const currentId = isModel(currentMaybeModel) ? currentMaybeModel.$modelId : null
+      const currentId = isModel(currentMaybeModel) ? currentMaybeModel[modelIdKey] : null
       if (expectedId !== currentId) {
         return { resolved: false }
       }

--- a/packages/lib/src/patch/applyPatches.ts
+++ b/packages/lib/src/patch/applyPatches.ts
@@ -7,7 +7,7 @@ import { PathElement } from "../parent/pathTypes"
 import { Patch } from "../patch/Patch"
 import { reconcileSnapshot } from "../snapshot/reconcileSnapshot"
 import { assertTweakedObject } from "../tweaker/core"
-import { failure, inDevMode, isArray } from "../utils"
+import { failure, inDevMode, isArray, lazy } from "../utils"
 import { ModelPool } from "../utils/ModelPool"
 
 /**
@@ -28,7 +28,7 @@ export function applyPatches(
     return
   }
 
-  wrappedInternalApplyPatches.call(node, patches, reverse)
+  wrappedInternalApplyPatches().call(node, patches, reverse)
 }
 
 /**
@@ -72,10 +72,8 @@ export function internalApplyPatches(
   }
 }
 
-const wrappedInternalApplyPatches = wrapInAction(
-  BuiltInAction.ApplyPatches,
-  internalApplyPatches,
-  ActionContextActionType.Sync
+const wrappedInternalApplyPatches = lazy(() =>
+  wrapInAction(BuiltInAction.ApplyPatches, internalApplyPatches, ActionContextActionType.Sync)
 )
 
 function applySinglePatch(obj: object, patch: Patch, modelPool: ModelPool): void {

--- a/packages/lib/src/snapshot/applySnapshot.ts
+++ b/packages/lib/src/snapshot/applySnapshot.ts
@@ -7,7 +7,7 @@ import { modelIdKey, modelTypeKey } from "../model/metadata"
 import { getModelInfoForName } from "../model/modelInfo"
 import { isModel, isModelSnapshot } from "../model/utils"
 import { assertTweakedObject } from "../tweaker/core"
-import { assertIsObject, failure, inDevMode, isArray, isPlainObject } from "../utils"
+import { assertIsObject, failure, inDevMode, isArray, isPlainObject, lazy } from "../utils"
 import { ModelPool } from "../utils/ModelPool"
 import { reconcileSnapshot } from "./reconcileSnapshot"
 import { SnapshotOutOf } from "./SnapshotOf"
@@ -23,7 +23,7 @@ export function applySnapshot<T extends object>(node: T, snapshot: SnapshotOutOf
   assertTweakedObject(node, "node")
   assertIsObject(snapshot, "snapshot")
 
-  wrappedInternalApplySnapshot.call(node, snapshot)
+  wrappedInternalApplySnapshot().call(node, snapshot)
 }
 
 function internalApplySnapshot<T extends object>(this: T, sn: SnapshotOutOf<T>): void {
@@ -96,8 +96,6 @@ function internalApplySnapshot<T extends object>(this: T, sn: SnapshotOutOf<T>):
   throw failure(`unsupported snapshot - ${sn}`)
 }
 
-const wrappedInternalApplySnapshot = wrapInAction(
-  BuiltInAction.ApplySnapshot,
-  internalApplySnapshot,
-  ActionContextActionType.Sync
+const wrappedInternalApplySnapshot = lazy(() =>
+  wrapInAction(BuiltInAction.ApplySnapshot, internalApplySnapshot, ActionContextActionType.Sync)
 )

--- a/packages/lib/src/snapshot/reconcileSnapshot.ts
+++ b/packages/lib/src/snapshot/reconcileSnapshot.ts
@@ -203,7 +203,10 @@ function detachIfNeeded(newValue: any, oldValue: any, modelPool: ModelPool) {
     return
   }
 
-  if (isModel(newValue) && modelPool.findModelByTypeAndId(newValue.$modelType, newValue.$modelId)) {
+  if (
+    isModel(newValue) &&
+    modelPool.findModelByTypeAndId(newValue[modelTypeKey], newValue[modelIdKey])
+  ) {
     const parentPath = fastGetParentPathIncludingDataObjects(newValue)
     if (parentPath) {
       set(parentPath.parent, parentPath.path, null)

--- a/packages/lib/src/typeChecking/model.ts
+++ b/packages/lib/src/typeChecking/model.ts
@@ -2,8 +2,8 @@ import { O } from "ts-toolbelt"
 import { AnyModel, ModelClass } from "../model/BaseModel"
 import { getModelDataType } from "../model/getModelDataType"
 import { modelInfoByClass } from "../model/modelInfo"
-import { modelPropertiesSymbol } from "../model/modelSymbols"
-import { ModelProps, noDefaultValue } from "../model/prop"
+import { getInternalModelClassPropsInfo } from "../model/modelPropsInfo"
+import { noDefaultValue } from "../model/prop"
 import { assertIsModelClass, isModelClass } from "../model/utils"
 import { failure, lateVal } from "../utils"
 import { resolveTypeChecker } from "./resolveTypeChecker"
@@ -101,7 +101,7 @@ export interface ModelTypeInfoProps {
  */
 export class ModelTypeInfo extends TypeInfo {
   private _props = lateVal(() => {
-    const objSchema: ModelProps = (this.modelClass as any)[modelPropertiesSymbol]
+    const objSchema = getInternalModelClassPropsInfo(this.modelClass)
 
     const propTypes: O.Writable<ModelTypeInfoProps> = {}
     Object.keys(objSchema).forEach(propName => {

--- a/packages/lib/src/utils/ModelPool.ts
+++ b/packages/lib/src/utils/ModelPool.ts
@@ -1,4 +1,5 @@
 import { AnyModel } from "../model/BaseModel"
+import { modelIdKey, modelTypeKey } from "../model/metadata"
 import { isModelSnapshot } from "../model/utils"
 import { dataObjectParent } from "../parent/core"
 import { byModelTypeAndIdKey, getDeepObjectChildren } from "../parent/coreObjectChildren"
@@ -22,6 +23,6 @@ export class ModelPool {
       return undefined
     }
 
-    return this.findModelByTypeAndId(sn.$modelType, sn.$modelId)
+    return this.findModelByTypeAndId(sn[modelTypeKey], sn[modelIdKey])
   }
 }

--- a/packages/lib/src/utils/index.ts
+++ b/packages/lib/src/utils/index.ts
@@ -312,3 +312,20 @@ export function lateVal<TF extends (...args: any[]) => any>(getter: TF): TF {
 
   return fn as TF
 }
+
+/**
+ * @ignore
+ * @internal
+ */
+export function lazy<V>(valueGen: () => V): () => V {
+  let inited = false
+  let val: V | undefined
+
+  return (): V => {
+    if (!inited) {
+      val = valueGen()
+      inited = true
+    }
+    return val!
+  }
+}

--- a/packages/lib/test/action/applyCall.test.ts
+++ b/packages/lib/test/action/applyCall.test.ts
@@ -3,9 +3,11 @@ import {
   applyAction,
   applyCall,
   BuiltInAction,
+  deserializeActionCall,
   model,
   Model,
   prop,
+  serializeActionCall,
 } from "../../src"
 import "../commonSetup"
 import { autoDispose } from "../utils"
@@ -98,12 +100,17 @@ test("applyCall", () => {
   `)
 
   // apply action should work
-  const ret = applyAction(p.arr, {
+  const act = {
     actionName: BuiltInAction.ApplyCall,
     args: ["push", 6, 7],
     targetPath: [],
     targetPathIds: [],
-  })
+  }
+
+  const serAct = serializeActionCall(act, p.arr)
+  const desAct = deserializeActionCall(serAct, p.arr)
+
+  const ret = applyAction(p.arr, desAct)
   expect(p.arr).toEqual([1, 2, 3, 4, 5, 6, 7])
   expect(ret).toBe(p.arr.length)
 })

--- a/packages/lib/test/action/applyCall.test.ts
+++ b/packages/lib/test/action/applyCall.test.ts
@@ -1,0 +1,109 @@
+import {
+  addActionMiddleware,
+  applyAction,
+  applyCall,
+  BuiltInAction,
+  model,
+  Model,
+  prop,
+} from "../../src"
+import "../commonSetup"
+import { autoDispose } from "../utils"
+
+@model("P")
+export class P extends Model({
+  arr: prop<number[]>(() => []),
+}) {}
+
+test("applyCall", () => {
+  const events: any = []
+
+  const p = new P({ arr: [1, 2, 3] })
+
+  autoDispose(
+    addActionMiddleware({
+      subtreeRoot: p,
+      middleware(ctx, next) {
+        events.push({
+          event: "action started",
+          ctx,
+        })
+        const result = next()
+        events.push({
+          event: "action finished",
+          ctx,
+          result,
+        })
+        return result
+      },
+    })
+  )
+  expect(events.length).toBe(0)
+
+  expect(applyCall(p.arr, "push", 4, 5)).toBe(p.arr.length)
+  expect(p.arr).toEqual([1, 2, 3, 4, 5])
+
+  expect(events).toMatchInlineSnapshot(`
+    Array [
+      Object {
+        "ctx": Object {
+          "actionName": "$$applyCall",
+          "args": Array [
+            "push",
+            Array [
+              4,
+              5,
+            ],
+          ],
+          "data": Object {},
+          "parentContext": undefined,
+          "rootContext": [Circular],
+          "target": Array [
+            1,
+            2,
+            3,
+            4,
+            5,
+          ],
+          "type": "sync",
+        },
+        "event": "action started",
+      },
+      Object {
+        "ctx": Object {
+          "actionName": "$$applyCall",
+          "args": Array [
+            "push",
+            Array [
+              4,
+              5,
+            ],
+          ],
+          "data": Object {},
+          "parentContext": undefined,
+          "rootContext": [Circular],
+          "target": Array [
+            1,
+            2,
+            3,
+            4,
+            5,
+          ],
+          "type": "sync",
+        },
+        "event": "action finished",
+        "result": 5,
+      },
+    ]
+  `)
+
+  // apply action should work
+  const ret = applyAction(p.arr, {
+    actionName: BuiltInAction.ApplyCall,
+    args: ["push", 6, 7],
+    targetPath: [],
+    targetPathIds: [],
+  })
+  expect(p.arr).toEqual([1, 2, 3, 4, 5, 6, 7])
+  expect(ret).toBe(p.arr.length)
+})

--- a/packages/lib/test/action/applyDelete.test.ts
+++ b/packages/lib/test/action/applyDelete.test.ts
@@ -1,0 +1,99 @@
+import {
+  addActionMiddleware,
+  applyAction,
+  applyDelete,
+  BuiltInAction,
+  model,
+  Model,
+  prop,
+} from "../../src"
+import "../commonSetup"
+import { autoDispose } from "../utils"
+
+@model("P")
+export class P extends Model({
+  obj: prop<{ [k: string]: number } | undefined>(undefined),
+}) {}
+
+test("applyDelete", () => {
+  const events: any = []
+
+  const p = new P({ obj: { a: 1, b: 2 } })
+
+  autoDispose(
+    addActionMiddleware({
+      subtreeRoot: p,
+      middleware(ctx, next) {
+        events.push({
+          event: "action started",
+          ctx,
+        })
+        const result = next()
+        events.push({
+          event: "action finished",
+          ctx,
+          result,
+        })
+        return result
+      },
+    })
+  )
+  expect(events.length).toBe(0)
+
+  expect(p.obj!.a).toBe(1)
+  expect(p.obj!.b).toBe(2)
+  expect(Object.keys(p.obj!)).toEqual(["a", "b"])
+  applyDelete(p.obj!, "a")
+  expect(p.obj!.a).toBe(undefined)
+  expect(p.obj!.b).toBe(2)
+  expect(Object.keys(p.obj!)).toEqual(["b"])
+
+  expect(events).toMatchInlineSnapshot(`
+    Array [
+      Object {
+        "ctx": Object {
+          "actionName": "$$applyDelete",
+          "args": Array [
+            "a",
+          ],
+          "data": Object {},
+          "parentContext": undefined,
+          "rootContext": [Circular],
+          "target": Object {
+            "b": 2,
+          },
+          "type": "sync",
+        },
+        "event": "action started",
+      },
+      Object {
+        "ctx": Object {
+          "actionName": "$$applyDelete",
+          "args": Array [
+            "a",
+          ],
+          "data": Object {},
+          "parentContext": undefined,
+          "rootContext": [Circular],
+          "target": Object {
+            "b": 2,
+          },
+          "type": "sync",
+        },
+        "event": "action finished",
+        "result": undefined,
+      },
+    ]
+  `)
+
+  // apply action should work
+  applyAction(p.obj!, {
+    actionName: BuiltInAction.ApplyDelete,
+    args: ["b"],
+    targetPath: [],
+    targetPathIds: [],
+  })
+
+  expect(p.obj!.b).toBe(undefined)
+  expect(Object.keys(p.obj!)).toEqual([])
+})

--- a/packages/lib/test/action/applySet.test.ts
+++ b/packages/lib/test/action/applySet.test.ts
@@ -1,0 +1,210 @@
+import {
+  addActionMiddleware,
+  applyAction,
+  applySet,
+  BuiltInAction,
+  model,
+  Model,
+  prop,
+} from "../../src"
+import "../commonSetup"
+import { autoDispose } from "../utils"
+
+@model("P")
+export class P extends Model({
+  y: prop(0),
+  ch: prop<P | undefined>(undefined),
+  obj: prop<{ [k: string]: number } | undefined>(undefined),
+}) {}
+
+test("applySet", () => {
+  const events: any = []
+
+  const p = new P({})
+
+  autoDispose(
+    addActionMiddleware({
+      subtreeRoot: p,
+      middleware(ctx, next) {
+        events.push({
+          event: "action started",
+          ctx,
+        })
+        const result = next()
+        events.push({
+          event: "action finished",
+          ctx,
+          result,
+        })
+        return result
+      },
+    })
+  )
+  expect(events.length).toBe(0)
+
+  applySet(p, "y", 5)
+  expect(p.y).toBe(5)
+
+  expect(events).toMatchInlineSnapshot(`
+    Array [
+      Object {
+        "ctx": Object {
+          "actionName": "$$applySet",
+          "args": Array [
+            "y",
+            5,
+          ],
+          "data": Object {},
+          "parentContext": undefined,
+          "rootContext": [Circular],
+          "target": P {
+            "$": Object {
+              "ch": undefined,
+              "obj": undefined,
+              "y": 5,
+            },
+            "$modelType": "P",
+          },
+          "type": "sync",
+        },
+        "event": "action started",
+      },
+      Object {
+        "ctx": Object {
+          "actionName": "$$applySet",
+          "args": Array [
+            "y",
+            5,
+          ],
+          "data": Object {},
+          "parentContext": undefined,
+          "rootContext": [Circular],
+          "target": P {
+            "$": Object {
+              "ch": undefined,
+              "obj": undefined,
+              "y": 5,
+            },
+            "$modelType": "P",
+          },
+          "type": "sync",
+        },
+        "event": "action finished",
+        "result": undefined,
+      },
+    ]
+  `)
+
+  // apply action should work
+  applyAction(p, {
+    actionName: BuiltInAction.ApplySet,
+    args: ["y", 3],
+    targetPath: [],
+    targetPathIds: [],
+  })
+
+  expect(p.y).toBe(3)
+
+  // complex props
+  events.length = 0
+  const p2 = new P({ y: 1 })
+  applySet(p, "ch", p2)
+  expect(p.ch).toBe(p2)
+  expect(events).toMatchInlineSnapshot(`
+    Array [
+      Object {
+        "ctx": Object {
+          "actionName": "$$applySet",
+          "args": Array [
+            "ch",
+            P {
+              "$": Object {
+                "ch": undefined,
+                "obj": undefined,
+                "y": 1,
+              },
+              "$modelType": "P",
+            },
+          ],
+          "data": Object {},
+          "parentContext": undefined,
+          "rootContext": [Circular],
+          "target": P {
+            "$": Object {
+              "ch": P {
+                "$": Object {
+                  "ch": undefined,
+                  "obj": undefined,
+                  "y": 1,
+                },
+                "$modelType": "P",
+              },
+              "obj": undefined,
+              "y": 3,
+            },
+            "$modelType": "P",
+          },
+          "type": "sync",
+        },
+        "event": "action started",
+      },
+      Object {
+        "ctx": Object {
+          "actionName": "$$applySet",
+          "args": Array [
+            "ch",
+            P {
+              "$": Object {
+                "ch": undefined,
+                "obj": undefined,
+                "y": 1,
+              },
+              "$modelType": "P",
+            },
+          ],
+          "data": Object {},
+          "parentContext": undefined,
+          "rootContext": [Circular],
+          "target": P {
+            "$": Object {
+              "ch": P {
+                "$": Object {
+                  "ch": undefined,
+                  "obj": undefined,
+                  "y": 1,
+                },
+                "$modelType": "P",
+              },
+              "obj": undefined,
+              "y": 3,
+            },
+            "$modelType": "P",
+          },
+          "type": "sync",
+        },
+        "event": "action finished",
+        "result": undefined,
+      },
+    ]
+  `)
+
+  const p3 = new P({ y: 2 })
+  applyAction(p, {
+    actionName: BuiltInAction.ApplySet,
+    args: ["ch", p3],
+    targetPath: [],
+    targetPathIds: [],
+  })
+
+  expect(p.ch).toBe(p3)
+
+  // check it also works over plain objs
+  applySet(p, "obj", { a: 1 })
+  expect(p.obj!.a).toBe(1)
+
+  applySet(p.obj!, "a", 2)
+  expect(p.obj!.a).toBe(2)
+
+  applySet(p.obj!, "b", 3)
+  expect(p.obj!.b).toBe(3)
+})

--- a/packages/lib/test/model/setterAction.test.ts
+++ b/packages/lib/test/model/setterAction.test.ts
@@ -1,0 +1,137 @@
+import { addActionMiddleware, model, Model, modelAction, prop } from "../../src"
+import "../commonSetup"
+import { autoDispose } from "../utils"
+
+@model("P")
+export class P extends Model({
+  y: prop(0, { setterAction: true }),
+}) {
+  @modelAction
+  setY(n: number) {
+    this.y = n
+  }
+}
+
+test("setterAction", () => {
+  const events: any = []
+
+  const p = new P({})
+
+  autoDispose(
+    addActionMiddleware({
+      subtreeRoot: p,
+      middleware(ctx, next) {
+        events.push({
+          event: "action started",
+          ctx,
+        })
+        const result = next()
+        events.push({
+          event: "action finished",
+          ctx,
+          result,
+        })
+        return result
+      },
+    })
+  )
+  expect(events.length).toBe(0)
+
+  p.y = 5
+  expect(p.y).toBe(5)
+
+  expect(events).toMatchInlineSnapshot(`
+    Array [
+      Object {
+        "ctx": Object {
+          "actionName": "$$applySet",
+          "args": Array [
+            "y",
+            5,
+          ],
+          "data": Object {},
+          "parentContext": undefined,
+          "rootContext": [Circular],
+          "target": P {
+            "$": Object {
+              "y": 5,
+            },
+            "$modelType": "P",
+          },
+          "type": "sync",
+        },
+        "event": "action started",
+      },
+      Object {
+        "ctx": Object {
+          "actionName": "$$applySet",
+          "args": Array [
+            "y",
+            5,
+          ],
+          "data": Object {},
+          "parentContext": undefined,
+          "rootContext": [Circular],
+          "target": P {
+            "$": Object {
+              "y": 5,
+            },
+            "$modelType": "P",
+          },
+          "type": "sync",
+        },
+        "event": "action finished",
+        "result": undefined,
+      },
+    ]
+  `)
+  events.length = 0
+
+  // check that it is not wrapped in action when used inside an action already
+  p.setY(10)
+  expect(p.y).toBe(10)
+  expect(events).toMatchInlineSnapshot(`
+    Array [
+      Object {
+        "ctx": Object {
+          "actionName": "setY",
+          "args": Array [
+            10,
+          ],
+          "data": Object {},
+          "parentContext": undefined,
+          "rootContext": [Circular],
+          "target": P {
+            "$": Object {
+              "y": 10,
+            },
+            "$modelType": "P",
+          },
+          "type": "sync",
+        },
+        "event": "action started",
+      },
+      Object {
+        "ctx": Object {
+          "actionName": "setY",
+          "args": Array [
+            10,
+          ],
+          "data": Object {},
+          "parentContext": undefined,
+          "rootContext": [Circular],
+          "target": P {
+            "$": Object {
+              "y": 10,
+            },
+            "$modelType": "P",
+          },
+          "type": "sync",
+        },
+        "event": "action finished",
+        "result": undefined,
+      },
+    ]
+  `)
+  events.length = 0
+})

--- a/packages/site/package.json
+++ b/packages/site/package.json
@@ -16,7 +16,7 @@
     "react-dom": "^16.10.2",
     "react-feather": "^2.0.3",
     "remotedev": "^0.2.9",
-    "uuid": "^3.3.2"
+    "uuid": "^7.0.0"
   },
   "devDependencies": {
     "@babel/plugin-proposal-decorators": "^7.7.4",

--- a/packages/site/package.json
+++ b/packages/site/package.json
@@ -22,7 +22,7 @@
     "@babel/plugin-proposal-decorators": "^7.7.4",
     "@types/react": "^16.9.5",
     "@types/react-dom": "^16.9.1",
-    "@types/uuid": "^3.4.5",
+    "@types/uuid": "^7.0.0",
     "raw-loader": "^4.0.0",
     "typescript": "^3.6.3"
   }

--- a/packages/site/src/examples/todoList/store.ts
+++ b/packages/site/src/examples/todoList/store.ts
@@ -10,7 +10,7 @@ import {
   tProp,
   types,
 } from "mobx-keystone"
-import uuid from "uuid"
+import { v4 as uuidv4 } from "uuid"
 
 // for this example we will enable runtime data checking even in production mode
 setGlobalConfig({
@@ -25,12 +25,12 @@ export class Todo extends Model({
   // and also part of the required initialization data of the model
 
   // in this case we use runtime type checking,
-  id: tProp(types.string, () => uuid.v4()), // an optional string that will use a random id when not provided
+  id: tProp(types.string, () => uuidv4()), // an optional string that will use a random id when not provided
   text: tProp(types.string), // a required string
   done: tProp(types.boolean, false), // an optional boolean that will default to false
 
   // if we didn't require runtime type checking we could do this
-  // id: prop(() => uuid.v4())
+  // id: prop(() => uuidv4())
   // text: prop<string>(),
   // done: prop(false)
 }) {

--- a/packages/site/src/examples/todoList/store.ts.txt
+++ b/packages/site/src/examples/todoList/store.ts.txt
@@ -10,7 +10,7 @@ import {
   tProp,
   types,
 } from "mobx-keystone"
-import uuid from "uuid"
+import { v4 as uuidv4 } from "uuid"
 
 // for this example we will enable runtime data checking even in production mode
 setGlobalConfig({
@@ -25,12 +25,12 @@ export class Todo extends Model({
   // and also part of the required initialization data of the model
 
   // in this case we use runtime type checking,
-  id: tProp(types.string, () => uuid.v4()), // an optional string that will use a random id when not provided
+  id: tProp(types.string, () => uuidv4()), // an optional string that will use a random id when not provided
   text: tProp(types.string), // a required string
   done: tProp(types.boolean, false), // an optional boolean that will default to false
 
   // if we didn't require runtime type checking we could do this
-  // id: prop(() => uuid.v4())
+  // id: prop(() => uuidv4())
   // text: prop<string>(),
   // done: prop(false)
 }) {

--- a/packages/site/src/models.mdx
+++ b/packages/site/src/models.mdx
@@ -61,15 +61,15 @@ Note that there are several ways to define properties.
 
 Without runtime type checking:
 
-- `prop<T>()` - A property of a given type, with no default set if it is `null` or `undefined` in the initial data.
-- `prop<T>(defaultValue: T)` - A property of a given type, with a default set if it is `null` or `undefined` in the initial data. Use this only for default primitives.
-- `prop<T>(defaultFn: () => T)` - A property of a given type, with a default value generator if it is `null` or `undefined` in the initial data. Usually used for default objects / arrays / models.
+- `prop<T>(options?: ModelOptions)` - A property of a given type, with no default set if it is `null` or `undefined` in the initial data.
+- `prop<T>(defaultValue: T, options?: ModelOptions)` - A property of a given type, with a default set if it is `null` or `undefined` in the initial data. Use this only for default primitives.
+- `prop<T>(defaultFn: () => T, options?: ModelOptions)` - A property of a given type, with a default value generator if it is `null` or `undefined` in the initial data. Usually used for default objects / arrays / models.
 
 With runtime type checking (check the relevant section for more info):
 
-- `tProp(type)` - A property of a given runtime checked type, with no default set if it is `null` or `undefined` in the initial data.
-- `tProp<T>(type, defaultValue: T)` - A property of a given runtime checked type, with a default set if it is `null` or `undefined` in the initial data. Use this only for default primitives.
-- `tProp<T>(type, defaultFn: () => T)` - A property of a given runtime checked type, with a default value generator if it is `null` or `undefined` in the initial data. Usually used for default objects / arrays / models.
+- `tProp(type, options?: ModelOptions)` - A property of a given runtime checked type, with no default set if it is `null` or `undefined` in the initial data.
+- `tProp<T>(type, defaultValue: T, options?: ModelOptions)` - A property of a given runtime checked type, with a default set if it is `null` or `undefined` in the initial data. Use this only for default primitives.
+- `tProp<T>(type, defaultFn: () => T, options?: ModelOptions)` - A property of a given runtime checked type, with a default value generator if it is `null` or `undefined` in the initial data. Usually used for default objects / arrays / models.
 
 ## Model rules
 
@@ -92,6 +92,41 @@ const myTodo1 = new Todo({ done: true, text: "buy some milk" })
 // note how `done` can be skipped since it was declared with a default value
 const myTodo2 = new Todo({ text: "buy some coffee" })
 ```
+
+## Automatic model actions for property setters
+
+Since most of the times the only action we need for a property is a setter we can use the model option `setterAction` to reduce boilerplace and allow setting properties as if they were wrapped in a `modelAction`. For example, the model above could be written as:
+
+```ts
+@model("myCoolApp/Todo")
+export class Todo extends Model({
+  text: prop<string>({ setterAction: true }),
+  done: prop(false, { setterAction: true }),
+}) {}
+
+const myTodo = new Todo({ text: "buy some coffee" })
+
+// this is now allowed and properly wrapped in two respective actions
+myTodo.text = "buy some milk"
+myTodo.done = true
+```
+
+Note however that this does not apply when setting the properties under `$`, sub-objects or array methods. For example, these would still require a `modelAction`:
+
+```ts
+// all these will throw
+
+myTodo.$.text = "buy some milk"
+myTodo.$.done = true
+
+// given someObject uses setterAction
+myTodo.someObject.foo = ...
+
+// given someArray uses setterAction
+myTodo.someArray.push(...)
+```
+
+If for some reason you still require to change these without using a `modelAction` consider using `applySet`, `applyDelete` and/or `applyCall` if needed.
 
 ## Life-cycle event hooks
 

--- a/packages/site/src/treeLikeStructure.mdx
+++ b/packages/site/src/treeLikeStructure.mdx
@@ -143,7 +143,7 @@ The mode can be one of:
 
 ## Utility methods
 
-### `detach(value: object)`
+### `detach(value: object): void`
 
 Besides the aforementioned `isTreeNode` and `toTreeNode` methods, there's also the `detach(value: object)` method, which allows a node to get detached from its parent following this logic:
 
@@ -162,6 +162,30 @@ The optional `options` parameter accepts and object with the following options:
 - `fireForCurrentChildren: boolean` (default: `true`) - `true` if the callback should be immediately called for currently attached children, `false` if only for future attachments.
 
 Returns a disposer, which has a boolean parameter which should be `true` if pending detachment callbacks should be run, or `false` otherwise.
+
+### `applySet<O extends object, K extends keyof O, V extends O[K]>(node: O, fieldName: K, value: V): void`
+
+Allows setting an object/model field / array index to a given value without the need to wrap it in `modelAction`. Unlike `runUnprotected`, these is actually an action that can be captured and replicated.
+
+```ts
+applySet(someModel, "prop", "value")
+```
+
+### `applyDelete<O extends object, K extends keyof O>(node: O, fieldName: K): void`
+
+Allows deleting an object field / array index without the need to wrap it in `modelAction`. Unlike `runUnprotected`, these is actually an action that can be captured and replicated.
+
+```ts
+applyDelete(someObject, "field")
+```
+
+### `applyCall<O extends object, K extends keyof O, FN extends O[K]>(node: O, methodName: K, ..args: Parameters<FN> : ReturnType<FN>`
+
+Allows calling an model/object/array method without the need to wrap it in `modelAction`. Unlike `runUnprotected`, these is actually an action that can be captured and replicated.
+
+```ts
+const newArrayLength = applyCall(someArray, "push", 1, 2, 3)
+```
 
 ### `deepEquals(a: any, b: any): boolean`
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -2770,9 +2770,9 @@
     "@types/react" "*"
 
 "@types/react@*", "@types/react@^16.9.5":
-  version "16.9.21"
-  resolved "https://registry.yarnpkg.com/@types/react/-/react-16.9.21.tgz#99e274e2ecfab6bb93920e918341daa3198b348d"
-  integrity sha512-xpmenCMeBwJRct8vmIfczlgdOXWIWASoOM857kxKfHlVQvDltRh7IFRVfGws79iO2jkNPXOeWREyKoClzhBaQA==
+  version "16.9.22"
+  resolved "https://registry.yarnpkg.com/@types/react/-/react-16.9.22.tgz#f0288c92d94e93c4b43e3f5633edf788b2c040ae"
+  integrity sha512-7OSt4EGiLvy0h5R7X+r0c7S739TCU/LvWbkNOrm10lUwNHe7XPz5OLhLOSZeCkqO9JSCly1NkYJ7ODTUqVnHJQ==
   dependencies:
     "@types/prop-types" "*"
     csstype "^2.2.0"
@@ -18766,6 +18766,11 @@ uuid@^3.0.0, uuid@^3.0.1, uuid@^3.3.2, uuid@^3.3.3, uuid@^3.4.0:
   version "3.4.0"
   resolved "https://registry.yarnpkg.com/uuid/-/uuid-3.4.0.tgz#b23e4358afa8a202fe7a100af1f5f883f02007ee"
   integrity sha512-HjSDRw6gZE5JMggctHBcjVak08+KEVhSIiDzFnT9S9aegmp85S/bReBVTb4QTFaRNptJ9kuYaNhnbNEOkbKb/A==
+
+uuid@^7.0.0:
+  version "7.0.0"
+  resolved "https://registry.yarnpkg.com/uuid/-/uuid-7.0.0.tgz#1833d4b9ce50b732bfaa271f9cb74e974d303c79"
+  integrity sha512-LNUrNsXdI/fUsypJbWM8Jt4DgQdFAZh41p9C7WE9Cn+CULOEkoG2lgQyH68v3wnIy5K3fN4jdSt270K6IFA3MQ==
 
 v8-compile-cache@^1.1.2:
   version "1.1.2"

--- a/yarn.lock
+++ b/yarn.lock
@@ -2065,12 +2065,12 @@
     glob-to-regexp "^0.3.0"
 
 "@netlify/build@^0.1.7":
-  version "0.1.67"
-  resolved "https://registry.yarnpkg.com/@netlify/build/-/build-0.1.67.tgz#9de259ba5b1296780af34d97c128109a807239c9"
-  integrity sha512-UzKO65j+YqgUGFsV1X/M4Ziu97OPT6gK1CFNln32GsB71Lhi3bb9+bzatVtPg4QDjPtyIdvgHGvKpWmjPKL+TA==
+  version "0.1.71"
+  resolved "https://registry.yarnpkg.com/@netlify/build/-/build-0.1.71.tgz#51ea62b3bc0592fe9f7b37ff3a2da9e7011c80ab"
+  integrity sha512-UOSVl1gtRPQTQlhYYrOS8f6mwGGuL95I9hqwnLl7ydkzAPO4cnA81UAeViNmzvpFnjDXoc4Kmf3daW0sZ5c5og==
   dependencies:
     "@netlify/cache-utils" "^0.2.2"
-    "@netlify/config" "^0.1.19"
+    "@netlify/config" "^0.1.21"
     "@netlify/functions-utils" "^0.1.0"
     "@netlify/git-utils" "^0.2.0"
     "@netlify/run-utils" "^0.1.0"
@@ -2127,10 +2127,10 @@
     path-exists "^4.0.0"
     readdirp "^3.3.0"
 
-"@netlify/config@^0.1.12", "@netlify/config@^0.1.19", "@netlify/config@^0.1.7":
-  version "0.1.19"
-  resolved "https://registry.yarnpkg.com/@netlify/config/-/config-0.1.19.tgz#2b8e29b74da30cd1949b361f366c581fb973d39a"
-  integrity sha512-5qHbV++i9ddZL+K+/lBub0mWeQlUl/HmazuLMqlq2ElFFd1N1ZSp93mMxAi89PlOt6hsY5a7iFQRV/EF2D9WRA==
+"@netlify/config@^0.1.12", "@netlify/config@^0.1.21":
+  version "0.1.21"
+  resolved "https://registry.yarnpkg.com/@netlify/config/-/config-0.1.21.tgz#92114fc6aa58a825b3c1f584ad4d1813e3826647"
+  integrity sha512-7q9OQe56AyQXEeR8Fpm/cCzuG/tGDHcx8suXwFXBhVA7/1t84XDldHBlgzw5O9cIlvdwy26gJi3lU+KpHmihAg==
   dependencies:
     chalk "^3.0.0"
     configorama "^0.3.6"
@@ -2354,13 +2354,13 @@
     "@octokit/types" "^2.0.0"
 
 "@octokit/endpoint@^5.5.0":
-  version "5.5.2"
-  resolved "https://registry.yarnpkg.com/@octokit/endpoint/-/endpoint-5.5.2.tgz#ed19d01fe85ac58bc2b774661658f9e5429b8164"
-  integrity sha512-ICDcRA0C2vtTZZGud1nXRrBLXZqFayodXAKZfo3dkdcLNqcHsgaz3YSTupbURusYeucSVRjjG+RTcQhx6HPPcg==
+  version "5.5.3"
+  resolved "https://registry.yarnpkg.com/@octokit/endpoint/-/endpoint-5.5.3.tgz#0397d1baaca687a4c8454ba424a627699d97c978"
+  integrity sha512-EzKwkwcxeegYYah5ukEeAI/gYRLv2Y9U5PpIsseGSFDk+G3RbipQGBs8GuYS1TLCtQaqoO66+aQGtITPalxsNQ==
   dependencies:
     "@octokit/types" "^2.0.0"
     is-plain-object "^3.0.0"
-    universal-user-agent "^4.0.0"
+    universal-user-agent "^5.0.0"
 
 "@octokit/plugin-enterprise-rest@^3.6.1":
   version "3.6.2"
@@ -2397,9 +2397,9 @@
     once "^1.4.0"
 
 "@octokit/request@^5.2.0":
-  version "5.3.1"
-  resolved "https://registry.yarnpkg.com/@octokit/request/-/request-5.3.1.tgz#3a1ace45e6f88b1be4749c5da963b3a3b4a2f120"
-  integrity sha512-5/X0AL1ZgoU32fAepTfEoggFinO3rxsMLtzhlUX+RctLrusn/CApJuGFCd0v7GMFhF+8UiCsTTfsu7Fh1HnEJg==
+  version "5.3.2"
+  resolved "https://registry.yarnpkg.com/@octokit/request/-/request-5.3.2.tgz#1ca8b90a407772a1ee1ab758e7e0aced213b9883"
+  integrity sha512-7NPJpg19wVQy1cs2xqXjjRq/RmtSomja/VSWnptfYwuBxLdbYh2UjhGi0Wx7B1v5Iw5GKhfFDQL7jM7SSp7K2g==
   dependencies:
     "@octokit/endpoint" "^5.5.0"
     "@octokit/request-error" "^1.0.1"
@@ -2408,7 +2408,7 @@
     is-plain-object "^3.0.0"
     node-fetch "^2.3.0"
     once "^1.4.0"
-    universal-user-agent "^4.0.0"
+    universal-user-agent "^5.0.0"
 
 "@octokit/rest@^16.28.1", "@octokit/rest@^16.28.4":
   version "16.43.1"
@@ -2433,9 +2433,9 @@
     universal-user-agent "^4.0.0"
 
 "@octokit/types@^2.0.0", "@octokit/types@^2.0.1":
-  version "2.1.1"
-  resolved "https://registry.yarnpkg.com/@octokit/types/-/types-2.1.1.tgz#77e80d1b663c5f1f829e5377b728fa3c4fe5a97d"
-  integrity sha512-89LOYH+d/vsbDX785NOfLxTW88GjNd0lWRz1DVPVsZgg9Yett5O+3MOvwo7iHgvUwbFz0mf/yPIjBkUbs4kxoQ==
+  version "2.2.0"
+  resolved "https://registry.yarnpkg.com/@octokit/types/-/types-2.2.0.tgz#ddb0a90cf3e9624ae97e09d16f21f4c4a682d3be"
+  integrity sha512-iEeW3XlkxeM/CObeoYvbUv24Oe+DldGofY+3QyeJ5XKKA6B+V94ePk14EDCarseWdMs6afKZPv3dFq8C+SY5lw==
   dependencies:
     "@types/node" ">= 8"
 
@@ -2718,16 +2718,17 @@
     "@types/node" "*"
 
 "@types/node-fetch@^2.1.6":
-  version "2.5.4"
-  resolved "https://registry.yarnpkg.com/@types/node-fetch/-/node-fetch-2.5.4.tgz#5245b6d8841fc3a6208b82291119bc11c4e0ce44"
-  integrity sha512-Oz6id++2qAOFuOlE1j0ouk1dzl3mmI1+qINPNBhi9nt/gVOz0G+13Ao6qjhdF0Ys+eOkhu6JnFmt38bR3H0POQ==
+  version "2.5.5"
+  resolved "https://registry.yarnpkg.com/@types/node-fetch/-/node-fetch-2.5.5.tgz#cd264e20a81f4600a6c52864d38e7fef72485e92"
+  integrity sha512-IWwjsyYjGw+em3xTvWVQi5MgYKbRs0du57klfTaZkv/B24AEQ/p/IopNeqIYNy3EsfHOpg8ieQSDomPcsYMHpA==
   dependencies:
     "@types/node" "*"
+    form-data "^3.0.0"
 
 "@types/node@*", "@types/node@>= 8":
-  version "13.7.4"
-  resolved "https://registry.yarnpkg.com/@types/node/-/node-13.7.4.tgz#76c3cb3a12909510f52e5dc04a6298cdf9504ffd"
-  integrity sha512-oVeL12C6gQS/GAExndigSaLxTrKpQPxewx9bOcwfvJiJge4rr7wNaph4J+ns5hrmIV2as5qxqN8YKthn9qh0jw==
+  version "13.7.5"
+  resolved "https://registry.yarnpkg.com/@types/node/-/node-13.7.5.tgz#2da244d764666f85154274cac94a1cb5b88dcb8d"
+  integrity sha512-PfSBCTQhAQg6QBP4UhXgrZ/wQ3pjfwBr4sA7Aul+pC9XwGgm9ezrJF7OiC/I4Kf+7VPu/5ThKngAruqxyctZfA==
 
 "@types/node@^7.0.11":
   version "7.10.9"
@@ -2770,9 +2771,9 @@
     "@types/react" "*"
 
 "@types/react@*", "@types/react@^16.9.5":
-  version "16.9.22"
-  resolved "https://registry.yarnpkg.com/@types/react/-/react-16.9.22.tgz#f0288c92d94e93c4b43e3f5633edf788b2c040ae"
-  integrity sha512-7OSt4EGiLvy0h5R7X+r0c7S739TCU/LvWbkNOrm10lUwNHe7XPz5OLhLOSZeCkqO9JSCly1NkYJ7ODTUqVnHJQ==
+  version "16.9.23"
+  resolved "https://registry.yarnpkg.com/@types/react/-/react-16.9.23.tgz#1a66c6d468ba11a8943ad958a8cb3e737568271c"
+  integrity sha512-SsGVT4E7L2wLN3tPYLiF20hmZTPGuzaayVunfgXzUn1x4uHVsKH6QDJQ/TdpHqwsTLd4CwrmQ2vOgxN7gE24gw==
   dependencies:
     "@types/prop-types" "*"
     csstype "^2.2.0"
@@ -2820,10 +2821,10 @@
   resolved "https://registry.yarnpkg.com/@types/unist/-/unist-2.0.3.tgz#9c088679876f374eb5983f150d4787aa6fb32d7e"
   integrity sha512-FvUupuM3rlRsRtCN+fDudtmytGO6iHJuuRKS1Ss0pG5z8oX0diNEw94UEL7hgDbpN94rgaK5R7sWm6RrSkZuAQ==
 
-"@types/uuid@^3.4.5":
-  version "3.4.7"
-  resolved "https://registry.yarnpkg.com/@types/uuid/-/uuid-3.4.7.tgz#51d42247473bc00e38cc8dfaf70d936842a36c03"
-  integrity sha512-C2j2FWgQkF1ru12SjZJyMaTPxs/f6n90+5G5qNakBxKXjTBc/YTSelHh4Pz1HUDwxFXD9WvpQhOGCDC+/Y4mIQ==
+"@types/uuid@^7.0.0":
+  version "7.0.0"
+  resolved "https://registry.yarnpkg.com/@types/uuid/-/uuid-7.0.0.tgz#9f6993ccc8210efa90bda7e1afabbb06a9f860cd"
+  integrity sha512-RiX1I0lK9WFLFqy2xOxke396f0wKIzk5sAll0tL4J4XDYJXURI7JOs96XQb3nP+2gEpQ/LutBb66jgiT5oQshQ==
 
 "@types/vfile-message@*":
   version "2.0.0"
@@ -2904,9 +2905,9 @@
     tsutils "^3.17.1"
 
 "@typescript-eslint/typescript-estree@^2.4.0":
-  version "2.20.0"
-  resolved "https://registry.yarnpkg.com/@typescript-eslint/typescript-estree/-/typescript-estree-2.20.0.tgz#90a0f5598826b35b966ca83483b1a621b1a4d0c9"
-  integrity sha512-WlFk8QtI8pPaE7JGQGxU7nGcnk1ccKAJkhbVookv94ZcAef3m6oCE/jEDL6dGte3JcD7reKrA0o55XhBRiVT3A==
+  version "2.21.0"
+  resolved "https://registry.yarnpkg.com/@typescript-eslint/typescript-estree/-/typescript-estree-2.21.0.tgz#7e4be29f2e338195a2e8c818949ed0ff727cc943"
+  integrity sha512-NC/nogZNb9IK2MEFQqyDBAciOT8Lp8O3KgAfvHx2Skx6WBo+KmDqlU3R9KxHONaijfTIKtojRe3SZQyMjr3wBw==
   dependencies:
     debug "^4.1.1"
     eslint-visitor-keys "^1.1.0"
@@ -3195,9 +3196,9 @@ ajv-keywords@^3.1.0, ajv-keywords@^3.4.1:
   integrity sha512-RO1ibKvd27e6FEShVFfPALuHI3WjSVNeK5FIsmme/LYRNxjKuNj+Dt7bucLa6NdSv3JcVTyMlm9kGR84z1XpaQ==
 
 ajv@^6.1.0, ajv@^6.10.0, ajv@^6.10.2, ajv@^6.11.0, ajv@^6.5.5:
-  version "6.11.0"
-  resolved "https://registry.yarnpkg.com/ajv/-/ajv-6.11.0.tgz#c3607cbc8ae392d8a5a536f25b21f8e5f3f87fe9"
-  integrity sha512-nCprB/0syFYy9fVYU1ox1l2KN8S9I+tziH8D4zdZuLT3N6RMlGSGt5FSTpAiHB/Whv8Qs1cWHma1aMKZyaHRKA==
+  version "6.12.0"
+  resolved "https://registry.yarnpkg.com/ajv/-/ajv-6.12.0.tgz#06d60b96d87b8454a5adaba86e7854da629db4b7"
+  integrity sha512-D6gFiFA0RRLyUbvijN74DWAjXSFxWKaWP7mldxkVhyhAV3+SWA9HEJPHQ2c9soIeTFJqcSdFDGFgdqs1iUU2Hw==
   dependencies:
     fast-deep-equal "^3.1.1"
     fast-json-stable-stringify "^2.0.0"
@@ -3697,9 +3698,9 @@ autoprefixer@^9.7.3:
     postcss-value-parser "^4.0.2"
 
 aws-sdk@^2.488.0:
-  version "2.622.0"
-  resolved "https://registry.yarnpkg.com/aws-sdk/-/aws-sdk-2.622.0.tgz#8f006f082c32ad6fc11df9bbecfd55c8d8c9a5c2"
-  integrity sha512-CV5RZjoh2PZ/wALQXx932dTYukPTZXZmfjlRTJqNibRhyN36/E1KwkX1va1CROii2AnfnxjzV7OqymH0TgKlUg==
+  version "2.626.0"
+  resolved "https://registry.yarnpkg.com/aws-sdk/-/aws-sdk-2.626.0.tgz#6011c3dccd1ea3af4a97bd9b6962c85f9d9947ce"
+  integrity sha512-1D5slT34OI1NseXLszpWwZ+N/Jla8BsY+XsGDH/4yNDDN8Cf+8zKb1AqqSw4T4onz9xhoTHWCTWqTLDL+8XAnw==
   dependencies:
     buffer "4.9.1"
     events "1.1.1"
@@ -5262,7 +5263,7 @@ columnify@^1.5.4:
     strip-ansi "^3.0.0"
     wcwidth "^1.0.0"
 
-combined-stream@^1.0.6, combined-stream@~1.0.6:
+combined-stream@^1.0.6, combined-stream@^1.0.8, combined-stream@~1.0.6:
   version "1.0.8"
   resolved "https://registry.yarnpkg.com/combined-stream/-/combined-stream-1.0.8.tgz#c3d45a8b34fd730631a110a8a2520682b31d5a7f"
   integrity sha512-FQN4MRfuJeHf7cBbBMJFXhKSDq+2kAArBlmRBvcvFE5BB1HZKXtSFASDhdlz9zOYwxh8lDdnvmMOe/+5cdoEdg==
@@ -5823,14 +5824,14 @@ cp-file@^7.0.0:
     p-event "^4.1.0"
 
 cpy@^8.0.0:
-  version "8.0.0"
-  resolved "https://registry.yarnpkg.com/cpy/-/cpy-8.0.0.tgz#8195db0db19a9ea6aa4f229784cbf3e3f53c3158"
-  integrity sha512-iTjLUqtVr45e17GFAyxA0lqFinbGMblMCTtAqrPzT/IETNtDuyyhDDk8weEZ08MiCc6EcuyNq2KtGH5J2BIAoQ==
+  version "8.0.1"
+  resolved "https://registry.yarnpkg.com/cpy/-/cpy-8.0.1.tgz#78884cd2db1fb2ae445c6d150300bda1b24a72a6"
+  integrity sha512-XplonbFkGld3KST+wKFutU+Al3srtT9RaeLTJeRY47QzzLDlA5kpK4s+o0DdgRx7W0cdkifOehGnCBCGIFfdeg==
   dependencies:
     arrify "^2.0.1"
     cp-file "^7.0.0"
     globby "^9.2.0"
-    is-glob "^4.0.1"
+    has-glob "^1.0.0"
     junk "^3.1.0"
     nested-error-stacks "^2.1.0"
     p-all "^2.1.0"
@@ -7875,15 +7876,16 @@ fast-glob@^2.2.6:
     micromatch "^3.1.10"
 
 fast-glob@^3.0.3, fast-glob@^3.0.4, fast-glob@^3.1.0:
-  version "3.1.1"
-  resolved "https://registry.yarnpkg.com/fast-glob/-/fast-glob-3.1.1.tgz#87ee30e9e9f3eb40d6f254a7997655da753d7c82"
-  integrity sha512-nTCREpBY8w8r+boyFYAx21iL6faSsQynliPHM4Uf56SbkyohCNxpVPEH9xrF5TXKy+IsjkPUHDKiUkzBVRXn9g==
+  version "3.2.2"
+  resolved "https://registry.yarnpkg.com/fast-glob/-/fast-glob-3.2.2.tgz#ade1a9d91148965d4bf7c51f72e1ca662d32e63d"
+  integrity sha512-UDV82o4uQyljznxwMxyVRJgZZt3O5wENYojjzbaGEGZgeOxkLFf+V4cnUD+krzb2F72E18RhamkMZ7AdeggF7A==
   dependencies:
     "@nodelib/fs.stat" "^2.0.2"
     "@nodelib/fs.walk" "^1.2.3"
     glob-parent "^5.1.0"
     merge2 "^1.3.0"
     micromatch "^4.0.2"
+    picomatch "^2.2.1"
 
 fast-json-stable-stringify@2.x, fast-json-stable-stringify@^2.0.0:
   version "2.1.0"
@@ -8237,6 +8239,15 @@ forever-agent@~0.6.1:
   version "0.6.1"
   resolved "https://registry.yarnpkg.com/forever-agent/-/forever-agent-0.6.1.tgz#fbc71f0c41adeb37f96c577ad1ed42d8fdacca91"
   integrity sha1-+8cfDEGt6zf5bFd60e1C2P2sypE=
+
+form-data@^3.0.0:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/form-data/-/form-data-3.0.0.tgz#31b7e39c85f1355b7139ee0c647cf0de7f83c682"
+  integrity sha512-CKMFDglpbMi6PyN+brwB9Q/GOw0eAnsrEZDgcsH5Krhz5Od/haKHAX0NmQfha2zPPz0JpWzA7GJHGSnvCRLWsg==
+  dependencies:
+    asynckit "^0.4.0"
+    combined-stream "^1.0.8"
+    mime-types "^2.1.12"
 
 form-data@~2.3.2:
   version "2.3.3"
@@ -9425,6 +9436,13 @@ has-flag@^4.0.0:
   resolved "https://registry.yarnpkg.com/has-flag/-/has-flag-4.0.0.tgz#944771fd9c81c81265c4d6941860da06bb59479b"
   integrity sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==
 
+has-glob@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/has-glob/-/has-glob-1.0.0.tgz#9aaa9eedbffb1ba3990a7b0010fb678ee0081207"
+  integrity sha1-mqqe7b/7G6OZCnsAEPtnjuAIEgc=
+  dependencies:
+    is-glob "^3.0.0"
+
 has-symbol-support-x@^1.4.1:
   version "1.4.2"
   resolved "https://registry.yarnpkg.com/has-symbol-support-x/-/has-symbol-support-x-1.4.2.tgz#1409f98bc00247da45da67cee0a36f282ff26455"
@@ -9638,9 +9656,9 @@ homedir-polyfill@^1.0.1:
     parse-passwd "^1.0.0"
 
 hosted-git-info@^2.1.4, hosted-git-info@^2.7.1:
-  version "2.8.5"
-  resolved "https://registry.yarnpkg.com/hosted-git-info/-/hosted-git-info-2.8.5.tgz#759cfcf2c4d156ade59b0b2dfabddc42a6b9c70c"
-  integrity sha512-kssjab8CvdXfcXMXVcvsXum4Hwdq9XGtRD3TteMEvEbq0LXyiNQr6AprqKqfeaDXze7SxWvRxdpwE6ku7ikLkg==
+  version "2.8.6"
+  resolved "https://registry.yarnpkg.com/hosted-git-info/-/hosted-git-info-2.8.6.tgz#3a6e6d0324c5371fc8c7ba7175e1e5d14578724d"
+  integrity sha512-Kp6rShEsCHhF5dD3EWKdkgVA8ix90oSUJ0VY4g9goxxa0+f4lx63muTftn0mlJ/+8IESGWyKnP//V2D7S4ZbIQ==
 
 hosted-git-info@^3.0.2:
   version "3.0.2"
@@ -10184,12 +10202,7 @@ ip@1.1.5, ip@^1.1.0, ip@^1.1.5:
   resolved "https://registry.yarnpkg.com/ip/-/ip-1.1.5.tgz#bdded70114290828c0a039e72ef25f5aaec4354a"
   integrity sha1-vd7XARQpCCjAoDnnLvJfWq7ENUo=
 
-ipaddr.js@1.9.0:
-  version "1.9.0"
-  resolved "https://registry.yarnpkg.com/ipaddr.js/-/ipaddr.js-1.9.0.tgz#37df74e430a0e47550fe54a2defe30d8acd95f65"
-  integrity sha512-M4Sjn6N/+O6/IXSJseKqHoFc+5FdGJ22sXqnjTpdZweHK64MzEPAyQZyEU3R/KRv2GLoa7nNtg/C2Ev6m7z+eA==
-
-ipaddr.js@^1.9.0:
+ipaddr.js@1.9.1, ipaddr.js@^1.9.0:
   version "1.9.1"
   resolved "https://registry.yarnpkg.com/ipaddr.js/-/ipaddr.js-1.9.1.tgz#bff38543eeb8984825079ff3a2a8e6cbd46781b3"
   integrity sha512-0KI/607xoxSToH7GjN1FfSbLoU0+btTicjsQSWQlh/hZykN8KpmMf7uYwPW3R+akZ6R/w18ZlXSHBYXiYUPO3g==
@@ -10428,7 +10441,7 @@ is-glob@^2.0.0:
   dependencies:
     is-extglob "^1.0.0"
 
-is-glob@^3.1.0:
+is-glob@^3.0.0, is-glob@^3.1.0:
   version "3.1.0"
   resolved "https://registry.yarnpkg.com/is-glob/-/is-glob-3.1.0.tgz#7ba5ae24217804ac70707b96922567486cc3e84a"
   integrity sha1-e6WuJCF4BKxwcHuWkiVnSGzD6Eo=
@@ -12870,12 +12883,12 @@ nested-error-stacks@^2.0.0, nested-error-stacks@^2.1.0:
   integrity sha512-AO81vsIO1k1sM4Zrd6Hu7regmJN1NSiAja10gc4bX3F0wd+9rQmcuHQaHVQCYIEC8iFXnE+mavh23GOt7wBgug==
 
 netlify-cli@^2.17.0:
-  version "2.35.0"
-  resolved "https://registry.yarnpkg.com/netlify-cli/-/netlify-cli-2.35.0.tgz#91859bf9ea448066826e0cdd51d1b8407ce24d11"
-  integrity sha512-ZvtklsaUXdVknQLzocmVuGAhbJ8kTJt9sRqwntCYe5w78SwPmDNlxWRk2xwfxxMVtdzT7iqLqhPQP8zg0EtO0g==
+  version "2.36.0"
+  resolved "https://registry.yarnpkg.com/netlify-cli/-/netlify-cli-2.36.0.tgz#150d2b97dc5ac6f577cefb743f6e353ecaba1e5c"
+  integrity sha512-lmk5W1q6Vgdtv/bv0dR5/wTe4a8zw/09g1lbPeDoScNyiMytcUlh96PwX2euj9qG/MukPs70C8M1MbKe2ItH8w==
   dependencies:
     "@netlify/build" "^0.1.7"
-    "@netlify/config" "^0.1.7"
+    "@netlify/config" "^0.1.21"
     "@netlify/zip-it-and-ship-it" "^0.3.1"
     "@oclif/command" "^1.5.18"
     "@oclif/config" "^1.13.2"
@@ -12951,6 +12964,7 @@ netlify-cli@^2.17.0:
     update-notifier "^2.5.0"
     uuid "^3.3.3"
     wait-port "^0.2.2"
+    winston "^3.2.1"
     wrap-ansi "^6.0.0"
     write-file-atomic "^3.0.0"
 
@@ -14166,7 +14180,7 @@ physical-cpu-count@^2.0.0:
   resolved "https://registry.yarnpkg.com/physical-cpu-count/-/physical-cpu-count-2.0.0.tgz#18de2f97e4bf7a9551ad7511942b5496f7aba660"
   integrity sha1-GN4vl+S/epVRrXURlCtUlverpmA=
 
-picomatch@^2.0.4, picomatch@^2.0.5, picomatch@^2.0.7:
+picomatch@^2.0.4, picomatch@^2.0.5, picomatch@^2.0.7, picomatch@^2.2.1:
   version "2.2.1"
   resolved "https://registry.yarnpkg.com/picomatch/-/picomatch-2.2.1.tgz#21bac888b6ed8601f831ce7816e335bc779f0a4a"
   integrity sha512-ISBaA8xQNmwELC7eOjqFKMESB2VIqt4PPDD0nsS95b/9dZXvVKOlz9keMSnoGGKcOHXfTvDD6WMaRoSc9UuhRA==
@@ -14857,12 +14871,12 @@ protoduck@^5.0.1:
     genfun "^5.0.0"
 
 proxy-addr@~2.0.5:
-  version "2.0.5"
-  resolved "https://registry.yarnpkg.com/proxy-addr/-/proxy-addr-2.0.5.tgz#34cbd64a2d81f4b1fd21e76f9f06c8a45299ee34"
-  integrity sha512-t/7RxHXPH6cJtP0pRG6smSr9QJidhB+3kXu0KgXnbGYMgzEnUxRQ4/LDdfOwZEMyIh3/xHb8PX3t+lfL9z+YVQ==
+  version "2.0.6"
+  resolved "https://registry.yarnpkg.com/proxy-addr/-/proxy-addr-2.0.6.tgz#fdc2336505447d3f2f2c638ed272caf614bbb2bf"
+  integrity sha512-dh/frvCBVmSsDYzw6n926jv974gddhkFPfiN8hPOi30Wax25QZyZEGveluCgliBnqmuM+UJmBErbAUFIoDbjOw==
   dependencies:
     forwarded "~0.1.2"
-    ipaddr.js "1.9.0"
+    ipaddr.js "1.9.1"
 
 prr@~1.0.1:
   version "1.0.1"
@@ -18540,9 +18554,16 @@ unist-util-visit@^1.0.0, unist-util-visit@^1.1.0, unist-util-visit@^1.4.1:
     unist-util-visit-parents "^2.0.0"
 
 universal-user-agent@^4.0.0:
-  version "4.0.0"
-  resolved "https://registry.yarnpkg.com/universal-user-agent/-/universal-user-agent-4.0.0.tgz#27da2ec87e32769619f68a14996465ea1cb9df16"
-  integrity sha512-eM8knLpev67iBDizr/YtqkJsF3GK8gzDc6st/WKzrTuPtcsOKW/0IdL4cnMBsU69pOx0otavLWBDGTwg+dB0aA==
+  version "4.0.1"
+  resolved "https://registry.yarnpkg.com/universal-user-agent/-/universal-user-agent-4.0.1.tgz#fd8d6cb773a679a709e967ef8288a31fcc03e557"
+  integrity sha512-LnST3ebHwVL2aNe4mejI9IQh2HfZ1RLo8Io2HugSif8ekzD1TlWpHpColOB/eh8JHMLkGH3Akqf040I+4ylNxg==
+  dependencies:
+    os-name "^3.1.0"
+
+universal-user-agent@^5.0.0:
+  version "5.0.0"
+  resolved "https://registry.yarnpkg.com/universal-user-agent/-/universal-user-agent-5.0.0.tgz#a3182aa758069bf0e79952570ca757de3579c1d9"
+  integrity sha512-B5TPtzZleXyPrUMKCpEHFmVhMN6EhmJYjG5PQna9s7mXeSqGTLap4OpqLl5FCEFUI3UBmllkETwKf/db66Y54Q==
   dependencies:
     os-name "^3.1.0"
 
@@ -19303,9 +19324,9 @@ write-file-atomic@^2.0.0, write-file-atomic@^2.3.0, write-file-atomic@^2.4.2:
     signal-exit "^3.0.2"
 
 write-file-atomic@^3.0.0:
-  version "3.0.1"
-  resolved "https://registry.yarnpkg.com/write-file-atomic/-/write-file-atomic-3.0.1.tgz#558328352e673b5bb192cf86500d60b230667d4b"
-  integrity sha512-JPStrIyyVJ6oCSz/691fAjFtefZ6q+fP6tm+OS4Qw6o+TGQxNp1ziY2PgS+X/m0V8OWhZiO/m4xSj+Pr4RrZvw==
+  version "3.0.3"
+  resolved "https://registry.yarnpkg.com/write-file-atomic/-/write-file-atomic-3.0.3.tgz#56bd5c5a5c70481cd19c571bd39ab965a5de56e8"
+  integrity sha512-AvHcyZ5JnSfq3ioSyjrBkH9yW4m7Ayk8/9My/DD9onKeu/94fwrMocemO2QAJFAlnnDN+ZDS+ZjAR5ua1/PV/Q==
   dependencies:
     imurmurhash "^0.1.4"
     is-typedarray "^1.0.0"


### PR DESCRIPTION
- Added the model property option `setterAction` so that it automatically implenents model prop setters wrapped in actions.
- Added `applySet`, `applyDelete`, `applyCall` to be able manipulate data without the need to use `modelAction`.
