### PR TITLE
use builtin Omit utility type instead of ts-toolbelt's

### DIFF
--- a/packages/lib/src/model/BaseModel.ts
+++ b/packages/lib/src/model/BaseModel.ts
@@ -1,5 +1,4 @@
 import { observable } from "mobx"
-import type { O } from "ts-toolbelt"
 import {
   fromSnapshotOverrideTypeSymbol,
   ModelClass,
@@ -219,7 +218,7 @@ export type ModelIdPropertyName<M extends AnyModel> = M[typeof modelIdPropertyNa
  */
 export function modelSnapshotInWithMetadata<M extends AnyModel>(
   modelClass: ModelClass<M>,
-  snapshot: O.Omit<SnapshotInOfModel<M>, typeof modelTypeKey>
+  snapshot: Omit<SnapshotInOfModel<M>, typeof modelTypeKey>
 ): SnapshotInOfModel<M> {
   assertIsModelClass(modelClass, "modelClass")
   assertIsObject(snapshot, "initialData")
@@ -243,7 +242,7 @@ export function modelSnapshotInWithMetadata<M extends AnyModel>(
  */
 export function modelSnapshotOutWithMetadata<M extends AnyModel>(
   modelClass: ModelClass<M>,
-  snapshot: O.Omit<SnapshotOutOfModel<M>, typeof modelTypeKey>
+  snapshot: Omit<SnapshotOutOfModel<M>, typeof modelTypeKey>
 ): SnapshotOutOfModel<M> {
   assertIsModelClass(modelClass, "modelClass")
   assertIsObject(snapshot, "initialData")

--- a/packages/lib/src/modelShared/prop.ts
+++ b/packages/lib/src/modelShared/prop.ts
@@ -1,4 +1,3 @@
-import type { O } from "ts-toolbelt"
 import type { SnapshotInOf, SnapshotOutOf } from "../snapshot/SnapshotOf"
 import type { LateTypeChecker, TypeChecker } from "../types/TypeChecker"
 import { getOrCreate } from "../utils/mapUtils"
@@ -184,7 +183,7 @@ export type ModelPropsToSnapshotData<MP extends ModelProps> = Flatten<{
 export type ModelPropsToCreationData<MP extends ModelProps> = Flatten<
   {
     [k in keyof MP]?: MP[k]["_internal"]["$creationValueType"]
-  } & O.Omit<
+  } & Omit<
     {
       [k in keyof MP]: MP[k]["_internal"]["$creationValueType"]
     },
@@ -198,7 +197,7 @@ export type ModelPropsToCreationData<MP extends ModelProps> = Flatten<
 export type ModelPropsToSnapshotCreationData<MP extends ModelProps> = Flatten<
   {
     [k in keyof MP]?: ModelPropFromSnapshot<MP[k]> extends infer R ? R : never
-  } & O.Omit<
+  } & Omit<
     {
       [k in keyof MP]: ModelPropFromSnapshot<MP[k]> extends infer R ? R : never
     },
@@ -222,7 +221,7 @@ export type ModelPropsToTransformedData<MP extends ModelProps> = Flatten<{
 export type ModelPropsToTransformedCreationData<MP extends ModelProps> = Flatten<
   {
     [k in keyof MP]?: MP[k]["_internal"]["$transformedCreationValueType"]
-  } & O.Omit<
+  } & Omit<
     {
       [k in keyof MP]: MP[k]["_internal"]["$transformedCreationValueType"]
     },


### PR DESCRIPTION
I've replaced remaining occurrences of `O.Omit` by `Omit` for consistency. `Omit` has been used elsewhere in the library anyway and was [introduced in TS 3.5](https://www.typescriptlang.org/docs/handbook/utility-types.html#omittype-keys) which is a sufficiently old version IMO.