### PR TITLE
Implement arrayActions.swap function (as suggestion to close #258)

### DIFF
--- a/packages/lib/src/standardActions/arrayActions.ts
+++ b/packages/lib/src/standardActions/arrayActions.ts
@@ -17,7 +17,17 @@ const _arrayActions = fnModel<unknown[]>("mobx-keystone/arrayActions").actions({
   setLength(length: number): void {
     this.length = length
   },
-
+  swap(indexA, indexB: number): void {
+    if (indexA < 0 || indexB < 0 || indexA > this.length - 1 || indexB > this.length - 1) {
+      return
+    }
+    var tmp1 = this[indexA]
+    var tmp2 = this[indexB]
+    set(this, indexA, null)
+    set(this, indexB, null)
+    set(this, indexA, tmp2)
+    set(this, indexB, tmp1)
+  },
   concat(...items: ConcatArray<any>[]): any[] {
     return this.concat(...items)
   },
@@ -57,6 +67,8 @@ export const arrayActions = {
   delete: _arrayActions.delete as <T>(array: T[], index: number) => boolean,
 
   setLength: _arrayActions.setLength as <T>(array: T[], length: number) => void,
+
+  swap: _arrayActions.swap as <T>(array: T[], indexA: number, indexB: number) => void,
 
   concat: _arrayActions.concat as <T>(array: T[], ...items: ConcatArray<T>[]) => T[],
 

--- a/packages/lib/test/actionMiddlewares/undoMiddleware.test.ts
+++ b/packages/lib/test/actionMiddlewares/undoMiddleware.test.ts
@@ -2,6 +2,7 @@ import { computed } from "mobx"
 import {
   getSnapshot,
   model,
+  arrayActions,
   Model,
   modelAction,
   modelFlow,
@@ -485,6 +486,23 @@ test("undo-aware substore called from non undo-aware root store", () => {
   expect(manager.undoLevels).toBe(1) // substore action indirectly called
   expect(manager.undoQueue).toMatchSnapshot()
   manager.clearUndo()
+})
+
+test("works with arrayActions ", () => {
+  const p = new P({})
+  const manager = undoMiddleware(p)
+  arrayActions.push(p.arr, 1)
+  arrayActions.push(p.arr, 2)
+  arrayActions.push(p.arr, 3)
+  arrayActions.swap(p.arr, 0, 1)
+  expect(p.arr[0]).toBe(2)
+  expect(p.arr[1]).toBe(1)
+  manager.undo()
+  expect(p.arr[0]).toBe(1)
+  expect(p.arr[1]).toBe(2)
+  manager.redo()
+  expect(p.arr[0]).toBe(2)
+  expect(p.arr[1]).toBe(1)
 })
 
 test("does not generate steps if using withoutUndo", () => {

--- a/packages/lib/test/standardActions/arrayActions.test.ts
+++ b/packages/lib/test/standardActions/arrayActions.test.ts
@@ -14,6 +14,13 @@ test("typed array", () => {
   expect(arr.length).toBe(1)
 })
 
+test("swap function", () => {
+  const arr = arrayActions.create([1, 2, 3, 4])
+  arrayActions.swap(arr, 1, 2)
+  expect(arr[1]).toBe(3)
+  expect(arr[2]).toBe(2)
+})
+
 test("untyped array", () => {
   const arr = arrayActions.create<any>([1, 2])
   expect(arr[0]).toBe(1)


### PR DESCRIPTION
Problem: 
- currently it’s not possible to swap elements in an array without relying on a “host” mobx keystone model
- there are currently not user-exposed ways to extend arrayActions

Solution / Workaround: 
- implement a (non-standard) array function for now directly on arrayActions module
- + tests