### PR TITLE
Add runtime type validation

### DIFF
--- a/packages/lib/src/model/BaseModel.ts
+++ b/packages/lib/src/model/BaseModel.ts
@@ -8,6 +8,7 @@ import { typesModel } from "../typeChecking/model"
 import { typeCheck } from "../typeChecking/typeCheck"
 import { TypeCheckError } from "../typeChecking/TypeCheckError"
 import { assertIsObject } from "../utils"
+import { getModelValidationType } from "./getModelValidationType"
 import { modelIdKey, modelTypeKey } from "./metadata"
 import { ModelConstructorOptions } from "./ModelConstructorOptions"
 import { modelInfoByClass } from "./modelInfo"
@@ -123,6 +124,17 @@ export abstract class BaseModel<
    */
   typeCheck(): TypeCheckError | null {
     const type = typesModel<this>(this.constructor as any)
+    return typeCheck(type, this as any)
+  }
+
+  /**
+   * Performs type validation over the model instance.
+   * For this to work a validation type has do be declared in the model decorator.
+   *
+   * @returns A `TypeCheckError` or `null` if there is no error.
+   */
+  typeValidate(): TypeCheckError | null {
+    const type = getModelValidationType(this.constructor as any)
     return typeCheck(type, this as any)
   }
 

--- a/packages/lib/src/model/getModelValidationType.ts
+++ b/packages/lib/src/model/getModelValidationType.ts
@@ -1,0 +1,24 @@
+import { AnyType } from "../typeChecking/schemas"
+import { failure } from "../utils"
+import { AnyModel, ModelClass } from "./BaseModel"
+import { modelValidationTypeCheckerSymbol } from "./modelSymbols"
+import { isModel, isModelClass } from "./utils"
+
+/**
+ * Returns the associated validation type for runtime checking (if any) to a model instance or
+ * class.
+ *
+ * @param modelClassOrInstance Model class or instance.
+ * @returns The associated validation type, or `undefined` if none.
+ */
+export function getModelValidationType(
+  modelClassOrInstance: AnyModel | ModelClass<AnyModel>
+): AnyType | undefined {
+  if (isModel(modelClassOrInstance)) {
+    return (modelClassOrInstance as any).constructor[modelValidationTypeCheckerSymbol]
+  } else if (isModelClass(modelClassOrInstance)) {
+    return (modelClassOrInstance as any)[modelValidationTypeCheckerSymbol]
+  } else {
+    throw failure(`modelClassOrInstance must be a model class or instance`)
+  }
+}

--- a/packages/lib/src/model/index.ts
+++ b/packages/lib/src/model/index.ts
@@ -1,5 +1,6 @@
 export * from "./BaseModel"
 export * from "./getModelDataType"
+export * from "./getModelValidationType"
 export * from "./metadata"
 export * from "./Model"
 export * from "./modelDecorator"

--- a/packages/lib/src/model/modelSymbols.ts
+++ b/packages/lib/src/model/modelSymbols.ts
@@ -1,2 +1,3 @@
 export const modelDataTypeCheckerSymbol = Symbol("modelDataTypeChecker")
+export const modelValidationTypeCheckerSymbol = Symbol("modelValidationTypeChecker")
 export const modelUnwrappedClassSymbol = Symbol("modelUnwrappedClass")


### PR DESCRIPTION
This is an attempt at making a step forward towards supporting comprehensive runtime type validation (#160).

So far, I've implemented support for specifying a (possibly complex) runtime type that can be passed to the model decorator. This approach, in contrast to specifying runtime types as model props, allows for more complex runtime type specifications, e.g. union types for a model (see https://github.com/xaviergonz/mobx-keystone/issues/160#issuecomment-665791881 and the added test for a union of objects), as well as runtime type checking of class instance properties and computed properties.

All changes are intentionally non-breaking for now at the cost of having an additional way of defining runtime types.

@xaviergonz and possibly others: What do you think?