### PR TITLE
fix patchRecorder signature in docs

### DIFF
--- a/packages/site/src/patches.mdx
+++ b/packages/site/src/patches.mdx
@@ -39,7 +39,7 @@ const disposer = onPatches(todo, (patches, inversePatches) => {
 
 Note that the listener callback is called _immediately_ after an observable value has changed and before the outermost action has completed. This behavior differs from, e.g., `onSnapshot` or a MobX reaction.
 
-### `patchRecorder(target: object, opts?: { recording?: boolean; filter?(patches: Patch[], inversePatches: Patch[]): boolean }; onPatches?: OnPatchesListener): PatchRecorder;`
+### `patchRecorder(target: object, opts?: PatchRecorderOptions): PatchRecorder`
 
 `patchRecorder` is an abstraction over `onPatches` that can be used like this:
 


### PR DESCRIPTION
The fix is two-fold:
1. `patchRecorder` does not have a third argument `onPatches`, it's actually part of the `opts` argument.
2. The expanded `opts` argument type is a bit verbose and the `PatchRecorderOptions` interface is shown below anyway, so for better readability and consistency with the documentation of other functions, I've replaced the expanded type by the `PatchRecorderOptions` type.