### PR TITLE
Fix typo in patch recorder docs

### DIFF
--- a/packages/lib/src/patch/patchRecorder.ts
+++ b/packages/lib/src/patch/patchRecorder.ts
@@ -46,7 +46,7 @@ export interface PatchRecorder {
  */
 export interface PatchRecorderOptions {
   /**
-   * If the patch recorder is initilly recording when created.
+   * If the patch recorder is initially recording when created.
    */
   recording?: boolean
 

--- a/packages/site/src/patches.mdx
+++ b/packages/site/src/patches.mdx
@@ -53,7 +53,7 @@ Where the allowed options are:
  */
 export interface PatchRecorderOptions {
   /**
-   * If the patch recorder is initilly recording when created.
+   * If the patch recorder is initially recording when created.
    */
   recording?: boolean
 


### PR DESCRIPTION
Just a minor typo fix in the `PatchRecorderOptions` interface docs.