### PR TITLE
add link to undo middleware in standalone actions docs

### DIFF
--- a/packages/site/src/standardAndStandaloneActions.mdx
+++ b/packages/site/src/standardAndStandaloneActions.mdx
@@ -9,7 +9,7 @@ import { FixStyle } from "./components/FixStyle.tsx"
 
 # Standalone Actions
 
-Sometimes you might need to define a "model" action but without an associated model. Say for example that you need an array swap method that needs to be processed by middlewares (undoable, etc.). One way to achieve this is to use standalone actions like this:
+Sometimes you might need to define a "model" action but without an associated model. Say for example that you need an array swap method that needs to be processed by middlewares (e.g. [`undoMiddleware`](./actionMiddlewares/undoMiddleware)). One way to achieve this is to use standalone actions like this:
 
 ```ts
 const arraySwap = standaloneAction(


### PR DESCRIPTION
Just a minor improvement (IMO) regarding navigation across the docs pages.