### PR TITLE
Fix TypeError path of refinement type

### DIFF
--- a/packages/lib/src/typeChecking/refinement.ts
+++ b/packages/lib/src/typeChecking/refinement.ts
@@ -63,7 +63,7 @@ export function typesRefinement<T extends AnyType>(
         if (refinementErr === true) {
           return null
         } else if (refinementErr === false) {
-          return new TypeCheckError([], getTypeName(thisTc), data)
+          return new TypeCheckError(path, getTypeName(thisTc), data)
         } else {
           return refinementErr ?? null
         }

--- a/packages/lib/test/typeChecking/typeChecking.test.ts
+++ b/packages/lib/test/typeChecking/typeChecking.test.ts
@@ -1021,6 +1021,17 @@ test("refinement (simple)", () => {
   expect(typeInfo.typeName).toBe("integer")
 })
 
+test("refinement (simple child)", () => {
+  const checkFn = (n: number) => {
+    return Number.isInteger(n)
+  }
+
+  const type = types.object(() => ({ value: types.refinement(types.number, checkFn, "integer") }))
+
+  expectTypeCheckOk(type, { value: 5 })
+  expectTypeCheckFail(type, { value: 5.5 }, ["value"], "integer<number>")
+})
+
 test("refinement (complex)", () => {
   const sumObjType = types.object(() => ({
     a: types.number,


### PR DESCRIPTION
A refinement type error always had the path `[]` even when the refinement type was used as a child of another type, e.g. `types.object`. I've added a test and fixed the refinement type to use the path passed to the check function instead.