### PR TITLE
add snapshot processors for class models

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -10,7 +10,11 @@
     "titleBar.activeBackground": "#68217a",
     "titleBar.inactiveBackground": "#68217a99",
     "titleBar.activeForeground": "#e7e7e7",
-    "titleBar.inactiveForeground": "#e7e7e799"
+    "titleBar.inactiveForeground": "#e7e7e799",
+    "editorGroup.border": "#8a2ca2",
+    "panel.border": "#8a2ca2",
+    "sash.hoverBorder": "#8a2ca2",
+    "sideBar.border": "#8a2ca2"
   },
   "search.exclude": {
     "**/.yarn": true,

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## 0.63.0
 
-- [BREAKING CHANGE] The model override `fromSnapshot` has been removed in favor of `fromSnapshotProcessor` / `toSnapshotProcessor` for `Model` / `ExtendedModel`. These allow you to set up pre/post snapshot processors for models.
+- [BREAKING CHANGE] The model override `fromSnapshot` has been removed in favor of `fromSnapshotProcessor` / `toSnapshotProcessor` options of `Model` / `ExtendedModel`. These allow you to set up pre/post snapshot processors for models.
 
 ## 0.62.0
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Change Log
 
+## 0.63.0
+
+- [BREAKING CHANGE] The model override `fromSnapshot` has been removed in favor of `fromSnapshotProcessor` / `toSnapshotProcessor` for `Model` / `ExtendedModel`. These allow you to set up pre/post snapshot processors for models.
+
 ## 0.62.0
 
 - [BREAKING CHANGE] `$modelId` is no longer a requirement and will be no longer automatically added to models. If you want your models to keep using the old behavior (having a `$modelId` property) then add a `[modelIdKey]: idProp` or a `$modelId: idProp` property to them. Note that `$modelId` can still be used in instances to get/set the current ID property, just that it might be undefined (get) / throw (set) when there is none.

--- a/packages/lib/package.json
+++ b/packages/lib/package.json
@@ -1,6 +1,6 @@
 {
   "name": "mobx-keystone",
-  "version": "0.62.0",
+  "version": "0.63.0",
   "description": "A MobX powered state management solution based on data trees with first class support for Typescript, snapshots, patches and much more",
   "keywords": [
     "mobx",

--- a/packages/lib/src/dataModel/DataModel.ts
+++ b/packages/lib/src/dataModel/DataModel.ts
@@ -125,5 +125,12 @@ function internalDataModel<TProps extends ModelProps, TBaseModel extends AnyData
   modelProps: TProps,
   baseModel: ModelClass<TBaseModel> | undefined
 ): _DataModel<TBaseModel, TProps> {
-  return sharedInternalModel({ modelProps, baseModel, type: "data", valueType: false })
+  return sharedInternalModel({
+    modelProps,
+    baseModel,
+    type: "data",
+    valueType: false,
+    fromSnapshotProcessor: undefined,
+    toSnapshotProcessor: undefined,
+  })
 }

--- a/packages/lib/src/model/BaseModel.ts
+++ b/packages/lib/src/model/BaseModel.ts
@@ -3,17 +3,15 @@ import type { O } from "ts-toolbelt"
 import {
   creationDataTypeSymbol,
   dataTypeSymbol,
+  fromSnapshotTypeSymbol,
   ModelClass,
+  toSnapshotTypeSymbol,
   transformedCreationDataTypeSymbol,
   transformedDataTypeSymbol,
 } from "../modelShared/BaseModelShared"
 import { modelInfoByClass } from "../modelShared/modelInfo"
 import { getSnapshot } from "../snapshot/getSnapshot"
-import type {
-  SnapshotInOfModel,
-  SnapshotInOfObject,
-  SnapshotOutOfModel,
-} from "../snapshot/SnapshotOf"
+import type { SnapshotInOfModel, SnapshotOutOfModel } from "../snapshot/SnapshotOf"
 import { typesModel } from "../typeChecking/model"
 import { typeCheck } from "../typeChecking/typeCheck"
 import type { TypeCheckError } from "../typeChecking/TypeCheckError"
@@ -44,6 +42,8 @@ export abstract class BaseModel<
   CreationData extends { [k: string]: any },
   TransformedData extends { [k: string]: any },
   TransformedCreationData extends { [k: string]: any },
+  FromSnapshot extends { [k: string]: any },
+  ToSnapshot extends { [k: string]: any },
   ModelIdPropertyName extends string = never
 > {
   // just to make typing work properly
@@ -51,6 +51,8 @@ export abstract class BaseModel<
   [creationDataTypeSymbol]: CreationData;
   [transformedDataTypeSymbol]: TransformedData;
   [transformedCreationDataTypeSymbol]: TransformedCreationData;
+  [fromSnapshotTypeSymbol]: FromSnapshot;
+  [toSnapshotTypeSymbol]: ToSnapshot;
   [modelIdPropertyNameSymbol]: ModelIdPropertyName;
 
   /**
@@ -109,17 +111,6 @@ export abstract class BaseModel<
   protected onAttachedToRootStore?(rootStore: object): (() => void) | void
 
   /**
-   * Optional transformation that will be run when converting from a snapshot to the data part of the model.
-   * Useful for example to do versioning and keep the data part up to date with the latest version of the model.
-   *
-   * @param snapshot The custom input snapshot.
-   * @returns An input snapshot that must match the current model input snapshot.
-   */
-  fromSnapshot?(snapshot: { [k: string]: any }): SnapshotInOfObject<CreationData> & {
-    [modelTypeKey]?: string
-  }
-
-  /**
    * Performs a type check over the model instance.
    * For this to work a data type has to be declared as part of the model properties.
    *
@@ -147,6 +138,8 @@ export abstract class BaseModel<
     delete self[creationDataTypeSymbol]
     delete self[transformedDataTypeSymbol]
     delete self[transformedCreationDataTypeSymbol]
+    delete self[fromSnapshotTypeSymbol]
+    delete self[toSnapshotTypeSymbol]
     delete self[modelIdPropertyNameSymbol]
 
     if (!snapshotInitialData) {
@@ -195,14 +188,13 @@ export const baseModelPropNames = new Set<BaseModelKeys>([
   "$",
   "getRefId",
   "onAttachedToRootStore",
-  "fromSnapshot",
   "typeCheck",
 ])
 
 /**
  * Any kind of model instance.
  */
-export interface AnyModel extends BaseModel<any, any, any, any, any> {}
+export interface AnyModel extends BaseModel<any, any, any, any, any, any, any> {}
 
 /**
  * @deprecated Should not be needed anymore.

--- a/packages/lib/src/model/Model.ts
+++ b/packages/lib/src/model/Model.ts
@@ -20,16 +20,17 @@ export type _ComposedCreationData<
   ? ModelPropsToTransformedCreationData<TProps> & TCD
   : ModelPropsToTransformedCreationData<TProps>
 
+export type _FromSnapshot<TProps extends ModelProps> = SnapshotInOfObject<
+  ModelPropsToCreationData<TProps>
+>
+
+export type _ToSnapshot<TProps extends ModelProps> = SnapshotOutOfObject<ModelPropsToData<TProps>>
+
 export type _ModelId<SuperModel, TProps extends ModelProps> = SuperModel extends AnyModel
   ? ModelIdPropertyName<SuperModel>
   : ExtractModelIdProp<TProps> & string
 
-export interface _Model<
-  SuperModel,
-  TProps extends ModelProps,
-  FromSnapshot = SnapshotInOfObject<ModelPropsToCreationData<TProps>>,
-  ToSnapshot = SnapshotOutOfObject<ModelPropsToData<TProps>>
-> {
+export interface _Model<SuperModel, TProps extends ModelProps, FromSnapshot, ToSnapshot> {
   new (data: _ComposedCreationData<SuperModel, TProps>): SuperModel &
     BaseModel<
       ModelPropsToData<TProps>,
@@ -49,47 +50,6 @@ export interface _Model<
 }
 
 /**
- * Optional transformation that will be run when converting from a snapshot to the data part of the model.
- * Useful for example to do versioning and keep the data part up to date with the latest version of the model.
- *
- * @param model The model to apply the transformation over.
- * @param fn The function that will convert the custom input snapshot. Returns an input snapshot that must
- * match the current model input snapshot.
- * @returns The model with the transform.
- */
-export function fromSnapshotProcessor<
-  FS,
-  SuperModel,
-  TProps extends ModelProps,
-  FromSnapshot,
-  ToSnapshot
->(
-  model: _Model<SuperModel, TProps, FromSnapshot, ToSnapshot>,
-  fn: (sn: FS) => FromSnapshot
-): _Model<SuperModel, TProps, FS, ToSnapshot> {
-  return (model as any).withFromSnapshotProcessor(fn)
-}
-
-/**
- * Optional transformation that will be run when converting the data part of the model into a snapshot.
- *
- * @param fn The function that will convert the output snapshot. Returns a custom output snapshot.
- * @returns  The model with the transform.
- */
-export function toSnapshotProcessor<
-  TS,
-  SuperModel,
-  TProps extends ModelProps,
-  FromSnapshot,
-  ToSnapshot
->(
-  model: _Model<SuperModel, TProps, FromSnapshot, ToSnapshot>,
-  fn: (sn: ToSnapshot, modelInstance: any) => TS
-): _Model<SuperModel, TProps, FromSnapshot, TS> {
-  return (model as any).withToSnapshotProcessor(fn)
-}
-
-/**
  * Extract the model id property from the model props.
  */
 export type ExtractModelIdProp<TProps extends ModelProps> = {
@@ -105,13 +65,19 @@ export type ExtractModelIdProp<TProps extends ModelProps> = {
  * @param modelOptions Model options.
  * @returns
  */
-export function ExtendedModel<TProps extends ModelProps, TModel extends AnyModel, A extends []>(
+export function ExtendedModel<
+  TProps extends ModelProps,
+  TModel extends AnyModel,
+  A extends [],
+  FS = _FromSnapshot<TProps>,
+  TS = _ToSnapshot<TProps>
+>(
   genFn: (...args: A) => {
     baseModel: AbstractModelClass<TModel>
     props: TProps
   },
-  modelOptions?: ModelOptions
-): _Model<TModel, TProps>
+  modelOptions?: ModelOptions<TProps, FS, TS>
+): _Model<TModel, TProps, FS, TS>
 
 /**
  * Base abstract class for models that extends another model.
@@ -123,16 +89,24 @@ export function ExtendedModel<TProps extends ModelProps, TModel extends AnyModel
  * @param modelOptions Model options.
  * @returns
  */
-export function ExtendedModel<TProps extends ModelProps, TModel extends AnyModel>(
+export function ExtendedModel<
+  TProps extends ModelProps,
+  TModel extends AnyModel,
+  FS = _FromSnapshot<TProps>,
+  TS = _ToSnapshot<TProps>
+>(
   baseModel: AbstractModelClass<TModel>,
   modelProps: TProps,
-  modelOptions?: ModelOptions
-): _Model<TModel, TProps>
+  modelOptions?: ModelOptions<TProps, FS, TS>
+): _Model<TModel, TProps, FS, TS>
 
 // base
-export function ExtendedModel<TProps extends ModelProps, TModel extends AnyModel>(
-  ...args: any[]
-): _Model<TModel, TProps> {
+export function ExtendedModel<
+  TProps extends ModelProps,
+  TModel extends AnyModel,
+  FS = _FromSnapshot<TProps>,
+  TS = _ToSnapshot<TProps>
+>(...args: any[]): _Model<TModel, TProps, FS, TS> {
   let baseModel
   let modelProps
   let modelOptions
@@ -162,10 +136,15 @@ export function ExtendedModel<TProps extends ModelProps, TModel extends AnyModel
  * @param fnModelProps Function that generates model properties.
  * @param modelOptions Model options.
  */
-export function Model<TProps extends ModelProps, A extends []>(
+export function Model<
+  TProps extends ModelProps,
+  A extends [],
+  FS = _FromSnapshot<TProps>,
+  TS = _ToSnapshot<TProps>
+>(
   fnModelProps: (...args: A) => TProps,
-  modelOptions?: ModelOptions
-): _Model<unknown, TProps>
+  modelOptions?: ModelOptions<TProps, FS, TS>
+): _Model<unknown, TProps, FS, TS>
 
 /**
  * Base abstract class for models.
@@ -176,16 +155,21 @@ export function Model<TProps extends ModelProps, A extends []>(
  * @param modelProps Model properties.
  * @param modelOptions Model options.
  */
-export function Model<TProps extends ModelProps>(
-  modelProps: TProps,
-  modelOptions?: ModelOptions
-): _Model<unknown, TProps>
+export function Model<
+  TProps extends ModelProps,
+  FS = _FromSnapshot<TProps>,
+  TS = _ToSnapshot<TProps>
+>(modelProps: TProps, modelOptions?: ModelOptions<TProps, FS, TS>): _Model<unknown, TProps, FS, TS>
 
 // base
-export function Model<TProps extends ModelProps>(
+export function Model<
+  TProps extends ModelProps,
+  FS = _FromSnapshot<TProps>,
+  TS = _ToSnapshot<TProps>
+>(
   fnModelPropsOrModelProps: (() => TProps) | TProps,
-  modelOptions?: ModelOptions
-): _Model<unknown, TProps> {
+  modelOptions?: ModelOptions<TProps, FS, TS>
+): _Model<unknown, TProps, FS, TS> {
   const modelProps =
     typeof fnModelPropsOrModelProps === "function"
       ? fnModelPropsOrModelProps()
@@ -193,28 +177,51 @@ export function Model<TProps extends ModelProps>(
   return internalModel(modelProps, undefined, modelOptions)
 }
 
-function internalModel<TProps extends ModelProps, TBaseModel extends AnyModel>(
+function internalModel<
+  TProps extends ModelProps,
+  TBaseModel extends AnyModel,
+  FS = _FromSnapshot<TProps>,
+  TS = _ToSnapshot<TProps>
+>(
   modelProps: TProps,
   baseModel: ModelClass<TBaseModel> | undefined,
-  modelOptions?: ModelOptions
-): _Model<TBaseModel, TProps> {
+  modelOptions?: ModelOptions<TProps, FS, TS>
+): _Model<TBaseModel, TProps, FS, TS> {
   return sharedInternalModel({
     modelProps,
     baseModel,
     type: "class",
     valueType: modelOptions?.valueType ?? false,
-    fromSnapshotProcessor: undefined,
-    toSnapshotProcessor: undefined,
+    fromSnapshotProcessor: modelOptions?.fromSnapshotProcessor,
+    toSnapshotProcessor: modelOptions?.toSnapshotProcessor,
   })
 }
 
 /**
  * Model options.
  */
-export interface ModelOptions {
+export interface ModelOptions<TProps extends ModelProps, FS, TS> {
   /**
    * A value type will be cloned automatically when being attached to a new tree.
    * The default is `false`.
    */
   valueType?: boolean
+
+  /**
+   * Optional transformation that will be run when converting from a snapshot to the data part of the model.
+   * Useful for example to do versioning and keep the data part up to date with the latest version of the model.
+   *
+   * @param sn The custom input snapshot.
+   * @returns An input snapshot that must match the expected model input snapshot.
+   */
+  fromSnapshotProcessor?(sn: FS): _FromSnapshot<TProps>
+
+  /**
+   * Optional transformation that will be run when converting the data part of the model into a snapshot.
+   *
+   * @param sn The output snapshot.
+   * @param modelInstance The model instance.
+   * @returns  a custom output snapshot.
+   */
+  toSnapshotProcessor?(sn: _ToSnapshot<TProps>, modelInstance: any): TS
 }

--- a/packages/lib/src/model/newModel.ts
+++ b/packages/lib/src/model/newModel.ts
@@ -59,8 +59,8 @@ export const internalNewModel = action(
         }
       }
 
-      if (modelObj.fromSnapshot) {
-        sn = modelObj.fromSnapshot(sn)
+      if (modelClass.fromSnapshotProcessor) {
+        sn = modelClass.fromSnapshotProcessor(sn)
       }
 
       initialData = snapshotInitialData.snapshotToInitialData(sn)

--- a/packages/lib/src/model/utils.ts
+++ b/packages/lib/src/model/utils.ts
@@ -1,5 +1,4 @@
 import type { ModelClass } from "../modelShared/BaseModelShared"
-import type { SnapshotInOfModel } from "../snapshot/SnapshotOf"
 import { failure, isPlainObject } from "../utils"
 import type { AnyModel } from "./BaseModel"
 import { modelTypeKey } from "./metadata"
@@ -71,6 +70,6 @@ export function assertIsModelClass(
  * @ignore
  * @internal
  */
-export function isModelSnapshot(sn: any): sn is SnapshotInOfModel<AnyModel> {
+export function isModelSnapshot(sn: any): sn is { [modelTypeKey]: string } {
   return isPlainObject(sn) && !!sn[modelTypeKey]
 }

--- a/packages/lib/src/modelShared/BaseModelShared.ts
+++ b/packages/lib/src/modelShared/BaseModelShared.ts
@@ -23,6 +23,16 @@ export const transformedCreationDataTypeSymbol = Symbol()
 
 /**
  * @ignore
+ */
+export const fromSnapshotTypeSymbol = Symbol()
+
+/**
+ * @ignore
+ */
+export const toSnapshotTypeSymbol = Symbol()
+
+/**
+ * @ignore
  * @internal
  */
 export const modelInitializedSymbol = Symbol("modelInitialized")
@@ -32,6 +42,9 @@ export const modelInitializedSymbol = Symbol("modelInitialized")
  */
 export type ModelClass<M extends AnyModel | AnyDataModel> = {
   new (initialData: any): M
+
+  fromSnapshotProcessor?(sn: any): any
+  toSnapshotProcessor?(sn: any, modelInstance: any): any
 }
 
 /**
@@ -62,6 +75,18 @@ export type ModelTransformedData<M extends AnyModel | AnyDataModel> =
  */
 export type ModelTransformedCreationData<M extends AnyModel | AnyDataModel> =
   M[typeof transformedCreationDataTypeSymbol]
+
+/**
+ * The from snapshot type of a model.
+ * Use SnapshotInOf<Model> instead.
+ */
+export type ModelFromSnapshot<M extends AnyModel> = M[typeof fromSnapshotTypeSymbol]
+
+/**
+ * The to snapshot type of a model.
+ * Use SnapshotOutOf<Model> instead.
+ */
+export type ModelToSnapshot<M extends AnyModel> = M[typeof toSnapshotTypeSymbol]
 
 /**
  * Tricks Typescript into accepting a particular kind of generic class as a parameter for `ExtendedModel`.

--- a/packages/lib/src/modelShared/Model.ts
+++ b/packages/lib/src/modelShared/Model.ts
@@ -284,40 +284,21 @@ export function sharedInternalModel<
     }
   }
 
+  if (fromSnapshotProcessor) {
+    const fn = fromSnapshotProcessor
+    fromSnapshotProcessor = (sn) => ({ ...fn(sn), [modelTypeKey]: sn[modelTypeKey] })
+  }
+
+  if (toSnapshotProcessor) {
+    const fn = toSnapshotProcessor
+    toSnapshotProcessor = (sn: any, instance: any) => ({
+      ...fn(sn, instance),
+      [modelTypeKey]: sn[modelTypeKey],
+    })
+  }
+
   CustomBaseModel.fromSnapshotProcessor = fromSnapshotProcessor
   CustomBaseModel.toSnapshotProcessor = toSnapshotProcessor
-
-  if (type === "class") {
-    CustomBaseModel.withFromSnapshotProcessor = (fn: any) => {
-      const composedFn = (sn: any) =>
-        fromSnapshotProcessor
-          ? { ...fromSnapshotProcessor(fn(sn)), [modelTypeKey]: sn[modelTypeKey] }
-          : { ...fn(sn), [modelTypeKey]: sn[modelTypeKey] }
-      return sharedInternalModel({
-        modelProps,
-        baseModel,
-        type,
-        valueType,
-        fromSnapshotProcessor: composedFn,
-        toSnapshotProcessor,
-      })
-    }
-
-    CustomBaseModel.withToSnapshotProcessor = (fn: any) => {
-      const composedFn = (sn: any, instance: any) =>
-        toSnapshotProcessor
-          ? { ...fn(toSnapshotProcessor(sn, instance), instance), [modelTypeKey]: sn[modelTypeKey] }
-          : { ...fn(sn, instance), [modelTypeKey]: sn[modelTypeKey] }
-      return sharedInternalModel({
-        modelProps,
-        baseModel,
-        type,
-        valueType,
-        fromSnapshotProcessor,
-        toSnapshotProcessor: composedFn,
-      })
-    }
-  }
 
   return CustomBaseModel
 }

--- a/packages/lib/src/snapshot/SnapshotOf.ts
+++ b/packages/lib/src/snapshot/SnapshotOf.ts
@@ -1,7 +1,7 @@
 import type { Frozen, frozenKey } from "../frozen/Frozen"
 import type { AnyModel } from "../model/BaseModel"
 import type { modelIdKey, modelTypeKey } from "../model/metadata"
-import type { ModelCreationData, ModelData } from "../modelShared/BaseModelShared"
+import type { ModelFromSnapshot, ModelToSnapshot } from "../modelShared/BaseModelShared"
 import type { ArraySet, ObjectMap } from "../wrappers"
 
 // snapshot out
@@ -12,9 +12,7 @@ export type SnapshotOutOfObject<T> = {
   [k in keyof T]: SnapshotOutOf<T[k]> extends infer R ? R : never
 }
 
-export type SnapshotOutOfModel<M extends AnyModel> = SnapshotOutOfObject<ModelData<M>> & {
-  [modelTypeKey]: string
-}
+export type SnapshotOutOfModel<M extends AnyModel> = ModelToSnapshot<M>
 
 export type SnapshotOutOfFrozen<F extends Frozen<any>> = {
   [frozenKey]: true
@@ -61,11 +59,7 @@ export type SnapshotInOfObject<T> = {
   [k in keyof T]: SnapshotInOf<T[k]> extends infer R ? R : never
 }
 
-export type SnapshotInOfModel<M extends AnyModel> = SnapshotInOfObject<
-  M extends { fromSnapshot(sn: infer S): any } ? S : ModelCreationData<M>
-> & {
-  [modelTypeKey]: string
-}
+export type SnapshotInOfModel<M extends AnyModel> = ModelFromSnapshot<M>
 
 export type SnapshotInOfFrozen<F extends Frozen<any>> = {
   [frozenKey]: true

--- a/packages/lib/src/snapshot/applySnapshot.ts
+++ b/packages/lib/src/snapshot/applySnapshot.ts
@@ -13,7 +13,7 @@ import { assertTweakedObject } from "../tweaker/core"
 import { assertIsObject, failure, inDevMode, isArray, isPlainObject, lazy } from "../utils"
 import { ModelPool } from "../utils/ModelPool"
 import { reconcileSnapshot } from "./reconcileSnapshot"
-import type { SnapshotOutOf } from "./SnapshotOf"
+import type { SnapshotInOf } from "./SnapshotOf"
 
 /**
  * Applies a full snapshot over an object, reconciling it with the current contents of the object.
@@ -22,7 +22,7 @@ import type { SnapshotOutOf } from "./SnapshotOf"
  * @param node Target object (model object, object or array).
  * @param snapshot Snapshot to apply.
  */
-export function applySnapshot<T extends object>(node: T, snapshot: SnapshotOutOf<T>): void {
+export function applySnapshot<T extends object>(node: T, snapshot: SnapshotInOf<T>): void {
   assertTweakedObject(node, "node")
   assertIsObject(snapshot, "snapshot")
 
@@ -33,7 +33,7 @@ export function applySnapshot<T extends object>(node: T, snapshot: SnapshotOutOf
  * @ignore
  * @internal
  */
-export function internalApplySnapshot<T extends object>(this: T, sn: SnapshotOutOf<T>): void {
+export function internalApplySnapshot<T extends object>(this: T, sn: SnapshotInOf<T>): void {
   const obj = this
 
   const reconcile = () => {
@@ -84,7 +84,7 @@ export function internalApplySnapshot<T extends object>(this: T, sn: SnapshotOut
 
     const modelIdPropertyName = getModelIdPropertyName(modelInfo.class as ModelClass<AnyModel>)
     if (modelIdPropertyName) {
-      const id = sn[modelIdPropertyName]
+      const id = (sn as any)[modelIdPropertyName]
       if (obj[modelIdKey] !== id) {
         // different id, no reconciliation possible
         throw failure(

--- a/packages/lib/src/snapshot/getSnapshot.ts
+++ b/packages/lib/src/snapshot/getSnapshot.ts
@@ -25,5 +25,5 @@ export function getSnapshot<T>(nodeOrPrimitive: T): SnapshotOutOf<T> {
   }
 
   reportInternalSnapshotObserved(snapshot)
-  return snapshot.standard
+  return snapshot.transformed
 }

--- a/packages/lib/src/snapshot/reconcileModelSnapshot.ts
+++ b/packages/lib/src/snapshot/reconcileModelSnapshot.ts
@@ -3,7 +3,7 @@ import type { AnyModel } from "../model/BaseModel"
 import { getModelIdPropertyName } from "../model/getModelMetadata"
 import { isReservedModelKey, modelIdKey, modelTypeKey } from "../model/metadata"
 import { isModel, isModelSnapshot } from "../model/utils"
-import { ModelClass } from "../modelShared/BaseModelShared"
+import type { ModelClass } from "../modelShared/BaseModelShared"
 import { getModelInfoForName } from "../modelShared/modelInfo"
 import { runTypeCheckingAfterChange } from "../tweaker/typeChecking"
 import { withoutTypeChecking } from "../tweaker/withoutTypeChecking"
@@ -58,8 +58,9 @@ function reconcileModelSnapshot(
 
   withoutTypeChecking(() => {
     let processedSn: any = sn
-    if (modelObj.fromSnapshot) {
-      processedSn = modelObj.fromSnapshot(sn)
+    const modelClass: ModelClass<AnyModel> = (modelObj as any).constructor
+    if (modelClass.fromSnapshotProcessor) {
+      processedSn = modelClass.fromSnapshotProcessor(sn)
     }
 
     const data = modelObj.$

--- a/packages/lib/src/tweaker/tweakFrozen.ts
+++ b/packages/lib/src/tweaker/tweakFrozen.ts
@@ -24,7 +24,7 @@ export function tweakFrozen<T extends Frozen<any>>(
   })
 
   // we DON'T want data proxified, but the snapshot is the data itself
-  setInternalSnapshot(frozenObj, { [frozenKey]: true, data: frozenObj.data })
+  setInternalSnapshot(frozenObj, { [frozenKey]: true, data: frozenObj.data }, undefined)
 
   return frozenObj as any
 }

--- a/packages/lib/src/utils/ModelPool.ts
+++ b/packages/lib/src/utils/ModelPool.ts
@@ -38,7 +38,7 @@ export class ModelPool {
     const modelIdPropertyName = getModelIdPropertyName(modelInfo.class as ModelClass<AnyModel>)
 
     return modelIdPropertyName
-      ? this.findModelByTypeAndId(sn[modelTypeKey], sn[modelIdPropertyName])
+      ? this.findModelByTypeAndId(sn[modelTypeKey], (sn as any)[modelIdPropertyName])
       : undefined
   }
 }

--- a/packages/lib/test/model/modelDecorator.test.ts
+++ b/packages/lib/test/model/modelDecorator.test.ts
@@ -231,6 +231,7 @@ test("decoratedModel", () => {
         [modelIdKey]?: string
         x?: number | null
         y: number
+      } & {
         z: number
       } & {
         [modelTypeKey]: string
@@ -243,6 +244,7 @@ test("decoratedModel", () => {
         [modelIdKey]: string
         x: number
         y: number
+      } & {
         z: number
       } & {
         [modelTypeKey]: string

--- a/packages/lib/test/snapshot/processor.test.ts
+++ b/packages/lib/test/snapshot/processor.test.ts
@@ -1,32 +1,47 @@
 import { assert, _ } from "spec.ts"
 import {
+  applyPatches,
+  applySnapshot,
   fromSnapshot,
+  fromSnapshotProcessor,
+  getSnapshot,
   model,
   Model,
+  modelAction,
   modelSnapshotInWithMetadata,
+  modelSnapshotOutWithMetadata,
   modelTypeKey,
   prop,
   SnapshotInOf,
   SnapshotOutOf,
+  toSnapshotProcessor,
 } from "../../src"
 import "../commonSetup"
 
 test("input snapshot processor", () => {
   @model("customInputSnapshot")
-  class P3 extends Model({
-    arr: prop<number[]>(() => []),
-  }) {
-    fromSnapshot(sn: { y: string }) {
+  class P3 extends fromSnapshotProcessor(
+    fromSnapshotProcessor(
+      Model({
+        arr: prop<number[]>(() => []),
+      }),
+      (sn: { y: string }) => {
+        return {
+          arr: sn.y.split(",").map((x) => +x),
+        }
+      }
+    ),
+    (sn: { x: string }) => {
       return {
-        arr: sn.y.split(",").map((x) => +x),
+        y: sn.x,
       }
     }
-  }
+  ) {}
 
   assert(
     _ as SnapshotInOf<P3>,
     _ as {
-      y: string
+      x: string
     } & {
       [modelTypeKey]: string
     }
@@ -43,9 +58,163 @@ test("input snapshot processor", () => {
 
   const p = fromSnapshot<P3>(
     modelSnapshotInWithMetadata(P3, {
-      y: "30,40,50",
+      x: "30,40,50",
     })
   )
 
   expect(p.arr).toEqual([30, 40, 50])
+
+  applyPatches(p, [
+    {
+      path: ["arr"],
+      op: "replace",
+      value: [10, 20],
+    },
+  ])
+
+  expect(p.arr).toEqual([10, 20])
+
+  applySnapshot(
+    p,
+    modelSnapshotInWithMetadata(P3, {
+      x: "100,200",
+    })
+  )
+
+  expect(p.arr).toEqual([100, 200])
+
+  applySnapshot(p.arr, [300, 400])
+
+  expect(p.arr).toEqual([300, 400])
+})
+
+test("output snapshot processor", () => {
+  @model("innerCustomOutputSnapshot")
+  class IP4 extends toSnapshotProcessor(
+    Model({
+      arr: prop<number[]>(() => []),
+    }),
+    (sn, instance) => {
+      expect(instance instanceof IP4).toBe(true)
+      return {
+        y: sn.arr.map((x) => "" + x).join(","),
+      }
+    }
+  ) {
+    @modelAction
+    pop() {
+      this.arr.pop()
+    }
+  }
+
+  @model("customOutputSnapshot")
+  class P4 extends toSnapshotProcessor(
+    toSnapshotProcessor(
+      Model({
+        arr: prop<number[]>(() => []),
+        child: prop<IP4 | undefined>(),
+      }),
+      (sn, instance) => {
+        expect(instance instanceof P4).toBe(true)
+        return {
+          y: sn.arr.map((x) => "" + x).join(","),
+          child: sn.child,
+        }
+      }
+    ),
+    (sn) => {
+      return {
+        x: sn.y,
+        child: sn.child,
+      }
+    }
+  ) {
+    @modelAction
+    pop() {
+      this.arr.pop()
+    }
+  }
+
+  assert(
+    _ as SnapshotInOf<P4>,
+    _ as {
+      arr?: number[] | null
+      child?: SnapshotInOf<IP4>
+    } & {
+      [modelTypeKey]: string
+    }
+  )
+
+  assert(
+    _ as SnapshotOutOf<P4>,
+    _ as {
+      x: string
+      child: SnapshotOutOf<IP4> | undefined
+    } & {
+      [modelTypeKey]: string
+    }
+  )
+
+  const p = new P4({
+    arr: [30, 40, 50],
+    child: new IP4({
+      arr: [1, 2, 3],
+    }),
+  })
+
+  expect(getSnapshot(p)).toEqual(
+    modelSnapshotOutWithMetadata(P4, {
+      x: "30,40,50",
+      child: modelSnapshotOutWithMetadata(IP4, {
+        y: "1,2,3",
+      }),
+    })
+  )
+
+  p.pop()
+  p.child!.pop()
+
+  expect(getSnapshot(p)).toEqual(
+    modelSnapshotOutWithMetadata(P4, {
+      x: "30,40",
+      child: modelSnapshotOutWithMetadata(IP4, {
+        y: "1,2",
+      }),
+    })
+  )
+
+  applyPatches(p, [
+    {
+      path: ["arr", 0],
+      op: "replace",
+      value: 10,
+    },
+  ])
+
+  expect(getSnapshot(p)).toEqual(
+    modelSnapshotOutWithMetadata(P4, {
+      x: "10,40",
+      child: modelSnapshotOutWithMetadata(IP4, {
+        y: "1,2",
+      }),
+    })
+  )
+
+  applySnapshot(p, {
+    [modelTypeKey]: "customOutputSnapshot",
+    arr: [100, 200],
+    child: {
+      [modelTypeKey]: "innerCustomOutputSnapshot",
+      arr: [300, 400],
+    },
+  })
+
+  expect(getSnapshot(p)).toEqual(
+    modelSnapshotOutWithMetadata(P4, {
+      x: "100,200",
+      child: modelSnapshotOutWithMetadata(IP4, {
+        y: "300,400",
+      }),
+    })
+  )
 })

--- a/packages/site/src/classModels.mdx
+++ b/packages/site/src/classModels.mdx
@@ -472,27 +472,29 @@ Note that the `$modelType` property will always be there and will remain unchang
 
 ```ts
 @model("name")
-class Name extends fromSnapshotProcessor(
-  Model({
+class Name extends Model(
+  {
     // in version 2 we split fullName into firstName and lastName
     _version: prop(2),
     firstName: prop<string>(),
     lastName: prop<string>(),
   },
-  (
-    sn: { _version: 2; firstName: string; lastName: string } | { _version: 1; fullName: string }
-  ) => {
-    if (sn._version === 2) {
-      return sn
-    }
+  {
+    fromSnapshotProcessor(
+      sn: { _version: 2; firstName: string; lastName: string } | { _version: 1; fullName: string }
+    ) {
+      if (sn._version === 2) {
+        return sn
+      }
 
-    const [firstName, lastName] = sn.fullName.split(" ")
+      const [firstName, lastName] = sn.fullName.split(" ")
 
-    return {
-      _version: 2,
-      firstName,
-      lastName,
-    }
+      return {
+        _version: 2,
+        firstName,
+        lastName,
+      }
+    },
   }
 ) {
   // ...
@@ -504,18 +506,21 @@ Note that the `$modelType` property will always be there and will remain unchang
 
 ```ts
 @model("name")
-class Name extends toSnapshotProcessor(
-  Model({
+class Name extends Model(
+  {
     firstName: prop<string>(),
     lastName: prop<string>(),
   },
-  (sn, modelInstance) => {
-  // we want to also keep fullName for backwards compatibility
-  return {
-    ...sn,
-    fullName: `${sn.firstName} ${sn.lastName}`,
+  {
+    toSnapshotProcessor(sn, modelInstance) {
+      // we want to also keep fullName for backwards compatibility
+      return {
+        ...sn,
+        fullName: `${sn.firstName} ${sn.lastName}`,
+      }
+    },
   }
-}) {
+) {
   // ...
 }
 ```

--- a/packages/site/src/classModels.mdx
+++ b/packages/site/src/classModels.mdx
@@ -464,6 +464,62 @@ class X extends ExtendedModel(modelClass<SomeGenericClass<string>>(SomeGenericCl
 
 If you don't it will still compile, but the generic will be assumed to have unknown for all its generic parameters.
 
+## Snapshot pre/post-processors: `fromSnapshotProcessor` / `toSnapshotProcessor`
+
+`fromSnapshotProcessor` might be used to transform an input snapshot into the model expected input snapshot.
+This is useful for example for versioning.
+Note that the `$modelType` property will always be there and will remain unchanged no matter the transformation.
+
+```ts
+@model("name")
+class Name extends fromSnapshotProcessor(
+  Model({
+    // in version 2 we split fullName into firstName and lastName
+    _version: prop(2),
+    firstName: prop<string>(),
+    lastName: prop<string>(),
+  },
+  (
+    sn: { _version: 2; firstName: string; lastName: string } | { _version: 1; fullName: string }
+  ) => {
+    if (sn._version === 2) {
+      return sn
+    }
+
+    const [firstName, lastName] = sn.fullName.split(" ")
+
+    return {
+      _version: 2,
+      firstName,
+      lastName,
+    }
+  }
+) {
+  // ...
+}
+```
+
+`toSnapshotProcessor` is the opposite and might be used to transform the model expected output snapshot into another kind of object snapshot.
+Note that the `$modelType` property will always be there and will remain unchanged no matter the transformation.
+
+```ts
+@model("name")
+class Name extends toSnapshotProcessor(
+  Model({
+    firstName: prop<string>(),
+    lastName: prop<string>(),
+  },
+  (sn, modelInstance) => {
+  // we want to also keep fullName for backwards compatibility
+  return {
+    ...sn,
+    fullName: `${sn.firstName} ${sn.lastName}`,
+  }
+}) {
+  // ...
+}
+```
+
 ## Usage without decorators
 
 Although this library was primarily intented to be used with decorators it is also possible to use it without them.

--- a/packages/site/src/snapshots.mdx
+++ b/packages/site/src/snapshots.mdx
@@ -136,7 +136,7 @@ In both cases the returned disposer function can be called to cancel the effect.
 
 ## Applying snapshots
 
-### `applySnapshot<T extends object>(obj: T, sn: SnapshotOutOf<T>): void`
+### `applySnapshot<T extends object>(obj: T, sn: SnapshotInOf<T>): void`
 
 It is also possible to apply a snapshot over an object, reconciling the contents of the object and therefore ensuring that only the minimal set of snapshot changes / patches is triggered:
 


### PR DESCRIPTION
- [BREAKING CHANGE] The model override `fromSnapshot` has been removed in favor of `fromSnapshotProcessor` / `toSnapshotProcessor` for `Model` / `ExtendedModel`. These allow you to set up pre/post snapshot processors for models.

## Snapshot pre/post-processors: `fromSnapshotProcessor` / `toSnapshotProcessor`

`fromSnapshotProcessor` might be used to transform an input snapshot into the model expected input snapshot.
This is useful for example for versioning.
Note that the `$modelType` property will always be there and will remain unchanged no matter the transformation.

```ts
@model("name")
class Name extends Model(
  {
    // in version 2 we split fullName into firstName and lastName
    _version: prop(2),
    firstName: prop<string>(),
    lastName: prop<string>(),
  },
  {
    fromSnapshotProcessor(
      sn: { _version: 2; firstName: string; lastName: string } | { _version: 1; fullName: string }
    ) {
      if (sn._version === 2) {
        return sn
      }

      const [firstName, lastName] = sn.fullName.split(" ")

      return {
        _version: 2,
        firstName,
        lastName,
      }
    },
  }
) {
  // ...
}
```

`toSnapshotProcessor` is the opposite and might be used to transform the model expected output snapshot into another kind of object snapshot.
Note that the `$modelType` property will always be there and will remain unchanged no matter the transformation.

```ts
@model("name")
class Name extends Model(
  {
    firstName: prop<string>(),
    lastName: prop<string>(),
  },
  {
    toSnapshotProcessor(sn, modelInstance) {
      // we want to also keep fullName for backwards compatibility
      return {
        ...sn,
        fullName: `${sn.firstName} ${sn.lastName}`,
      }
    },
  }
) {
  // ...
}
```
