### PR TITLE
use kebab-case URL paths in docs

### DIFF
--- a/packages/site/docs/actionMiddlewares/customMiddlewares.mdx
+++ b/packages/site/docs/actionMiddlewares/customMiddlewares.mdx
@@ -1,5 +1,6 @@
 ---
 name: Custom Middlewares
+slug: /action-middlewares/custom-middlewares
 ---
 
 ## Overview

--- a/packages/site/docs/actionMiddlewares/onActionMiddleware.mdx
+++ b/packages/site/docs/actionMiddlewares/onActionMiddleware.mdx
@@ -1,5 +1,6 @@
 ---
 name: onActionMiddleware
+slug: /action-middlewares/on-action-middleware
 ---
 
 This action middleware invokes a listener for all actions of a given tree.

--- a/packages/site/docs/actionMiddlewares/readonlyMiddleware.mdx
+++ b/packages/site/docs/actionMiddlewares/readonlyMiddleware.mdx
@@ -1,5 +1,6 @@
 ---
 name: readonlyMiddleware
+slug: /action-middlewares/readonly-middleware
 ---
 
 ## Overview

--- a/packages/site/docs/actionMiddlewares/transactionMiddleware.mdx
+++ b/packages/site/docs/actionMiddlewares/transactionMiddleware.mdx
@@ -1,5 +1,6 @@
 ---
 name: transactionMiddleware
+slug: /action-middlewares/transaction-middleware
 ---
 
 ## Overview

--- a/packages/site/docs/actionMiddlewares/undoMiddleware.mdx
+++ b/packages/site/docs/actionMiddlewares/undoMiddleware.mdx
@@ -1,5 +1,6 @@
 ---
 name: undoMiddleware
+slug: /action-middlewares/undo-middleware
 ---
 
 ## Overview

--- a/packages/site/docs/classModels.mdx
+++ b/packages/site/docs/classModels.mdx
@@ -1,5 +1,6 @@
 ---
 title: Class Models
+slug: /class-models
 ---
 
 ## Overview

--- a/packages/site/docs/contexts.mdx
+++ b/packages/site/docs/contexts.mdx
@@ -1,5 +1,6 @@
 ---
 title: Contexts
+slug: /contexts
 ---
 
 ## Overview

--- a/packages/site/docs/dataModels.mdx
+++ b/packages/site/docs/dataModels.mdx
@@ -1,5 +1,6 @@
 ---
 title: Data Models
+slug: /data-models
 ---
 
 ## Overview

--- a/packages/site/docs/drafts.mdx
+++ b/packages/site/docs/drafts.mdx
@@ -1,5 +1,6 @@
 ---
 title: Drafts
+slug: /drafts
 ---
 
 ## Overview

--- a/packages/site/docs/examples/clientServer/clientServer.mdx
+++ b/packages/site/docs/examples/clientServer/clientServer.mdx
@@ -1,6 +1,6 @@
 ---
 title: Client/Server
-slug: /examples/clientServer
+slug: /examples/client-server
 ---
 
 import BrowserOnly from "@docusaurus/BrowserOnly"

--- a/packages/site/docs/examples/todoList/todoList.mdx
+++ b/packages/site/docs/examples/todoList/todoList.mdx
@@ -1,6 +1,6 @@
 ---
 title: Todo List
-slug: /examples/todoList
+slug: /examples/todo-list
 ---
 
 import BrowserOnly from "@docusaurus/BrowserOnly"

--- a/packages/site/docs/frozen.mdx
+++ b/packages/site/docs/frozen.mdx
@@ -1,5 +1,6 @@
 ---
 title: Frozen Data
+slug: /frozen-data
 ---
 
 ## Overview

--- a/packages/site/docs/mapsSetsDates.mdx
+++ b/packages/site/docs/mapsSetsDates.mdx
@@ -1,5 +1,6 @@
 ---
 title: Maps, Sets, Dates
+slug: /maps-sets-dates
 ---
 
 ## Overview

--- a/packages/site/docs/mstComparison.mdx
+++ b/packages/site/docs/mstComparison.mdx
@@ -1,5 +1,6 @@
 ---
 title: Comparison with mobx-state-tree
+slug: /mst-comparison
 ---
 
 import { ArrowUpIcon } from "@site/src/components/ArrowUpIcon"

--- a/packages/site/docs/patches.mdx
+++ b/packages/site/docs/patches.mdx
@@ -1,5 +1,6 @@
 ---
 title: Patches
+slug: /patches
 ---
 
 ## Overview

--- a/packages/site/docs/reduxCompatibility.mdx
+++ b/packages/site/docs/reduxCompatibility.mdx
@@ -1,5 +1,6 @@
 ---
 title: Redux Compatibility
+slug: /redux-compatibility
 ---
 
 ## `asReduxStore`

--- a/packages/site/docs/references.mdx
+++ b/packages/site/docs/references.mdx
@@ -1,5 +1,6 @@
 ---
 title: References
+slug: /references
 ---
 
 ## Overview

--- a/packages/site/docs/rootStores.mdx
+++ b/packages/site/docs/rootStores.mdx
@@ -1,5 +1,6 @@
 ---
 title: Root Stores
+slug: /root-stores
 ---
 
 ## Overview

--- a/packages/site/docs/runtimeTypeChecking.mdx
+++ b/packages/site/docs/runtimeTypeChecking.mdx
@@ -1,5 +1,6 @@
 ---
 title: Runtime Type Checking
+slug: /runtime-type-checking
 ---
 
 ## Overview

--- a/packages/site/docs/sandboxes.mdx
+++ b/packages/site/docs/sandboxes.mdx
@@ -1,5 +1,6 @@
 ---
 title: Sandboxes
+slug: /sandboxes
 ---
 
 ## Overview

--- a/packages/site/docs/snapshots.mdx
+++ b/packages/site/docs/snapshots.mdx
@@ -1,5 +1,6 @@
 ---
 title: Snapshots
+slug: /snapshots
 ---
 
 ## Overview

--- a/packages/site/docs/standardAndStandaloneActions.mdx
+++ b/packages/site/docs/standardAndStandaloneActions.mdx
@@ -1,5 +1,6 @@
 ---
 title: Standard and Standalone Actions
+slug: /standard-and-standalone-actions
 ---
 
 ## Standalone Actions

--- a/packages/site/docs/treeLikeStructure.mdx
+++ b/packages/site/docs/treeLikeStructure.mdx
@@ -1,5 +1,6 @@
 ---
 title: Tree-Like Structure
+slug: /tree-like-structure
 ---
 
 ## Overview

--- a/packages/site/sidebars.js
+++ b/packages/site/sidebars.js
@@ -29,7 +29,7 @@ module.exports = {
     "frozen",
     "runtimeTypeChecking",
     "drafts",
-    "sandbox",
+    "sandboxes",
     "reduxCompatibility",
     {
       type: "category",


### PR DESCRIPTION
This PR changes the URL path style of the docs from camel-case to kebab-case.

Follow-up of #347.