### PR TITLE
Fix committing non-idempotent sandbox changes to the original subtree

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 # Change Log
 
+- Fixed committing non-idempotent sandbox changes to the original subtree.
+
 ## 0.52.0
 
 - Added `withGroup` to `UndoManager` so that several sync actions can be undone/redone as a single step.

--- a/packages/lib/src/treeUtils/sandbox.ts
+++ b/packages/lib/src/treeUtils/sandbox.ts
@@ -229,9 +229,14 @@ export class SandboxManager {
           for (let i = 0; i < len; i++) {
             patches.push(...recorder.events[i].patches)
           }
+
+          const isCommitting = this.isComitting
           this.isComitting = true
-          applyPatches(this.subtreeRoot, patches)
-          this.isComitting = false
+          try {
+            applyPatches(this.subtreeRoot, patches)
+          } finally {
+            this.isComitting = isCommitting
+          }
         }
       } else {
         this.allowWrite(() => {

--- a/packages/lib/src/treeUtils/sandbox.ts
+++ b/packages/lib/src/treeUtils/sandbox.ts
@@ -76,7 +76,7 @@ export class SandboxManager {
   /**
    * Whether changes made in the sandbox are currently being committed to the original subtree.
    */
-  private isComitting: boolean = false
+  private isCommitting: boolean = false
 
   /**
    * Creates an instance of `SandboxManager`.
@@ -121,7 +121,7 @@ export class SandboxManager {
       if (this.withSandboxPatchRecorder) {
         throw failure("original subtree must not change while 'withSandbox' executes")
       }
-      if (!this.isComitting) {
+      if (!this.isCommitting) {
         this.allowWrite(() => {
           applyPatches(this.subtreeRootClone, patches)
         })
@@ -230,12 +230,12 @@ export class SandboxManager {
             patches.push(...recorder.events[i].patches)
           }
 
-          const isCommitting = this.isComitting
-          this.isComitting = true
+          const isCommitting = this.isCommitting
+          this.isCommitting = true
           try {
             applyPatches(this.subtreeRoot, patches)
           } finally {
-            this.isComitting = isCommitting
+            this.isCommitting = isCommitting
           }
         }
       } else {


### PR DESCRIPTION
I discovered a bug where committing non-idempotent changes in the sandbox to the original subtree resulted in an incorrect sandbox state. The problem was that applying the sandbox patches to the original subtree triggered the `onPatches` listener that applies changes in the original subtree to the sandbox to keep them in sync. When committing changes in the sandbox to the original subtree, the patches emitted in the original subtree should be ignored by the sandbox.

This PR fixes the bug.