### PR TITLE
prefer using generated setter in docs

### DIFF
--- a/packages/site/src/drafts.mdx
+++ b/packages/site/src/drafts.mdx
@@ -66,17 +66,10 @@ Given the preferences example mentioned above, let's imagine we have a model (pa
 
 ```ts
 @model("myApp/Preferences")
-class Preferences extends Model({ username: prop<string>(), avatarUrl: prop<string>() }) {
-  @modelAction
-  setUsername(val: string) {
-    this.username = val
-  }
-
-  @modelAction
-  setAvatarUrl(val: string) {
-    this.avatarUrl = val
-  }
-
+class Preferences extends Model({
+  username: prop<string>().withSetter(),
+  avatarUrl: prop<string>().withSetter(),
+}) {
   // just as an example, some validation code
   @computed
   get usernameValidationError(): string | null {

--- a/packages/site/src/mstComparison.mdx
+++ b/packages/site/src/mstComparison.mdx
@@ -107,29 +107,14 @@ In `mobx-keystone` snapshots are usually only expected when dealing with `getSna
 ```ts
 @model("myApp/Todo")
 class Todo extends Model({
-  done: prop(false),
-  text: prop<string>(),
-}) {
-  @modelAction
-  setText(text: string) {
-    this.text = text
-  }
-
-  @modelAction
-  setDone(done: boolean) {
-    this.done = done
-  }
-}
+  done: prop(false).withSetter(),
+  text: prop<string>().withSetter(),
+}) {}
 
 @model("myApp/RootStore")
 class RootStore extends Model({
-  selected: prop<Todo | undefined>(undefined),
-}) {
-  @modelAction
-  setSelected(todo: Todo | undefined) {
-    this.selected = todo
-  }
-}
+  selected: prop<Todo | undefined>(undefined).withSetter(),
+}) {}
 ```
 
 ### Less confusion between this/self usages - use of standard computed decorators

--- a/packages/site/src/rootStores.mdx
+++ b/packages/site/src/rootStores.mdx
@@ -47,7 +47,7 @@ First we need to define a model for the user preferences, as well as its desired
 type Theme = "light" | "dark"
 
 @model("myApp/UserPreferences")
-class UserPreferences extends Model({ theme: prop<Theme>() }) {
+class UserPreferences extends Model({ theme: prop<Theme>().withSetter() }) {
   // once we are part of the root store ...
   onAttachedToRootStore() {
     // every time the snapshot of the configuration changes
@@ -68,11 +68,6 @@ class UserPreferences extends Model({ theme: prop<Theme>() }) {
       reactionDisposer()
     }
   }
-
-  @modelAction
-  setTheme(theme: Theme) {
-    this.theme = theme
-  }
 }
 ```
 
@@ -80,12 +75,9 @@ class UserPreferences extends Model({ theme: prop<Theme>() }) {
 
 ```ts
 @model("myApp/RootStore")
-class RootStore extends Model({ userPreferences: prop<UserPreferences>() }) {
-  @modelAction
-  setUserPreferences(userPreferences: UserPreferences) {
-    this.userPreferences = userPreferences
-  }
-}
+class RootStore extends Model({
+  userPreferences: prop<UserPreferences>().withSetter(),
+}) {}
 ```
 
 ... then we will need some code to initialize our application, loading the preferences already stored in local storage ...

--- a/packages/site/src/sandbox.mdx
+++ b/packages/site/src/sandbox.mdx
@@ -18,16 +18,11 @@ For example, consider this simple model:
 ```ts
 @model("MyApp/EvenNumber")
 class EvenNumber extends Model({
-  value: prop<number>(),
+  value: prop<number>().withSetter(),
 }) {
   @computed
   get isValid(): number {
     return value % 2 === 0
-  }
-
-  @modelAction
-  setValue(value: number): void {
-    this.value = value
   }
 }
 ```


### PR DESCRIPTION
Since `withSetter()` should be the standard way of defining setters in my opinion unless a non-standard setter is needed, I think it should be preferred in the docs where applicable to promote its usage. I intentionally left `classModels.mdx` and `dataModels.mdx` untouched because those pages introduce `withSetter()` and for that reason should keep manually defined setters.

What do you think?