### PR TITLE
update deps

### DIFF
--- a/packages/site/package.json
+++ b/packages/site/package.json
@@ -10,8 +10,8 @@
     "serve": "docusaurus serve"
   },
   "dependencies": {
-    "@docusaurus/core": "2.0.0-beta.13",
-    "@docusaurus/preset-classic": "2.0.0-beta.13",
+    "@docusaurus/core": "2.0.0-beta.14",
+    "@docusaurus/preset-classic": "2.0.0-beta.14",
     "@easyops-cn/docusaurus-search-local": "^0.21.4",
     "@mdx-js/react": "^1.6.22",
     "bootstrap-icons": "^1.7.2",
@@ -25,7 +25,7 @@
   },
   "devDependencies": {
     "@babel/plugin-proposal-decorators": "^7.16.5",
-    "@docusaurus/module-type-aliases": "2.0.0-beta.13",
+    "@docusaurus/module-type-aliases": "2.0.0-beta.14",
     "@svgr/webpack": "^6.1.2",
     "@tsconfig/docusaurus": "^1.0.4",
     "@types/react": "^17.0.37",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1815,9 +1815,9 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@docusaurus/core@npm:2.0.0-beta.13":
-  version: 2.0.0-beta.13
-  resolution: "@docusaurus/core@npm:2.0.0-beta.13"
+"@docusaurus/core@npm:2.0.0-beta.14":
+  version: 2.0.0-beta.14
+  resolution: "@docusaurus/core@npm:2.0.0-beta.14"
   dependencies:
     "@babel/core": ^7.16.0
     "@babel/generator": ^7.16.0
@@ -1829,19 +1829,19 @@ __metadata:
     "@babel/runtime": ^7.16.3
     "@babel/runtime-corejs3": ^7.16.3
     "@babel/traverse": ^7.16.3
-    "@docusaurus/cssnano-preset": 2.0.0-beta.13
-    "@docusaurus/mdx-loader": 2.0.0-beta.13
+    "@docusaurus/cssnano-preset": 2.0.0-beta.14
+    "@docusaurus/logger": 2.0.0-beta.14
+    "@docusaurus/mdx-loader": 2.0.0-beta.14
     "@docusaurus/react-loadable": 5.5.2
-    "@docusaurus/utils": 2.0.0-beta.13
-    "@docusaurus/utils-common": 2.0.0-beta.13
-    "@docusaurus/utils-validation": 2.0.0-beta.13
+    "@docusaurus/utils": 2.0.0-beta.14
+    "@docusaurus/utils-common": 2.0.0-beta.14
+    "@docusaurus/utils-validation": 2.0.0-beta.14
     "@slorber/static-site-generator-webpack-plugin": ^4.0.0
     "@svgr/webpack": ^6.0.0
     autoprefixer: ^10.3.5
     babel-loader: ^8.2.2
     babel-plugin-dynamic-import-node: 2.3.0
     boxen: ^5.0.1
-    chalk: ^4.1.2
     chokidar: ^3.5.2
     clean-css: ^5.1.5
     commander: ^5.1.0
@@ -1899,31 +1899,41 @@ __metadata:
     react-dom: ^16.8.4 || ^17.0.0
   bin:
     docusaurus: bin/docusaurus.js
-  checksum: 2a2c80e4e45ed5922f2137d45dc7ade26ccd5dd8468d587a6b5fcc263f1633db081377208235c559d7b129e6cdd00aa210e3b1cbe0f0c9e0d6d0a8c837b3fb25
+  checksum: 6a5a89ecbb55c8436b3463748e4869d7adb0bbf781dcdb0559b8ac96089685e51f494557462841bbbf5d1eef04344004cf637fde119bf600063489361c1be573
   languageName: node
   linkType: hard
 
-"@docusaurus/cssnano-preset@npm:2.0.0-beta.13":
-  version: 2.0.0-beta.13
-  resolution: "@docusaurus/cssnano-preset@npm:2.0.0-beta.13"
+"@docusaurus/cssnano-preset@npm:2.0.0-beta.14":
+  version: 2.0.0-beta.14
+  resolution: "@docusaurus/cssnano-preset@npm:2.0.0-beta.14"
   dependencies:
     cssnano-preset-advanced: ^5.1.4
     postcss: ^8.3.7
     postcss-sort-media-queries: ^4.1.0
-  checksum: abf679eb70ed36388189efb05ff23536615d520e46c64ddd02ac1ff009245345dbf0969a6b86e907cdbe35b057fa9b0bdb1c92aad7e623cee15fe152f0587b19
+  checksum: 415e3b15ad51ed669bab463c4f27d1ce8afeb2513d5b7126068a1827b2154c55e6b37a7ffaad7c9ccad2011f9611cc7d70782ee56e06a6d725b38c581b69a0ac
   languageName: node
   linkType: hard
 
-"@docusaurus/mdx-loader@npm:2.0.0-beta.13":
-  version: 2.0.0-beta.13
-  resolution: "@docusaurus/mdx-loader@npm:2.0.0-beta.13"
+"@docusaurus/logger@npm:2.0.0-beta.14":
+  version: 2.0.0-beta.14
+  resolution: "@docusaurus/logger@npm:2.0.0-beta.14"
+  dependencies:
+    chalk: ^4.1.2
+    tslib: ^2.3.1
+  checksum: 4670f3f4c19d9427f3d554e4b67aee42df19d7c61be9335c6caf6e979eb9c5e6c14cb753f7456318ebdf799ccc9fee9e2283991b2166f5eaa7345ef0ef40a48a
+  languageName: node
+  linkType: hard
+
+"@docusaurus/mdx-loader@npm:2.0.0-beta.14":
+  version: 2.0.0-beta.14
+  resolution: "@docusaurus/mdx-loader@npm:2.0.0-beta.14"
   dependencies:
     "@babel/parser": ^7.16.4
     "@babel/traverse": ^7.16.3
-    "@docusaurus/utils": 2.0.0-beta.13
+    "@docusaurus/logger": 2.0.0-beta.14
+    "@docusaurus/utils": 2.0.0-beta.14
     "@mdx-js/mdx": ^1.6.21
     "@mdx-js/react": ^1.6.21
-    chalk: ^4.1.2
     escape-html: ^1.0.3
     file-loader: ^6.2.0
     fs-extra: ^10.0.0
@@ -1938,32 +1948,32 @@ __metadata:
   peerDependencies:
     react: ^16.8.4 || ^17.0.0
     react-dom: ^16.8.4 || ^17.0.0
-  checksum: 74d8b9b428974d2df431872199957ec7e302e7799cfe65a88aece18994dfbbe66125ab0ea3fee6d99f71b6d1915ba338bdeefe18e73b40ff9a98e98b44c8be8f
+  checksum: 248a8f73b4e016757ad5317e1312a8d2a4c6ee23ccf02782eb8395f5a7e165ae6a64cb9633441e4260e53c7518aa70e61d72c2f6d35246000d92f17a7ddfcfd6
   languageName: node
   linkType: hard
 
-"@docusaurus/module-type-aliases@npm:2.0.0-beta.13":
-  version: 2.0.0-beta.13
-  resolution: "@docusaurus/module-type-aliases@npm:2.0.0-beta.13"
+"@docusaurus/module-type-aliases@npm:2.0.0-beta.14":
+  version: 2.0.0-beta.14
+  resolution: "@docusaurus/module-type-aliases@npm:2.0.0-beta.14"
   dependencies:
-    "@docusaurus/types": 2.0.0-beta.13
+    "@docusaurus/types": 2.0.0-beta.14
     "@types/react": "*"
     "@types/react-helmet": "*"
     "@types/react-router-config": "*"
     "@types/react-router-dom": "*"
-  checksum: f614860d9e255382df93fdf6a920aafa1bca8463f9ba77a9ca64de66c18076dd94b1cf4399d7ee6b567a5c9390c4f9874fdaf5ee479b5b45ad266e1953434d78
+  checksum: d4bb46da110eedc32c2dc81743b81356c3fb179fad81a2cc6d9e26756658b99481167c0e5e790e23d11780d26a26f4fd6c45ce9423f63bf62c6bae5ff4f887a1
   languageName: node
   linkType: hard
 
-"@docusaurus/plugin-content-blog@npm:2.0.0-beta.13":
-  version: 2.0.0-beta.13
-  resolution: "@docusaurus/plugin-content-blog@npm:2.0.0-beta.13"
+"@docusaurus/plugin-content-blog@npm:2.0.0-beta.14":
+  version: 2.0.0-beta.14
+  resolution: "@docusaurus/plugin-content-blog@npm:2.0.0-beta.14"
   dependencies:
-    "@docusaurus/core": 2.0.0-beta.13
-    "@docusaurus/mdx-loader": 2.0.0-beta.13
-    "@docusaurus/utils": 2.0.0-beta.13
-    "@docusaurus/utils-validation": 2.0.0-beta.13
-    chalk: ^4.1.2
+    "@docusaurus/core": 2.0.0-beta.14
+    "@docusaurus/logger": 2.0.0-beta.14
+    "@docusaurus/mdx-loader": 2.0.0-beta.14
+    "@docusaurus/utils": 2.0.0-beta.14
+    "@docusaurus/utils-validation": 2.0.0-beta.14
     escape-string-regexp: ^4.0.0
     feed: ^4.2.2
     fs-extra: ^10.0.0
@@ -1979,19 +1989,19 @@ __metadata:
   peerDependencies:
     react: ^16.8.4 || ^17.0.0
     react-dom: ^16.8.4 || ^17.0.0
-  checksum: 1525515f9f8b1537eb22a8f9cc42127e8cb043fd7c5b6326b02791fc9ccbf3a68f88283f1fe63929f459e8cee42f28f134e799839c0e68fc414d219427d88ed1
+  checksum: 9d98707faa0e577a2f0fe1da562d7fed5a7251fc79bedaf538e334b5b3536375c35238f8e2141d24ee7f15858f169da14d4a83837608dafca2a3168c069b7c05
   languageName: node
   linkType: hard
 
-"@docusaurus/plugin-content-docs@npm:2.0.0-beta.13":
-  version: 2.0.0-beta.13
-  resolution: "@docusaurus/plugin-content-docs@npm:2.0.0-beta.13"
+"@docusaurus/plugin-content-docs@npm:2.0.0-beta.14":
+  version: 2.0.0-beta.14
+  resolution: "@docusaurus/plugin-content-docs@npm:2.0.0-beta.14"
   dependencies:
-    "@docusaurus/core": 2.0.0-beta.13
-    "@docusaurus/mdx-loader": 2.0.0-beta.13
-    "@docusaurus/utils": 2.0.0-beta.13
-    "@docusaurus/utils-validation": 2.0.0-beta.13
-    chalk: ^4.1.2
+    "@docusaurus/core": 2.0.0-beta.14
+    "@docusaurus/logger": 2.0.0-beta.14
+    "@docusaurus/mdx-loader": 2.0.0-beta.14
+    "@docusaurus/utils": 2.0.0-beta.14
+    "@docusaurus/utils-validation": 2.0.0-beta.14
     combine-promises: ^1.1.0
     escape-string-regexp: ^4.0.0
     fs-extra: ^10.0.0
@@ -2008,18 +2018,18 @@ __metadata:
   peerDependencies:
     react: ^16.8.4 || ^17.0.0
     react-dom: ^16.8.4 || ^17.0.0
-  checksum: 6fbdcaf82f2a56657b6b30bfe7265722e32220b0459f633554c79f71a67744df6fee90b6b046714a66c36d9ff8982e8838a7e64365083b2fe497c352a07ba742
+  checksum: d7c1951f189906481066a68461f4e4752d8ec7b3ba15de9b2a9ee6f36000a1fe0bcccee205594e8e8fff9bfb6e41a06639b50cf75a4c90fc6c4ac9ecfbe0d807
   languageName: node
   linkType: hard
 
-"@docusaurus/plugin-content-pages@npm:2.0.0-beta.13":
-  version: 2.0.0-beta.13
-  resolution: "@docusaurus/plugin-content-pages@npm:2.0.0-beta.13"
+"@docusaurus/plugin-content-pages@npm:2.0.0-beta.14":
+  version: 2.0.0-beta.14
+  resolution: "@docusaurus/plugin-content-pages@npm:2.0.0-beta.14"
   dependencies:
-    "@docusaurus/core": 2.0.0-beta.13
-    "@docusaurus/mdx-loader": 2.0.0-beta.13
-    "@docusaurus/utils": 2.0.0-beta.13
-    "@docusaurus/utils-validation": 2.0.0-beta.13
+    "@docusaurus/core": 2.0.0-beta.14
+    "@docusaurus/mdx-loader": 2.0.0-beta.14
+    "@docusaurus/utils": 2.0.0-beta.14
+    "@docusaurus/utils-validation": 2.0.0-beta.14
     globby: ^11.0.2
     remark-admonitions: ^1.2.1
     tslib: ^2.3.1
@@ -2027,88 +2037,90 @@ __metadata:
   peerDependencies:
     react: ^16.8.4 || ^17.0.0
     react-dom: ^16.8.4 || ^17.0.0
-  checksum: 00b923a08a9600b486fa536cc07cde97ef7ad596f841d25ec79ea094a021acfb050d52deb43766f611abde27f4cc9536cf8ee491070dc24859e97f6103e98771
+  checksum: 1372f554d8629fc31629e0b77dbe957703204760c1020ef0a32e0d7cfef277eb26244e9db23cad73adecb468db7397b53c169fd53126295f0b3dcbc7453940ca
   languageName: node
   linkType: hard
 
-"@docusaurus/plugin-debug@npm:2.0.0-beta.13":
-  version: 2.0.0-beta.13
-  resolution: "@docusaurus/plugin-debug@npm:2.0.0-beta.13"
+"@docusaurus/plugin-debug@npm:2.0.0-beta.14":
+  version: 2.0.0-beta.14
+  resolution: "@docusaurus/plugin-debug@npm:2.0.0-beta.14"
   dependencies:
-    "@docusaurus/core": 2.0.0-beta.13
-    "@docusaurus/utils": 2.0.0-beta.13
+    "@docusaurus/core": 2.0.0-beta.14
+    "@docusaurus/utils": 2.0.0-beta.14
     fs-extra: ^10.0.0
     react-json-view: ^1.21.3
     tslib: ^2.3.1
   peerDependencies:
     react: ^16.8.4 || ^17.0.0
     react-dom: ^16.8.4 || ^17.0.0
-  checksum: 0fce8901555bbad7586d7012026106a771382a7273911af53ec1025bca2e5559ed02c7fdee8cbbfd11924e5bc9041c0e2ececc35fe6c590e2ade2c4a7a301989
+  checksum: c5316e2d55970a3ebfef5e6a04726eef35ffbc54976bf13791ac2888566b0454b9f60620c4f840e5ef3e216359412754fef30ccef4755726b2e6a3875deae1a8
   languageName: node
   linkType: hard
 
-"@docusaurus/plugin-google-analytics@npm:2.0.0-beta.13":
-  version: 2.0.0-beta.13
-  resolution: "@docusaurus/plugin-google-analytics@npm:2.0.0-beta.13"
+"@docusaurus/plugin-google-analytics@npm:2.0.0-beta.14":
+  version: 2.0.0-beta.14
+  resolution: "@docusaurus/plugin-google-analytics@npm:2.0.0-beta.14"
   dependencies:
-    "@docusaurus/core": 2.0.0-beta.13
-    "@docusaurus/utils-validation": 2.0.0-beta.13
+    "@docusaurus/core": 2.0.0-beta.14
+    "@docusaurus/utils-validation": 2.0.0-beta.14
+    tslib: ^2.3.1
   peerDependencies:
     react: ^16.8.4 || ^17.0.0
     react-dom: ^16.8.4 || ^17.0.0
-  checksum: 95a0d83e4f1e3302dce8f3c64bdfbf800e8a1c028ce8615867680e61c3e3b4bf0e3774ef2d96296c929bdcfe7cdeb428599111268cddece2755d1f1b09236136
+  checksum: 6d36fc808a54ee04afd5713d6e2ed72a1f51256c928d93b04942a960188f4f7f5710300fbaff99f9ea344c26c3305823baaebd0a01cf5a25ed8261ec2f7296bd
   languageName: node
   linkType: hard
 
-"@docusaurus/plugin-google-gtag@npm:2.0.0-beta.13":
-  version: 2.0.0-beta.13
-  resolution: "@docusaurus/plugin-google-gtag@npm:2.0.0-beta.13"
+"@docusaurus/plugin-google-gtag@npm:2.0.0-beta.14":
+  version: 2.0.0-beta.14
+  resolution: "@docusaurus/plugin-google-gtag@npm:2.0.0-beta.14"
   dependencies:
-    "@docusaurus/core": 2.0.0-beta.13
-    "@docusaurus/utils-validation": 2.0.0-beta.13
+    "@docusaurus/core": 2.0.0-beta.14
+    "@docusaurus/utils-validation": 2.0.0-beta.14
+    tslib: ^2.3.1
   peerDependencies:
     react: ^16.8.4 || ^17.0.0
     react-dom: ^16.8.4 || ^17.0.0
-  checksum: 1f76ae0d242528798b6414b0508a0f1f87000380077111da2dccf1b8ab1ad45f5809d4b1288b21ba1016d1a16235632e1adaeb1ce3a4ec6cca66494dcee64cb5
+  checksum: f04ef80c58f64e349daca93a06c5cb91d026ddea7047fe5f788efc2a2ca2b0bbf1b5974fe799bb0d0b1da5cede6a5539ada165bb9a23511ca07d7b0e7ff655d3
   languageName: node
   linkType: hard
 
-"@docusaurus/plugin-sitemap@npm:2.0.0-beta.13":
-  version: 2.0.0-beta.13
-  resolution: "@docusaurus/plugin-sitemap@npm:2.0.0-beta.13"
+"@docusaurus/plugin-sitemap@npm:2.0.0-beta.14":
+  version: 2.0.0-beta.14
+  resolution: "@docusaurus/plugin-sitemap@npm:2.0.0-beta.14"
   dependencies:
-    "@docusaurus/core": 2.0.0-beta.13
-    "@docusaurus/utils": 2.0.0-beta.13
-    "@docusaurus/utils-common": 2.0.0-beta.13
-    "@docusaurus/utils-validation": 2.0.0-beta.13
+    "@docusaurus/core": 2.0.0-beta.14
+    "@docusaurus/utils": 2.0.0-beta.14
+    "@docusaurus/utils-common": 2.0.0-beta.14
+    "@docusaurus/utils-validation": 2.0.0-beta.14
     fs-extra: ^10.0.0
     sitemap: ^7.0.0
     tslib: ^2.3.1
   peerDependencies:
     react: ^16.8.4 || ^17.0.0
     react-dom: ^16.8.4 || ^17.0.0
-  checksum: 35c5ea019553704ea0bb6844f87d4fd2c24011ced241564e0f7701f9f258d8e2bedcdf08c6f438ddbe5e7c8d213391b6fc2cfe25fbfa0f68e085efd9c8982495
+  checksum: eb0408666be6928033ff79565de29da2cda998b8c0b207f1f6595a712e3e9c02df9a159f25a5be9f84a9e55d1df3984ffefb8c3f8808ae7b0e779af91838e23a
   languageName: node
   linkType: hard
 
-"@docusaurus/preset-classic@npm:2.0.0-beta.13":
-  version: 2.0.0-beta.13
-  resolution: "@docusaurus/preset-classic@npm:2.0.0-beta.13"
+"@docusaurus/preset-classic@npm:2.0.0-beta.14":
+  version: 2.0.0-beta.14
+  resolution: "@docusaurus/preset-classic@npm:2.0.0-beta.14"
   dependencies:
-    "@docusaurus/core": 2.0.0-beta.13
-    "@docusaurus/plugin-content-blog": 2.0.0-beta.13
-    "@docusaurus/plugin-content-docs": 2.0.0-beta.13
-    "@docusaurus/plugin-content-pages": 2.0.0-beta.13
-    "@docusaurus/plugin-debug": 2.0.0-beta.13
-    "@docusaurus/plugin-google-analytics": 2.0.0-beta.13
-    "@docusaurus/plugin-google-gtag": 2.0.0-beta.13
-    "@docusaurus/plugin-sitemap": 2.0.0-beta.13
-    "@docusaurus/theme-classic": 2.0.0-beta.13
-    "@docusaurus/theme-search-algolia": 2.0.0-beta.13
+    "@docusaurus/core": 2.0.0-beta.14
+    "@docusaurus/plugin-content-blog": 2.0.0-beta.14
+    "@docusaurus/plugin-content-docs": 2.0.0-beta.14
+    "@docusaurus/plugin-content-pages": 2.0.0-beta.14
+    "@docusaurus/plugin-debug": 2.0.0-beta.14
+    "@docusaurus/plugin-google-analytics": 2.0.0-beta.14
+    "@docusaurus/plugin-google-gtag": 2.0.0-beta.14
+    "@docusaurus/plugin-sitemap": 2.0.0-beta.14
+    "@docusaurus/theme-classic": 2.0.0-beta.14
+    "@docusaurus/theme-search-algolia": 2.0.0-beta.14
   peerDependencies:
     react: ^16.8.4 || ^17.0.0
     react-dom: ^16.8.4 || ^17.0.0
-  checksum: c725f9369598e6a10ec4b9bc9db1d615f96e2ad38fa8af9768d23b43347a72d7a9e38b8cc7e0a971f6ba85930fbbf3055618466d952510f98904061f80cf4c88
+  checksum: 67019820c851503a65a8083639fb299e859fe5b9ff49dde82d7b83b7a4f7aad72bcd0c5d0187a1dfcf56fa78db41be788cb1dfcad17117c8d0c562fbb46e4c48
   languageName: node
   linkType: hard
 
@@ -2124,24 +2136,24 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@docusaurus/theme-classic@npm:2.0.0-beta.13":
-  version: 2.0.0-beta.13
-  resolution: "@docusaurus/theme-classic@npm:2.0.0-beta.13"
+"@docusaurus/theme-classic@npm:2.0.0-beta.14":
+  version: 2.0.0-beta.14
+  resolution: "@docusaurus/theme-classic@npm:2.0.0-beta.14"
   dependencies:
-    "@docusaurus/plugin-content-blog": 2.0.0-beta.13
-    "@docusaurus/plugin-content-docs": 2.0.0-beta.13
-    "@docusaurus/plugin-content-pages": 2.0.0-beta.13
-    "@docusaurus/theme-common": 2.0.0-beta.13
-    "@docusaurus/theme-translations": 2.0.0-beta.13
-    "@docusaurus/utils": 2.0.0-beta.13
-    "@docusaurus/utils-validation": 2.0.0-beta.13
+    "@docusaurus/core": 2.0.0-beta.14
+    "@docusaurus/plugin-content-blog": 2.0.0-beta.14
+    "@docusaurus/plugin-content-docs": 2.0.0-beta.14
+    "@docusaurus/plugin-content-pages": 2.0.0-beta.14
+    "@docusaurus/theme-common": 2.0.0-beta.14
+    "@docusaurus/theme-translations": 2.0.0-beta.14
+    "@docusaurus/utils": 2.0.0-beta.14
+    "@docusaurus/utils-validation": 2.0.0-beta.14
     "@mdx-js/mdx": ^1.6.21
     "@mdx-js/react": ^1.6.21
-    chalk: ^4.1.2
     clsx: ^1.1.1
     copy-text-to-clipboard: ^3.0.1
     globby: ^11.0.2
-    infima: 0.2.0-alpha.36
+    infima: 0.2.0-alpha.37
     lodash: ^4.17.20
     postcss: ^8.3.7
     prism-react-renderer: ^1.2.1
@@ -2151,17 +2163,17 @@ __metadata:
   peerDependencies:
     react: ^16.8.4 || ^17.0.0
     react-dom: ^16.8.4 || ^17.0.0
-  checksum: e46520c96b649b7d0151a3086e5e38cf92bd2f568bd9d0eb5fb3b57c973683c3ab1c6abc6c65f93c34836cc67e666843a8c54bb5e503de3bc23652f1a851fd39
+  checksum: ebb4c362e4a2bedcb1539b4ba90751c3942145f482ddf03734df6aafddc558e7ef8075930829d15c19be54637728a63bdefbe2c5db78a2beb3212398ecb2f313
   languageName: node
   linkType: hard
 
-"@docusaurus/theme-common@npm:2.0.0-beta.13":
-  version: 2.0.0-beta.13
-  resolution: "@docusaurus/theme-common@npm:2.0.0-beta.13"
+"@docusaurus/theme-common@npm:2.0.0-beta.14":
+  version: 2.0.0-beta.14
+  resolution: "@docusaurus/theme-common@npm:2.0.0-beta.14"
   dependencies:
-    "@docusaurus/plugin-content-blog": 2.0.0-beta.13
-    "@docusaurus/plugin-content-docs": 2.0.0-beta.13
-    "@docusaurus/plugin-content-pages": 2.0.0-beta.13
+    "@docusaurus/plugin-content-blog": 2.0.0-beta.14
+    "@docusaurus/plugin-content-docs": 2.0.0-beta.14
+    "@docusaurus/plugin-content-pages": 2.0.0-beta.14
     clsx: ^1.1.1
     fs-extra: ^10.0.0
     parse-numeric-range: ^1.3.0
@@ -2171,45 +2183,47 @@ __metadata:
     prism-react-renderer: ^1.2.1
     react: ^16.8.4 || ^17.0.0
     react-dom: ^16.8.4 || ^17.0.0
-  checksum: e0f048a38f650fc9d52eefcc688fbedea0e47ea7b2d65a5ac72a0ca3a50d7a8079dda3c28f0d6e6a6d6cee21e7ddda2c33e99eb87dc1ac9c37bc2f4eacc1a38b
+  checksum: dbe969d676e901fe730cac2b95e87452e72c5fe31409e5d46c0d49f38da80177f79c20121eaa64b1d19cd60d6a8f179f30b13e0b1724d1e2618164a5f0dc0a2f
   languageName: node
   linkType: hard
 
-"@docusaurus/theme-search-algolia@npm:2.0.0-beta.13":
-  version: 2.0.0-beta.13
-  resolution: "@docusaurus/theme-search-algolia@npm:2.0.0-beta.13"
+"@docusaurus/theme-search-algolia@npm:2.0.0-beta.14":
+  version: 2.0.0-beta.14
+  resolution: "@docusaurus/theme-search-algolia@npm:2.0.0-beta.14"
   dependencies:
     "@docsearch/react": ^3.0.0-alpha.39
-    "@docusaurus/core": 2.0.0-beta.13
-    "@docusaurus/theme-common": 2.0.0-beta.13
-    "@docusaurus/theme-translations": 2.0.0-beta.13
-    "@docusaurus/utils": 2.0.0-beta.13
-    "@docusaurus/utils-validation": 2.0.0-beta.13
+    "@docusaurus/core": 2.0.0-beta.14
+    "@docusaurus/logger": 2.0.0-beta.14
+    "@docusaurus/theme-common": 2.0.0-beta.14
+    "@docusaurus/theme-translations": 2.0.0-beta.14
+    "@docusaurus/utils": 2.0.0-beta.14
+    "@docusaurus/utils-validation": 2.0.0-beta.14
     algoliasearch: ^4.10.5
     algoliasearch-helper: ^3.5.5
     clsx: ^1.1.1
     eta: ^1.12.3
     lodash: ^4.17.20
+    tslib: ^2.3.1
   peerDependencies:
     react: ^16.8.4 || ^17.0.0
     react-dom: ^16.8.4 || ^17.0.0
-  checksum: 7cf9fccbd1e18c5e15a781d1c91bd6b0cd9e13937ee9753c48ea4958b0de74586b66e2cdd3b387f2cbc22dac8127362a4f4b1a91c90c55614a3c906c3d654fbb
+  checksum: d4dbaebb21e667e254f06e8146259df29c867a5d8927d09358fa233e4d526252afc9210cc446f12c13930a39880aa201ebe34ba423f7a4744475c173197d2dae
   languageName: node
   linkType: hard
 
-"@docusaurus/theme-translations@npm:2.0.0-beta.13":
-  version: 2.0.0-beta.13
-  resolution: "@docusaurus/theme-translations@npm:2.0.0-beta.13"
+"@docusaurus/theme-translations@npm:2.0.0-beta.14":
+  version: 2.0.0-beta.14
+  resolution: "@docusaurus/theme-translations@npm:2.0.0-beta.14"
   dependencies:
     fs-extra: ^10.0.0
     tslib: ^2.3.1
-  checksum: a7244d01aa1ee567b363526bfec94c7a7fec27714f9674394e15f5217bb8e44e321d6fb5adbbf30c28f23dcd945d1e396d5df5be74b69ca68c4a14bc8c6f35b7
+  checksum: cb8d81ecc97aad96e3f320cb81bafe13bc9b5e0f509fdc7fbd1758c819aba8b3b50946505d2df2b0c802f3f15472295e49227c5f33037dcd3187ece7f03d227d
   languageName: node
   linkType: hard
 
-"@docusaurus/types@npm:2.0.0-beta.13":
-  version: 2.0.0-beta.13
-  resolution: "@docusaurus/types@npm:2.0.0-beta.13"
+"@docusaurus/types@npm:2.0.0-beta.14":
+  version: 2.0.0-beta.14
+  resolution: "@docusaurus/types@npm:2.0.0-beta.14"
   dependencies:
     commander: ^5.1.0
     joi: ^17.4.2
@@ -2217,7 +2231,7 @@ __metadata:
     utility-types: ^3.10.0
     webpack: ^5.61.0
     webpack-merge: ^5.8.0
-  checksum: 8d7896f07f7868816917f3308727f55b42c6b1b92fca8b5dfe441441a5aacf3e6371b5da291dc5bbf36f32d94986bdbcb70b0023a451d9e0ef64317a410b2dd3
+  checksum: 9981d6159b808ef0a6a45bc8944bdd5c9d6e34f5a2c5041bd178f7fbb9ce1c68c23772a01a9d9feff3329ac9c776332a78eebd7fe790f4c30d5684b14add2c6f
   languageName: node
   linkType: hard
 
@@ -2234,24 +2248,27 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@docusaurus/utils-common@npm:2.0.0-beta.13":
-  version: 2.0.0-beta.13
-  resolution: "@docusaurus/utils-common@npm:2.0.0-beta.13"
+"@docusaurus/utils-common@npm:2.0.0-beta.14":
+  version: 2.0.0-beta.14
+  resolution: "@docusaurus/utils-common@npm:2.0.0-beta.14"
   dependencies:
     tslib: ^2.3.1
-  checksum: 76232c036bfd91d4d6b5125e6958d818f2cc7b9b721bc2aefbe5bfb469e51cf08587bd645ef268f5bb354396cd5a4fcaf1aac25b6690de1b4dd1e75a142cd7c2
+  checksum: 9f4f225a299962aaff701e3bcb920129e1a5e6be91195ab35d121da0369316effa491e53db2dc027f001122f6dfd44f9c5eca2cfbcd18341cdd5364cc0b84377
   languageName: node
   linkType: hard
 
-"@docusaurus/utils-validation@npm:2.0.0-beta.13":
-  version: 2.0.0-beta.13
-  resolution: "@docusaurus/utils-validation@npm:2.0.0-beta.13"
+"@docusaurus/utils-validation@npm:2.0.0-beta.14":
+  version: 2.0.0-beta.14
+  resolution: "@docusaurus/utils-validation@npm:2.0.0-beta.14"
   dependencies:
-    "@docusaurus/utils": 2.0.0-beta.13
-    chalk: ^4.1.2
+    "@docusaurus/logger": 2.0.0-beta.14
+    "@docusaurus/utils": 2.0.0-beta.14
     joi: ^17.4.2
     tslib: ^2.3.1
-  checksum: 4c5e7925e35b35e9b32fc6973d433a1d68f22e5b1201cb59cbb64b1c79aabf1e0c0cf82bb7390d444c66f3aa52d2af01ec8bc390f239e273fa4738221bd1f9aa
+  peerDependencies:
+    react: "*"
+    react-dom: "*"
+  checksum: f7ce474afe40c94cd9c82e02ee4814d4be507bf4947a793e34cd39146bff0415913646386e136b6d1a8aca5fe1621ba199cb3f8cb7e5d7a87da197cdfc58a5f7
   languageName: node
   linkType: hard
 
@@ -2267,13 +2284,13 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@docusaurus/utils@npm:2.0.0-beta.13":
-  version: 2.0.0-beta.13
-  resolution: "@docusaurus/utils@npm:2.0.0-beta.13"
+"@docusaurus/utils@npm:2.0.0-beta.14":
+  version: 2.0.0-beta.14
+  resolution: "@docusaurus/utils@npm:2.0.0-beta.14"
   dependencies:
+    "@docusaurus/logger": 2.0.0-beta.14
     "@mdx-js/runtime": ^1.6.22
     "@svgr/webpack": ^6.0.0
-    chalk: ^4.1.2
     escape-string-regexp: ^4.0.0
     file-loader: ^6.2.0
     fs-extra: ^10.0.0
@@ -2291,7 +2308,7 @@ __metadata:
     react: "*"
     react-dom: "*"
     webpack: 5.x
-  checksum: d2dd59bf544b384454a5330d7f5aa342b263d567e2d00f83d55afe43f30f010d538e104089116c3d40122c2c9313b9e657aca2c5b8a08fa3e64e7eb365e5ba7d
+  checksum: f527eeeca51ca8f38a7d2a486af4091ef59440ff9c98c0053327d003a806a65298007ac57b02dd55b87d4cca222af45aebce3be4f6d065f5ac3abcf78567c49e
   languageName: node
   linkType: hard
 
@@ -11797,10 +11814,10 @@ __metadata:
   languageName: node
   linkType: hard
 
-"infima@npm:0.2.0-alpha.36":
-  version: 0.2.0-alpha.36
-  resolution: "infima@npm:0.2.0-alpha.36"
-  checksum: 1f7ab5e8a30c9a43b8c4c89e9d83ffd64a23b3958e2a2be6cfdcf531ced0e0db2728f172d0c735d20c2d61455376763c088453372741eb0e9f3a8d4f4a4fa37e
+"infima@npm:0.2.0-alpha.37":
+  version: 0.2.0-alpha.37
+  resolution: "infima@npm:0.2.0-alpha.37"
+  checksum: e62695838bb628a0a11ea126b4ede6984e26ad46f7170ea5325bae373c6be93ea3bd1f19c274ca8ab1549705cd07b677d73a71ffe7134f06450ca299edb4d68f
   languageName: node
   linkType: hard
 
@@ -19471,9 +19488,9 @@ __metadata:
   resolution: "site@workspace:packages/site"
   dependencies:
     "@babel/plugin-proposal-decorators": ^7.16.5
-    "@docusaurus/core": 2.0.0-beta.13
-    "@docusaurus/module-type-aliases": 2.0.0-beta.13
-    "@docusaurus/preset-classic": 2.0.0-beta.13
+    "@docusaurus/core": 2.0.0-beta.14
+    "@docusaurus/module-type-aliases": 2.0.0-beta.14
+    "@docusaurus/preset-classic": 2.0.0-beta.14
     "@easyops-cn/docusaurus-search-local": ^0.21.4
     "@mdx-js/react": ^1.6.22
     "@svgr/webpack": ^6.1.2


### PR DESCRIPTION
This PR updates Docusaurus packages to [v2.0.0-beta.14](https://github.com/facebook/docusaurus/releases/tag/v2.0.0-beta.14).