### PR TITLE
Fix grouping sandbox commit patches in a single undo item

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 # Change Log
 
+- Fixed the sandbox to group commit patches so that the undo manager will undo the commit in a single step.
 - Added `assign` to `fnObject`.
 
 ## 0.48.4

--- a/packages/lib/src/treeUtils/sandbox.ts
+++ b/packages/lib/src/treeUtils/sandbox.ts
@@ -7,6 +7,7 @@ import { createContext } from "../context"
 import { getParentToChildPath, resolvePath } from "../parent/path"
 import { applyPatches } from "../patch/applyPatches"
 import { onPatches } from "../patch/emitPatch"
+import { Patch } from "../patch/Patch"
 import { PatchRecorder, patchRecorder } from "../patch/patchRecorder"
 import { isRootStore, registerRootStore, unregisterRootStore } from "../rootStore/rootStore"
 import { clone } from "../snapshot/clone"
@@ -215,23 +216,25 @@ export class SandboxManager {
         recorder.dispose()
         this.withSandboxPatchRecorder = undefined
       }
-      runInAction(() => {
-        if (commit) {
-          if (!isNestedWithSandboxCall) {
-            const len = recorder.events.length
-            for (let i = 0; i < len; i++) {
-              applyPatches(this.subtreeRoot, recorder.events[i].patches)
-            }
+      if (commit) {
+        if (!isNestedWithSandboxCall) {
+          const patches: Patch[] = []
+          const len = recorder.events.length
+          for (let i = 0; i < len; i++) {
+            patches.push(...recorder.events[i].patches)
           }
-        } else {
-          this.allowWrite(() => {
+          applyPatches(this.subtreeRoot, patches)
+        }
+      } else {
+        this.allowWrite(() => {
+          runInAction(() => {
             let i = recorder.events.length
             while (i-- > numRecorderEvents) {
               applyPatches(this.subtreeRootClone, recorder.events[i].inversePatches, true)
             }
           })
-        }
-      })
+        })
+      }
     }
 
     return { sandboxNodes, applyRecorderChanges }

--- a/packages/lib/test/treeUtils/sandbox.test.ts
+++ b/packages/lib/test/treeUtils/sandbox.test.ts
@@ -16,6 +16,7 @@ import {
   runUnprotected,
   sandbox,
   SandboxManager,
+  undoMiddleware,
   unregisterRootStore,
 } from "../../src"
 import "../commonSetup"
@@ -491,4 +492,22 @@ test("isSandboxedNode recognizes ref/prev/next to all be sandboxed nodes or not 
   runUnprotected(() => {
     r.a = undefined
   })
+})
+
+test("sandbox commit patches are grouped in a single undo item", () => {
+  const b = new B({ value: 0 })
+  const sandboxManager = sandbox(b)
+  const undoManager = undoMiddleware(b)
+
+  expect(undoManager.undoLevels).toBe(0)
+  expect(undoManager.redoLevels).toBe(0)
+
+  sandboxManager.withSandbox(b, (node) => {
+    node.setValue(1)
+    node.setValue(2)
+    return { return: undefined, commit: true }
+  })
+
+  expect(undoManager.undoLevels).toBe(1)
+  expect(undoManager.redoLevels).toBe(0)
 })

--- a/packages/lib/test/treeUtils/sandbox.test.ts
+++ b/packages/lib/test/treeUtils/sandbox.test.ts
@@ -510,4 +510,44 @@ test("sandbox commit patches are grouped in a single undo item", () => {
 
   expect(undoManager.undoLevels).toBe(1)
   expect(undoManager.redoLevels).toBe(0)
+  expect(undoManager.undoQueue).toMatchInlineSnapshot(`
+    Array [
+      Object {
+        "actionName": "$$applyPatches",
+        "inversePatches": Array [
+          Object {
+            "op": "replace",
+            "path": Array [
+              "value",
+            ],
+            "value": 0,
+          },
+          Object {
+            "op": "replace",
+            "path": Array [
+              "value",
+            ],
+            "value": 1,
+          },
+        ],
+        "patches": Array [
+          Object {
+            "op": "replace",
+            "path": Array [
+              "value",
+            ],
+            "value": 1,
+          },
+          Object {
+            "op": "replace",
+            "path": Array [
+              "value",
+            ],
+            "value": 2,
+          },
+        ],
+        "targetPath": Array [],
+      },
+    ]
+  `)
 })


### PR DESCRIPTION
When committing multiple changes made in a sandbox to the original tree, multiple items in the undo manager's queue were created so that a single call to `undoManager.undo()` did not undo the commit. I think this behavior is not intuitive and unintended.

I've fixed the sandbox to apply the commit patches in a single action, so a single undo item is created for the entire commit.