### PR TITLE
add search to docs

### DIFF
--- a/.prettierignore
+++ b/.prettierignore
@@ -6,8 +6,8 @@ dist/
 /packages/lib/LICENSE
 /packages/lib/CHANGELOG.md
 
-/packages/site/.docz/
-/packages/site/public/api/
+/packages/site/.docusaurus/
+/packages/site/build/
 
 .yarn/*
 !.yarn/patches

--- a/package.json
+++ b/package.json
@@ -28,5 +28,9 @@
     "react-scripts": "^4.0.3",
     "typescript": "^4.5.2"
   },
-  "packageManager": "yarn@3.1.0"
+  "packageManager": "yarn@3.1.0",
+  "dependencies": {
+    "bufferutil": "^4.0.5",
+    "utf-8-validate": "^5.0.7"
+  }
 }

--- a/package.json
+++ b/package.json
@@ -9,6 +9,7 @@
     "lib:test": "cd packages && cd lib && yarn test",
     "site:start": "cd packages && cd site && yarn start",
     "site:build": "cd packages && cd site && yarn build",
+    "site:serve": "cd packages && cd site && yarn serve",
     "build-netlify": "yarn lib:build && yarn lib:build-docs && yarn site:build",
     "netlify-dev": "yarn build-netlify && netlify dev",
     "lint": "cd packages && cd lib && yarn lint"

--- a/package.json
+++ b/package.json
@@ -19,6 +19,10 @@
     "packages/site",
     "packages/benchmark"
   ],
+  "dependencies": {
+    "bufferutil": "^4.0.5",
+    "utf-8-validate": "^5.0.7"
+  },
   "devDependencies": {
     "codecov": "^3.8.3",
     "eslint": "^7.32.0",
@@ -28,9 +32,5 @@
     "react-scripts": "^4.0.3",
     "typescript": "^4.5.2"
   },
-  "packageManager": "yarn@3.1.0",
-  "dependencies": {
-    "bufferutil": "^4.0.5",
-    "utf-8-validate": "^5.0.7"
-  }
+  "packageManager": "yarn@3.1.0"
 }

--- a/packages/site/docusaurus.config.js
+++ b/packages/site/docusaurus.config.js
@@ -1,6 +1,8 @@
 // @ts-check
 // Note: type annotations allow type checking and IDEs autocompletion
 
+const docsRouteBasePath = "/"
+
 /** @type {import('@docusaurus/types').Config} */
 const config = {
   title: "mobx-keystone",
@@ -13,23 +15,34 @@ const config = {
   favicon: "img/favicon.ico",
   organizationName: "xaviergonz",
   projectName: "mobx-keystone",
-  themes: [
+  presets: [
     [
-      "@docusaurus/theme-classic",
-      /** @type {import('@docusaurus/theme-classic').Options} */
-      {
-        customCss: require.resolve("./src/css/custom.css"),
-      },
+      "@docusaurus/preset-classic",
+      /** @type {import('@docusaurus/preset-classic').Options} */
+      ({
+        docs: {
+          sidebarPath: require.resolve("./sidebars.js"),
+          editUrl: "https://github.com/xaviergonz/mobx-keystone/edit/master/packages/site/",
+          routeBasePath: docsRouteBasePath,
+        },
+        blog: false,
+        pages: false,
+        sitemap: false,
+        theme: {
+          customCss: require.resolve("./src/css/custom.css"),
+        },
+      }),
     ],
   ],
   plugins: [
     [
-      "@docusaurus/plugin-content-docs",
-      /** @type {import('@docusaurus/plugin-content-docs').Options} */
+      "@easyops-cn/docusaurus-search-local",
       {
-        sidebarPath: require.resolve("./sidebars.js"),
-        editUrl: "https://github.com/xaviergonz/mobx-keystone/edit/master/packages/site/",
-        routeBasePath: "/",
+        hashed: true,
+        indexDocs: true,
+        docsRouteBasePath,
+        indexBlog: false,
+        indexPages: false,
       },
     ],
   ],

--- a/packages/site/package.json
+++ b/packages/site/package.json
@@ -6,11 +6,13 @@
   "license": "MIT",
   "scripts": {
     "start": "docusaurus start",
-    "build": "docusaurus build"
+    "build": "docusaurus build",
+    "serve": "docusaurus serve"
   },
   "dependencies": {
     "@docusaurus/core": "2.0.0-beta.9",
     "@docusaurus/preset-classic": "2.0.0-beta.9",
+    "@easyops-cn/docusaurus-search-local": "^0.20.0",
     "@mdx-js/react": "^1.6.22",
     "bootstrap-icons": "^1.7.1",
     "mobx": "^6.3.7",

--- a/packages/site/src/css/custom.css
+++ b/packages/site/src/css/custom.css
@@ -9,6 +9,11 @@
   --ifm-navbar-background-color: #000;
   --ifm-menu-color-background-hover: rgba(255, 255, 255, 0.08);
   --ifm-menu-color-background-active: rgba(255, 255, 255, 0.1);
+  --ifm-navbar-search-input-background-color: rgba(255, 255, 255, 0.2);
+}
+
+.navbar__search-input:focus {
+  outline: var(--ifm-color-primary) solid 2px;
 }
 
 .footer--dark {
@@ -18,4 +23,8 @@
 svg.icon {
   display: inline;
   vertical-align: middle;
+}
+
+html[data-theme="dark"] input[type="search"] {
+  color: #000;
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -2467,6 +2467,19 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@docusaurus/types@npm:2.0.0-beta.ff31de0ff":
+  version: 2.0.0-beta.ff31de0ff
+  resolution: "@docusaurus/types@npm:2.0.0-beta.ff31de0ff"
+  dependencies:
+    commander: ^5.1.0
+    joi: ^17.4.0
+    querystring: 0.2.0
+    webpack: ^5.37.0
+    webpack-merge: ^5.7.3
+  checksum: 48458c02c953a07acc011f3d99734ff8fdd4b0a9936f43a325309b8f8af21a0d67727d84ae37ed99cfec5c69de2508b02efa0a16dce93c0fc727cde8848d229e
+  languageName: node
+  linkType: hard
+
 "@docusaurus/utils-common@npm:2.0.0-beta.9":
   version: 2.0.0-beta.9
   resolution: "@docusaurus/utils-common@npm:2.0.0-beta.9"
@@ -2486,6 +2499,18 @@ __metadata:
     joi: ^17.4.2
     tslib: ^2.3.1
   checksum: bac0183ef343786ac0c4023b61ff8666cd4d82437d650ba1522cd5509ae085e162a4b3e57ab38949a3bc11ecb67a0402460762bb012bbe74fe9205d656e03770
+  languageName: node
+  linkType: hard
+
+"@docusaurus/utils-validation@npm:^2.0.0-beta.4":
+  version: 2.0.0-beta.ff31de0ff
+  resolution: "@docusaurus/utils-validation@npm:2.0.0-beta.ff31de0ff"
+  dependencies:
+    "@docusaurus/utils": 2.0.0-beta.ff31de0ff
+    chalk: ^4.1.1
+    joi: ^17.4.0
+    tslib: ^2.1.0
+  checksum: b9edad2b0ca8986bc8ce911c4bc2df5e60ecb32b533443e16441f97e52aa278f6291104bf86668752887184e53e1b348ea61d6d73f16c2289766b433f1459bab
   languageName: node
   linkType: hard
 
@@ -2511,6 +2536,53 @@ __metadata:
     react: "*"
     react-dom: "*"
   checksum: e5eec7d1cb84a40025625eb2bafe91f19a9ead8b13b7fcb8cd183253a6c87f1ca56afc6e3a1f481f8b7adb7e44405887413ecd5ff01f88c39527ba4296d22e8d
+  languageName: node
+  linkType: hard
+
+"@docusaurus/utils@npm:2.0.0-beta.ff31de0ff, @docusaurus/utils@npm:^2.0.0-beta.4":
+  version: 2.0.0-beta.ff31de0ff
+  resolution: "@docusaurus/utils@npm:2.0.0-beta.ff31de0ff"
+  dependencies:
+    "@docusaurus/types": 2.0.0-beta.ff31de0ff
+    "@types/github-slugger": ^1.3.0
+    chalk: ^4.1.1
+    escape-string-regexp: ^4.0.0
+    fs-extra: ^10.0.0
+    gray-matter: ^4.0.3
+    lodash: ^4.17.20
+    resolve-pathname: ^3.0.0
+    tslib: ^2.2.0
+  checksum: 0aad6e43ba9d72da72d7b494e5792845b9c9fe7c9cefcae13e51717f4f576fd87815dd05df880e7f9d235af883ade0162c1b1083c41290aae7022f1eef4ee2c4
+  languageName: node
+  linkType: hard
+
+"@easyops-cn/autocomplete.js@npm:^0.38.1":
+  version: 0.38.1
+  resolution: "@easyops-cn/autocomplete.js@npm:0.38.1"
+  dependencies:
+    cssesc: ^3.0.0
+    immediate: ^3.2.3
+  checksum: d88b61f12c383856b8d5cedf176a6d07a21e013dc2c78be029af81e2e026ece2bb988c6ea7f9951a2759c2e6f806ea1d1c9627bf36d9cbe376e897a94ce5da09
+  languageName: node
+  linkType: hard
+
+"@easyops-cn/docusaurus-search-local@npm:^0.20.0":
+  version: 0.20.0
+  resolution: "@easyops-cn/docusaurus-search-local@npm:0.20.0"
+  dependencies:
+    "@docusaurus/utils": ^2.0.0-beta.4
+    "@docusaurus/utils-validation": ^2.0.0-beta.4
+    "@easyops-cn/autocomplete.js": ^0.38.1
+    cheerio: ^1.0.0-rc.3
+    clsx: ^1.1.1
+    debug: ^4.2.0
+    fs-extra: ^9.0.1
+    klaw-sync: ^6.0.0
+    lunr: ^2.3.9
+    lunr-languages: ^1.4.0
+    mark.js: ^8.11.1
+    tslib: ^2.2.0
+  checksum: 31459ad99510996cb31b76974452b88b45ae33858ffe1ab052ff1f8073b61bc432eea039b37f8bd0b8b4a5c17629a6b58e986ba7e23db569a3977794cc929522
   languageName: node
   linkType: hard
 
@@ -7656,7 +7728,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"chalk@npm:^4.0.0, chalk@npm:^4.1.0, chalk@npm:^4.1.2":
+"chalk@npm:^4.0.0, chalk@npm:^4.1.0, chalk@npm:^4.1.1, chalk@npm:^4.1.2":
   version: 4.1.2
   resolution: "chalk@npm:4.1.2"
   dependencies:
@@ -7708,6 +7780,19 @@ __metadata:
   languageName: node
   linkType: hard
 
+"cheerio-select@npm:^1.5.0":
+  version: 1.5.0
+  resolution: "cheerio-select@npm:1.5.0"
+  dependencies:
+    css-select: ^4.1.3
+    css-what: ^5.0.1
+    domelementtype: ^2.2.0
+    domhandler: ^4.2.0
+    domutils: ^2.7.0
+  checksum: d4506d8b9ad330a18f9de3a5a22138d0804063e92aac2fc020384cc52ab86d2194d2ae614fc87f0e2a62b6a6dd0c28ad23669cec64331172a9f99ad604863010
+  languageName: node
+  linkType: hard
+
 "cheerio@npm:^0.22.0":
   version: 0.22.0
   resolution: "cheerio@npm:0.22.0"
@@ -7729,6 +7814,21 @@ __metadata:
     lodash.reject: ^4.4.0
     lodash.some: ^4.4.0
   checksum: b0a6cfa61eb7ae96e4cb8cfeeb14eb45bb790fa40098509268629c4cecca5b99124aabe6daa1154c497ac8def47bc3f9706cef5f0e8a6177a0c137d4bdaaf8b7
+  languageName: node
+  linkType: hard
+
+"cheerio@npm:^1.0.0-rc.3":
+  version: 1.0.0-rc.10
+  resolution: "cheerio@npm:1.0.0-rc.10"
+  dependencies:
+    cheerio-select: ^1.5.0
+    dom-serializer: ^1.3.2
+    domhandler: ^4.2.0
+    htmlparser2: ^6.1.0
+    parse5: ^6.0.1
+    parse5-htmlparser2-tree-adapter: ^6.0.1
+    tslib: ^2.2.0
+  checksum: ace2f9c5809737534b1320d11d48762013694fa905b4deacac81a634edac178c1b0534f79d7b1896a88ce489db6cb539f222317996b21c8b6923ce413dcc1a2f
   languageName: node
   linkType: hard
 
@@ -9083,7 +9183,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"css-what@npm:^5.0.0":
+"css-what@npm:^5.0.0, css-what@npm:^5.0.1":
   version: 5.1.0
   resolution: "css-what@npm:5.1.0"
   checksum: 0b75d1bac95c885c168573c85744a6c6843d8c33345f54f717218b37ea6296b0e99bb12105930ea170fd4a921990392a7c790c16c585c1d8960c49e2b7ec39f7
@@ -9384,7 +9484,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"debug@npm:4, debug@npm:^4.0.0, debug@npm:^4.0.1, debug@npm:^4.1.0, debug@npm:^4.1.1, debug@npm:^4.3.1":
+"debug@npm:4, debug@npm:^4.0.0, debug@npm:^4.0.1, debug@npm:^4.1.0, debug@npm:^4.1.1, debug@npm:^4.2.0, debug@npm:^4.3.1":
   version: 4.3.2
   resolution: "debug@npm:4.3.2"
   dependencies:
@@ -10004,7 +10104,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"dom-serializer@npm:^1.0.1":
+"dom-serializer@npm:^1.0.1, dom-serializer@npm:^1.3.2":
   version: 1.3.2
   resolution: "dom-serializer@npm:1.3.2"
   dependencies:
@@ -10093,7 +10193,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"domutils@npm:^2.5.2, domutils@npm:^2.6.0":
+"domutils@npm:^2.5.2, domutils@npm:^2.6.0, domutils@npm:^2.7.0":
   version: 2.8.0
   resolution: "domutils@npm:2.8.0"
   dependencies:
@@ -13545,6 +13645,13 @@ fsevents@^1.2.7:
   languageName: node
   linkType: hard
 
+"immediate@npm:^3.2.3":
+  version: 3.3.0
+  resolution: "immediate@npm:3.3.0"
+  checksum: 634b4305101e2452eba6c07d485bf3e415995e533c94b9c3ffbc37026fa1be34def6e4f2276b0dc2162a3f91628564a4bfb26280278b89d3ee54624e854d2f5f
+  languageName: node
+  linkType: hard
+
 "immer@npm:8.0.1":
   version: 8.0.1
   resolution: "immer@npm:8.0.1"
@@ -15990,6 +16097,15 @@ fsevents@^1.2.7:
   languageName: node
   linkType: hard
 
+"klaw-sync@npm:^6.0.0":
+  version: 6.0.0
+  resolution: "klaw-sync@npm:6.0.0"
+  dependencies:
+    graceful-fs: ^4.1.11
+  checksum: 0da397f8961313c3ef8f79fb63af9002cde5a8fb2aeb1a37351feff0dd6006129c790400c3f5c3b4e757bedcabb13d21ec0a5eaef5a593d59515d4f2c291e475
+  languageName: node
+  linkType: hard
+
 "kleur@npm:^3.0.3":
   version: 3.0.3
   resolution: "kleur@npm:3.0.3"
@@ -16619,6 +16735,13 @@ fsevents@^1.2.7:
   languageName: node
   linkType: hard
 
+"lunr-languages@npm:^1.4.0":
+  version: 1.9.0
+  resolution: "lunr-languages@npm:1.9.0"
+  checksum: 19da5df19ba77bc5b91653ed801676f2cb6d4f38dc5fd1d5446d909e4134c54e206f97715814abdeb6792bd4e21915259a8c3e02b3a8727ec8545f2a6d13dd11
+  languageName: node
+  linkType: hard
+
 "lunr@npm:^2.3.9":
   version: 2.3.9
   resolution: "lunr@npm:2.3.9"
@@ -16737,6 +16860,13 @@ fsevents@^1.2.7:
   dependencies:
     object-visit: ^1.0.0
   checksum: c27045a5021c344fc19b9132eb30313e441863b2951029f8f8b66f79d3d8c1e7e5091578075a996f74e417479506fe9ede28c44ca7bc351a61c9d8073daec36a
+  languageName: node
+  linkType: hard
+
+"mark.js@npm:^8.11.1":
+  version: 8.11.1
+  resolution: "mark.js@npm:8.11.1"
+  checksum: aa6b9ae1c67245348d5b7abd253ef2acd6bb05c6be358d7d192416d964e42665fc10e0e865591c6f93ab9b57e8da1f23c23216e8ebddb580905ea7a0c0df15d4
   languageName: node
   linkType: hard
 
@@ -18944,7 +19074,16 @@ fsevents@^1.2.7:
   languageName: node
   linkType: hard
 
-"parse5@npm:6.0.1, parse5@npm:^6.0.0":
+"parse5-htmlparser2-tree-adapter@npm:^6.0.1":
+  version: 6.0.1
+  resolution: "parse5-htmlparser2-tree-adapter@npm:6.0.1"
+  dependencies:
+    parse5: ^6.0.1
+  checksum: 1848378b355d027915645c13f13f982e60502d201f53bc2067a508bf2dba4aac08219fc781dcd160167f5f50f0c73f58d20fa4fb3d90ee46762c20234fa90a6d
+  languageName: node
+  linkType: hard
+
+"parse5@npm:6.0.1, parse5@npm:^6.0.0, parse5@npm:^6.0.1":
   version: 6.0.1
   resolution: "parse5@npm:6.0.1"
   checksum: 7d569a176c5460897f7c8f3377eff640d54132b9be51ae8a8fa4979af940830b2b0c296ce75e5bd8f4041520aadde13170dbdec44889975f906098ea0002f4bd
@@ -23004,6 +23143,7 @@ resolve@1.18.1:
     "@docusaurus/core": 2.0.0-beta.9
     "@docusaurus/module-type-aliases": 2.0.0-beta.9
     "@docusaurus/preset-classic": 2.0.0-beta.9
+    "@easyops-cn/docusaurus-search-local": ^0.20.0
     "@mdx-js/react": ^1.6.22
     "@svgr/webpack": ^5.5.0
     "@tsconfig/docusaurus": ^1.0.4
@@ -24720,7 +24860,7 @@ resolve@1.18.1:
   languageName: node
   linkType: hard
 
-"tslib@npm:^2, tslib@npm:^2.0.0, tslib@npm:^2.0.3, tslib@npm:^2.3.0, tslib@npm:^2.3.1":
+"tslib@npm:^2, tslib@npm:^2.0.0, tslib@npm:^2.0.3, tslib@npm:^2.1.0, tslib@npm:^2.2.0, tslib@npm:^2.3.0, tslib@npm:^2.3.1":
   version: 2.3.1
   resolution: "tslib@npm:2.3.1"
   checksum: de17a98d4614481f7fcb5cd53ffc1aaf8654313be0291e1bfaee4b4bb31a20494b7d218ff2e15017883e8ea9626599b3b0e0229c18383ba9dce89da2adf15cb9
@@ -25945,7 +26085,7 @@ typescript@^3.9.7:
   languageName: node
   linkType: hard
 
-"webpack-merge@npm:^5.8.0":
+"webpack-merge@npm:^5.7.3, webpack-merge@npm:^5.8.0":
   version: 5.8.0
   resolution: "webpack-merge@npm:5.8.0"
   dependencies:
@@ -26007,6 +26147,43 @@ typescript@^3.9.7:
   bin:
     webpack: bin/webpack.js
   checksum: 3d42ee6af7a0ff14fc00136d02f4a36381fd5b6ad0636b95a8b83e6d99bc7e02f888f4994c095ae986e567033fe7bb1d445e27afe49d2872b8fe5c3a57d20de6
+  languageName: node
+  linkType: hard
+
+"webpack@npm:^5.37.0":
+  version: 5.64.3
+  resolution: "webpack@npm:5.64.3"
+  dependencies:
+    "@types/eslint-scope": ^3.7.0
+    "@types/estree": ^0.0.50
+    "@webassemblyjs/ast": 1.11.1
+    "@webassemblyjs/wasm-edit": 1.11.1
+    "@webassemblyjs/wasm-parser": 1.11.1
+    acorn: ^8.4.1
+    acorn-import-assertions: ^1.7.6
+    browserslist: ^4.14.5
+    chrome-trace-event: ^1.0.2
+    enhanced-resolve: ^5.8.3
+    es-module-lexer: ^0.9.0
+    eslint-scope: 5.1.1
+    events: ^3.2.0
+    glob-to-regexp: ^0.4.1
+    graceful-fs: ^4.2.4
+    json-parse-better-errors: ^1.0.2
+    loader-runner: ^4.2.0
+    mime-types: ^2.1.27
+    neo-async: ^2.6.2
+    schema-utils: ^3.1.0
+    tapable: ^2.1.1
+    terser-webpack-plugin: ^5.1.3
+    watchpack: ^2.2.0
+    webpack-sources: ^3.2.2
+  peerDependenciesMeta:
+    webpack-cli:
+      optional: true
+  bin:
+    webpack: bin/webpack.js
+  checksum: dc773c260b5db95d7c0e9aec079e9ed30a154420e3fc7fb46bd4f9b98714f322d8effe6534d5a3a17157f2c514a6edb26494585de4f1c92329980e04de235dd3
   languageName: node
   linkType: hard
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -7370,6 +7370,16 @@ __metadata:
   languageName: node
   linkType: hard
 
+"bufferutil@npm:^4.0.5":
+  version: 4.0.5
+  resolution: "bufferutil@npm:4.0.5"
+  dependencies:
+    node-gyp: latest
+    node-gyp-build: ^4.3.0
+  checksum: 37d5bef7cb38d29f9377b8891ff8a57f53ae6057313d77a8aa2a7417df37a72f16987100796cb2f1e1862f3eb80057705f3c052615ec076a0dcc7aa6c83b68c9
+  languageName: node
+  linkType: hard
+
 "builtin-modules@npm:^3.0.0, builtin-modules@npm:^3.1.0":
   version: 3.2.0
   resolution: "builtin-modules@npm:3.2.0"
@@ -17954,7 +17964,7 @@ fsevents@^1.2.7:
   languageName: node
   linkType: hard
 
-"node-gyp-build@npm:^4.2.2":
+"node-gyp-build@npm:^4.2.2, node-gyp-build@npm:^4.3.0":
   version: 4.3.0
   resolution: "node-gyp-build@npm:4.3.0"
   bin:
@@ -22467,6 +22477,7 @@ resolve@1.18.1:
   version: 0.0.0-use.local
   resolution: "root@workspace:."
   dependencies:
+    bufferutil: ^4.0.5
     codecov: ^3.8.3
     eslint: ^7.32.0
     eslint-config-prettier: ^8.3.0
@@ -22474,6 +22485,7 @@ resolve@1.18.1:
     prettier: ^2.4.1
     react-scripts: ^4.0.3
     typescript: ^4.5.2
+    utf-8-validate: ^5.0.7
   languageName: unknown
   linkType: soft
 
@@ -25548,6 +25560,16 @@ typescript@^3.9.7:
   version: 3.1.1
   resolution: "use@npm:3.1.1"
   checksum: 08a130289f5238fcbf8f59a18951286a6e660d17acccc9d58d9b69dfa0ee19aa038e8f95721b00b432c36d1629a9e32a464bf2e7e0ae6a244c42ddb30bdd8b33
+  languageName: node
+  linkType: hard
+
+"utf-8-validate@npm:^5.0.7":
+  version: 5.0.7
+  resolution: "utf-8-validate@npm:5.0.7"
+  dependencies:
+    node-gyp: latest
+    node-gyp-build: ^4.3.0
+  checksum: 588d272b359bf555a0c4c2ffe97286edc73126de132f63f4f0c80110bd06b67d3ce44d2b3d24feea6da13ced50c04d774ba4d25fe28576371cd714cd013bd3b7
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
This PR adds search to the docs using [`@easyops-cn/docusaurus-search-local`](https://github.com/easyops-cn/docusaurus-search-local).

I looked at all local search solutions for Docusaurus and found this one to be the best (IMO) considering functionality, design, code quality, and maintenance.

- [`docusaurus-plugin-lunr`](https://github.com/daldridge/docusaurus-plugin-lunr) - Appears to be umaintained.
- [`docusaurus-lunr-search`](https://github.com/lelouch77/docusaurus-lunr-search) - [No support for dark mode](https://github.com/lelouch77/docusaurus-lunr-search/issues/55) yet, written in JavaScript (not TypeScript), [requires manual swizzling](https://github.com/lelouch77/docusaurus-lunr-search#how-to-use-), not actually tested. But generally looks not too bad. Might be an alternative.
- [`@cmfcmf/docusaurus-search-local`](https://github.com/cmfcmf/docusaurus-search-local) - Needs some style adjustments, a bit difficult to style (mainly via Algolia CSS variables which are a bit odd because of `-rgb` and `-alpha` variables, so reusing `--ifm-` color varialbes doesn't work), result highlighting sometimes breaks text rendering and cannot be disabled, code quality could be better (IMO), [hiding result highlighting requires page reload or navigating to another page](https://github.com/cmfcmf/docusaurus-search-local/issues/42).
- [`docusaurus-theme-search-typesense`](https://github.com/typesense/docusaurus-theme-search-typesense) - Requires a Typesense server.

On the other hand, [`@easyops-cn/docusaurus-search-local`](https://github.com/easyops-cn/docusaurus-search-local) is easy to set up, requires minimal style customization, supports light and dark mode out of the box, code quality looks quite good (IMO), looks sufficiently maintained (although there's not a ton of activity), has a search page. I probably would have preferred a modal/overlay like Algolia's instead of a popover. Just a minor issue: For very small screens, the popover leaves the viewport at the left of the screen, but that's probably a rare case and could be fixed if needed.

A final note: In order to try the search feature, you need to _build_ the docs and serve the built files, i.e. run:
```bash
yarn site:build
yarn site:serve
```

Search doesn't work with the development server (`yarn site:start`).

Alternatively, we could use Algolia, of course. What do you think?

Follow-up of #347.