### PR TITLE
Improve sandbox manager API

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 # Change Log
 
+- [BREAKING CHANGE] The sandbox manager's `withSandbox` method now requires an array of nodes from the original tree and the corresponding sandbox nodes are now positional arguments of the callback function.
 - Added `assign` to `fnObject`.
 
 ## 0.48.4

--- a/packages/lib/src/treeUtils/sandbox.ts
+++ b/packages/lib/src/treeUtils/sandbox.ts
@@ -10,7 +10,7 @@ import { onPatches } from "../patch/emitPatch"
 import { PatchRecorder, patchRecorder } from "../patch/patchRecorder"
 import { isRootStore, registerRootStore, unregisterRootStore } from "../rootStore/rootStore"
 import { clone } from "../snapshot/clone"
-import { assertTweakedObject, isTweakedObject } from "../tweaker/core"
+import { assertTweakedObject } from "../tweaker/core"
 import { assertIsFunction, failure } from "../utils"
 
 /**
@@ -41,8 +41,8 @@ export function isSandboxedNode(node: object): boolean {
 /**
  * Callback function for `SandboxManager.withSandbox`.
  */
-export type WithSandboxCallback<T extends object | [object], R> = (
-  node: T
+export type WithSandboxCallback<T extends readonly [object, ...object[]], R> = (
+  ...nodes: T
 ) => boolean | { commit: boolean; return: R }
 
 /**
@@ -135,32 +135,33 @@ export class SandboxManager {
   }
 
   /**
-   * Executes `fn` with a sandbox copy of `node`. The changes made to the sandbox in `fn` can be
-   * accepted, i.e. applied to the original subtree, or rejected.
+   * Executes `fn` with sandbox copies of the elements of `nodes`. The changes made to the sandbox
+   * in `fn` can be accepted, i.e. applied to the original subtree, or rejected.
    *
    * @typeparam T Object type.
    * @typeparam R Return type.
-   * @param node Object or tuple of objects for which to obtain a sandbox copy.
-   * @param fn Function that is called with a sandbox copy of `node`. Any changes made to the
-   * sandbox are applied to the original subtree when `fn` returns `true` or
+   * @param nodes Tuple of objects for which to obtain sandbox copies.
+   * @param fn Function that is called with sandbox copies of the elements of `nodes`. Any changes
+   * made to the sandbox are applied to the original subtree when `fn` returns `true` or
    * `{ commit: true, ... }`. When `fn` returns `false` or `{ commit: false, ... }` the changes made
    * to the sandbox are rejected.
    * @returns Value of type `R` when `fn` returns an object of type `{ commit: boolean; return: R }`
    * or `void` when `fn` returns a boolean.
    */
-  withSandbox<T extends object | [object], R = void>(node: T, fn: WithSandboxCallback<T, R>): R {
+  withSandbox<T extends readonly [object, ...object[]], R = void>(
+    nodes: T,
+    fn: WithSandboxCallback<T, R>
+  ): R {
+    for (let i = 0; i < nodes.length; i++) {
+      assertTweakedObject(nodes[i], `nodes[${i}]`)
+    }
     assertIsFunction(fn, "fn")
-
-    const isNodesArray = Array.isArray(node) && !isTweakedObject(node, false)
-    const nodes: T[] = isNodesArray ? (node as T[]) : [node]
 
     const { sandboxNodes, applyRecorderChanges } = this.prepareSandboxChanges(nodes)
 
     let commit = false
     try {
-      const returnValue = this.allowWrite(() =>
-        fn((isNodesArray ? sandboxNodes : sandboxNodes[0]) as T)
-      )
+      const returnValue = this.allowWrite(() => fn(...sandboxNodes))
       if (typeof returnValue === "boolean") {
         commit = returnValue
         return undefined as any
@@ -180,14 +181,12 @@ export class SandboxManager {
     this.disposer()
   }
 
-  private prepareSandboxChanges<T extends object[]>(
+  private prepareSandboxChanges<T extends readonly [object, ...object[]]>(
     nodes: T
   ): { sandboxNodes: T; applyRecorderChanges: (commit: boolean) => void } {
     const isNestedWithSandboxCall = !!this.withSandboxPatchRecorder
 
-    const sandboxNodes = nodes.map((node) => {
-      assertTweakedObject(node, "node")
-
+    const sandboxNodes = (nodes.map((node) => {
       const path = getParentToChildPath(
         isNestedWithSandboxCall ? this.subtreeRootClone : this.subtreeRoot,
         node
@@ -202,7 +201,7 @@ export class SandboxManager {
       }
 
       return sandboxNode
-    }) as T
+    }) as unknown) as T
 
     if (!this.withSandboxPatchRecorder) {
       this.withSandboxPatchRecorder = patchRecorder(this.subtreeRootClone)

--- a/packages/lib/test/treeUtils/sandbox.test.ts
+++ b/packages/lib/test/treeUtils/sandbox.test.ts
@@ -48,33 +48,33 @@ test("withSandbox can be called with one node or a tuple of nodes", () => {
   const manager = sandbox(a)
   autoDispose(() => manager.dispose())
 
-  manager.withSandbox(a, (node) => {
+  manager.withSandbox([a], (node) => {
     assert(node, _ as A)
     expect(node.$modelType).toBe("A")
     return false
   })
 
-  manager.withSandbox([a], (nodes) => {
+  manager.withSandbox([a], (...nodes) => {
     assert(nodes, _ as [A])
     expect(nodes[0].$modelType).toBe("A")
     return false
   })
 
-  manager.withSandbox([a, a], (nodes) => {
+  manager.withSandbox([a, a], (...nodes) => {
     assert(nodes, _ as [A, A])
     expect(nodes[0].$modelType).toBe("A")
     expect(nodes[1].$modelType).toBe("A")
     return false
   })
 
-  manager.withSandbox([a, a.b], (nodes) => {
+  manager.withSandbox([a, a.b], (...nodes) => {
     assert(nodes, _ as [A, B])
     expect(nodes[0].$modelType).toBe("A")
     expect(nodes[1].$modelType).toBe("B")
     return false
   })
 
-  manager.withSandbox([a.b, a], (nodes) => {
+  manager.withSandbox([a.b, a], (...nodes) => {
     assert(nodes, _ as [B, A])
     expect(nodes[0].$modelType).toBe("B")
     expect(nodes[1].$modelType).toBe("A")
@@ -91,7 +91,7 @@ test("withSandbox can be called with an array node", () => {
   const manager = sandbox(r)
   autoDispose(() => manager.dispose())
 
-  manager.withSandbox(r.a, (node) => {
+  manager.withSandbox([r.a], (node) => {
     assert(node, _ as A[])
     expect(node).toHaveLength(2)
     expect(isTweakedObject(node, false)).toBeTruthy()
@@ -106,7 +106,7 @@ test("withSandbox callback is called when node is a child of subtreeRoot", () =>
 
   let called = false
 
-  manager.withSandbox(a, () => {
+  manager.withSandbox([a], () => {
     called = true
     return false
   })
@@ -119,7 +119,7 @@ test("withSandbox throws a failure when node is not a child of subtreeRoot", () 
   autoDispose(() => manager.dispose())
 
   expect(() => {
-    manager.withSandbox(a, () => false)
+    manager.withSandbox([a], () => false)
   }).toThrow("node is not a child of subtreeRoot")
 })
 
@@ -128,7 +128,7 @@ test("sandbox copy reuses IDs from original tree", () => {
   const manager = sandbox(a)
   autoDispose(() => manager.dispose())
 
-  manager.withSandbox(a, (node) => {
+  manager.withSandbox([a], (node) => {
     expect(node.$modelId).toBe(a.$modelId)
     expect(node.b.$modelId).toBe(a.b.$modelId)
     return false
@@ -141,7 +141,7 @@ test("original tree must not be changed while withSandbox executes", () => {
   autoDispose(() => manager.dispose())
 
   expect(() =>
-    manager.withSandbox(a.b, () => {
+    manager.withSandbox([a.b], () => {
       a.b.setValue(2)
       return false
     })
@@ -158,9 +158,9 @@ test.each<[boolean, boolean]>([
   const manager = sandbox(a)
   autoDispose(() => manager.dispose())
 
-  manager.withSandbox(a.b, (node1) => {
+  manager.withSandbox([a.b], (node1) => {
     node1.setValue(1)
-    manager.withSandbox(node1, (node2) => {
+    manager.withSandbox([node1], (node2) => {
       expect(node2.value).toBe(1)
       node2.setValue(2)
       return commitInner
@@ -172,7 +172,7 @@ test.each<[boolean, boolean]>([
   const expectedValue = commitOuter ? (commitInner ? 2 : 1) : 0
 
   expect(a.b.value).toBe(expectedValue)
-  manager.withSandbox(a.b, (node1) => {
+  manager.withSandbox([a.b], (node1) => {
     expect(node1.value).toBe(expectedValue)
     return false
   })
@@ -183,9 +183,9 @@ test("nested withSandbox call requires sandbox node", () => {
   const manager = sandbox(a)
   autoDispose(() => manager.dispose())
 
-  manager.withSandbox(a.b, () => {
+  manager.withSandbox([a.b], () => {
     expect(() =>
-      manager.withSandbox(a.b, () => {
+      manager.withSandbox([a.b], () => {
         return false
       })
     ).toThrow("node is not a child of subtreeRootClone")
@@ -204,7 +204,7 @@ test("sandbox node is a root store if original subtree root is a root store", ()
   autoDispose(() => manager.dispose())
 
   expect(isRootStore(a)).toBeFalsy()
-  manager.withSandbox(a, (node) => {
+  manager.withSandbox([a], (node) => {
     expect(isRootStore(node)).toBeFalsy()
     return false
   })
@@ -212,7 +212,7 @@ test("sandbox node is a root store if original subtree root is a root store", ()
   registerRootStore(a)
 
   expect(isRootStore(a)).toBeTruthy()
-  manager.withSandbox(a, (node) => {
+  manager.withSandbox([a], (node) => {
     expect(isRootStore(node)).toBeTruthy()
     return false
   })
@@ -220,7 +220,7 @@ test("sandbox node is a root store if original subtree root is a root store", ()
   unregisterRootStore(a)
 
   expect(isRootStore(a)).toBeFalsy()
-  manager.withSandbox(a, (node) => {
+  manager.withSandbox([a], (node) => {
     expect(isRootStore(node)).toBeFalsy()
     return false
   })
@@ -231,14 +231,14 @@ test("sandbox is patched when original tree changes", () => {
   const manager = sandbox(a)
   autoDispose(() => manager.dispose())
 
-  manager.withSandbox(a.b, (node) => {
+  manager.withSandbox([a.b], (node) => {
     expect(node.value).toBe(0)
     return false
   })
 
   a.b.setValue(1)
 
-  manager.withSandbox(a.b, (node) => {
+  manager.withSandbox([a.b], (node) => {
     expect(node.value).toBe(1)
     return false
   })
@@ -249,7 +249,7 @@ test("changes in sandbox can be applied to original tree", () => {
   const manager = sandbox(a)
   autoDispose(() => manager.dispose())
 
-  manager.withSandbox(a.b, (node) => {
+  manager.withSandbox([a.b], (node) => {
     node.setValue(1)
     expect(a.b.value).toBe(0)
     expect(node.value).toBe(1)
@@ -262,7 +262,7 @@ test("changes in sandbox can be applied to original tree", () => {
   })
   expect(a.b.value).toBe(2)
 
-  manager.withSandbox(a.b, (node) => {
+  manager.withSandbox([a.b], (node) => {
     expect(node.value).toBe(2)
     return false
   })
@@ -273,7 +273,7 @@ test("changes in sandbox can be rejected", () => {
   const manager = sandbox(a)
   autoDispose(() => manager.dispose())
 
-  manager.withSandbox(a.b, (node) => {
+  manager.withSandbox([a.b], (node) => {
     node.setValue(1)
     expect(a.b.value).toBe(0)
     expect(node.value).toBe(1)
@@ -286,7 +286,7 @@ test("changes in sandbox can be rejected", () => {
   })
   expect(a.b.value).toBe(0)
 
-  manager.withSandbox(a.b, (node) => {
+  manager.withSandbox([a.b], (node) => {
     expect(node.value).toBe(0)
     return false
   })
@@ -298,7 +298,7 @@ test("changes in sandbox are rejected when fn throws", () => {
   autoDispose(() => manager.dispose())
 
   expect(() => {
-    manager.withSandbox(a.b, (node) => {
+    manager.withSandbox([a.b], (node) => {
       node.setValue(1)
       expect(a.b.value).toBe(0)
       expect(node.value).toBe(1)
@@ -308,7 +308,7 @@ test("changes in sandbox are rejected when fn throws", () => {
 
   expect(a.b.value).toBe(0)
 
-  manager.withSandbox(a.b, (node) => {
+  manager.withSandbox([a.b], (node) => {
     expect(node.value).toBe(0)
     return false
   })
@@ -319,7 +319,7 @@ test("withSandbox can return value from fn", () => {
   const manager = sandbox(a)
   autoDispose(() => manager.dispose())
 
-  const returnValue1 = manager.withSandbox(a.b, (node) => {
+  const returnValue1 = manager.withSandbox([a.b], (node) => {
     node.setValue(1)
     return { commit: false, return: 123 }
   })
@@ -327,7 +327,7 @@ test("withSandbox can return value from fn", () => {
   expect(returnValue1).toBe(123)
   expect(a.b.value).toBe(0)
 
-  const returnValue2 = manager.withSandbox(a.b, (node) => {
+  const returnValue2 = manager.withSandbox([a.b], (node) => {
     node.setValue(1)
     return { commit: true, return: { x: "x" } }
   })
@@ -342,7 +342,7 @@ test("sandbox cannot be changed outside of fn", () => {
   autoDispose(() => manager.dispose())
 
   let n!: B
-  manager.withSandbox(a.b, (node) => {
+  manager.withSandbox([a.b], (node) => {
     n = node
     return false
   })
@@ -440,7 +440,7 @@ test("sanboxed nodes can check if they are sandboxed", () => {
   expect(a.b.isSandboxed).toBe(false)
   a.b.shouldBeSandboxed(false)
 
-  manager.withSandbox(a, (sa) => {
+  manager.withSandbox([a], (sa) => {
     expect(getNodeSandboxManager(sa)).toBe(manager)
     expect(isSandboxedNode(sa)).toBe(true)
     expect(getNodeSandboxManager(sa.b)).toBe(manager)

--- a/packages/lib/test/treeUtils/sandbox.test.ts
+++ b/packages/lib/test/treeUtils/sandbox.test.ts
@@ -502,7 +502,7 @@ test("sandbox commit patches are grouped in a single undo item", () => {
   expect(undoManager.undoLevels).toBe(0)
   expect(undoManager.redoLevels).toBe(0)
 
-  sandboxManager.withSandbox(b, (node) => {
+  sandboxManager.withSandbox([b], (node) => {
     node.setValue(1)
     node.setValue(2)
     return { return: undefined, commit: true }

--- a/packages/site/src/sandbox.mdx
+++ b/packages/site/src/sandbox.mdx
@@ -42,7 +42,7 @@ const numSandbox = sandbox(num)
 The sandbox manager `numSandbox` can now be used to test assigning a new value by performing the `setValue` action on a copy of `num` and validating the result using the computed property `isValid`.
 
 ```ts
-const isValid = numSandbox.withSandbox(num, (numCopy) => {
+const isValid = numSandbox.withSandbox([num], (numCopy) => {
   numCopy.setValue(2)
   return { commit: false, return: numCopy.isValid }
 })
@@ -68,7 +68,7 @@ const store = new NumberStore({
 })
 
 const storeSandbox = sandbox(store)
-storeSandbox.withSandbox([store.a, store.b], ([a, b]) => {
+storeSandbox.withSandbox([store.a, store.b], (a, b) => {
   // ...
 })
 ```
@@ -76,11 +76,11 @@ storeSandbox.withSandbox([store.a, store.b], ([a, b]) => {
 `withSandbox` calls can be nested:
 
 ```ts
-const isValid = numSandbox.withSandbox(num, (numCopy1) => {
+const isValid = numSandbox.withSandbox([num], (numCopy1) => {
   numCopy1.setValue(2)
 
   const isValid1 = numCopy1.isValid
-  const isValid2 = numSandbox.withSandbox(numCopy1, (numCopy2) => {
+  const isValid2 = numSandbox.withSandbox([numCopy1], (numCopy2) => {
     numCopy2.setValue(numCopy2.value * 2)
     return { commit: false, return: numCopy2.isValid }
   })
@@ -93,16 +93,16 @@ When nesting `withSandbox` calls, the node for which the corresponding sandbox n
 
 ```ts
 // good:
-numSandbox.withSandbox(num, (numCopy1) => {
-  numSandbox.withSandbox(numCopy1, (numCopy2) => {
+numSandbox.withSandbox([num], (numCopy1) => {
+  numSandbox.withSandbox([numCopy1], (numCopy2) => {
     // ...
   })
   // ...
 })
 
 // bad:
-numSandbox.withSandbox(num, (numCopy1) => {
-  numSandbox.withSandbox(num, (numCopy2) => {
+numSandbox.withSandbox([num], (numCopy1) => {
+  numSandbox.withSandbox([num], (numCopy2) => {
     // ...
   })
   // ...
@@ -112,15 +112,15 @@ numSandbox.withSandbox(num, (numCopy1) => {
 When changes made in nested `withSandbox` calls are to be committed, only the outermost `withSandbox` call commits changes to the original subtree. Changes made in any inner `withSandbox` call are either retained or rolled back depending on the commit flag. E.g.:
 
 ```ts
-numSandbox.withSandbox(num, (numCopy1) => {
+numSandbox.withSandbox([num], (numCopy1) => {
   // numCopy1.value => 0
   numCopy1.setValue(1)
   // numCopy1.value => 1
-  numSandbox.withSandbox(numCopy1, (numCopy2) => {
+  numSandbox.withSandbox([numCopy1], (numCopy2) => {
     // numCopy2.value => 1
     numCopy2.setValue(2)
     // numCopy2.value => 2
-    numSandbox.withSandbox(numCopy2, (numCopy3) => {
+    numSandbox.withSandbox([numCopy2], (numCopy3) => {
       // numCopy3.value => 2
       numCopy3.setValue(3)
       // numCopy3.value => 3
@@ -139,7 +139,7 @@ The sandbox copy of a subtree root node tracks the [root store](../rootStores) s
 
 The `sandbox` function generates an instance with the following methods:
 
-- `withSandbox<T extends object | [object], R = void>(node: T, fn: (node: T) => boolean | { commit: boolean; return: R }): R` - Executes `fn` with a sandbox copy of `node`. Any changes made to the sandbox are applied to the original subtree when `fn` returns `true` or `{ commit: true, ... }`. When `fn` returns `false` or `{ commit: false, ... }` the changes made to the sandbox are rejected. When `fn` returns an object of type `{ commit: boolean; return: R }` then `withSandbox` returns a value of type `R`.
+- `withSandbox<T extends [object, ...object[]], R = void>(nodes: T, fn: (...nodes: T) => boolean | { commit: boolean; return: R }): R` - Executes `fn` with sandbox copies of the elements of `nodes`. Any changes made to the sandbox are applied to the original subtree when `fn` returns `true` or `{ commit: true, ... }`. When `fn` returns `false` or `{ commit: false, ... }` the changes made to the sandbox are rejected. When `fn` returns an object of type `{ commit: boolean; return: R }` then `withSandbox` returns a value of type `R`.
 - `dispose()` - Disposes of the sandbox.
 
 ### Checking if a node is sandboxed / getting a node sandbox manager
@@ -190,7 +190,7 @@ class ItemStore extends Model({
   }
 
   canAddItem(item: Item): boolean {
-    return !!sandboxCtx.get(this)?.withSandbox(this, (node) => {
+    return !!sandboxCtx.get(this)?.withSandbox([this], (node) => {
       node.addItem(item)
       return { commit: false, return: node.errors.length === 0 }
     })


### PR DESCRIPTION
This PR contains an (in my opinion) improvement of the sandbox API.

The sandbox manager's `withSandbox` method now requires an array of nodes from the original tree and the corresponding sandbox nodes are now positional arguments of the callback function. E.g.:

```ts
// before
sandboxManager.withSandbox(a, (sa) => { ... })
// after
sandboxManager.withSandbox([a], (sa) => { ... })

// before
sandboxManager.withSandbox([a, b], ([sa, sb]) => { ... })
// after
sandboxManager.withSandbox([a, b], (sa, sb) => { ... })
```

Note that this PR contains a breaking change in the signature of the `withSandbox` method.

@xaviergonz What do you think? I hope a minor breaking change in this isolated feature is okay.