### PR TITLE
improve internal identityFn typing

### DIFF
--- a/packages/lib/src/types/primitiveBased/primitives.ts
+++ b/packages/lib/src/types/primitiveBased/primitives.ts
@@ -5,7 +5,7 @@ import type { AnyStandardType, IdentityType } from "../schemas"
 import { TypeChecker, TypeCheckerBaseType, TypeInfo, TypeInfoGen } from "../TypeChecker"
 import { TypeCheckError } from "../TypeCheckError"
 
-const identityFn = (x: any) => x
+const identityFn = <T>(x: T): T => x
 
 /**
  * A type that represents a certain value of a primitive (for example an *exact* number or string).


### PR DESCRIPTION
Just a minor improvement to type `identityFn` properly.