### PR TITLE
fix internal lateVal function typing

### DIFF
--- a/packages/lib/src/utils/index.ts
+++ b/packages/lib/src/utils/index.ts
@@ -382,15 +382,13 @@ export function lateVal<A extends unknown[], R>(getter: (...args: A) => R): type
   let memoizedValue: R
   let memoized = false
 
-  const fn = (...args: A): R => {
+  return (...args: A): R => {
     if (!memoized) {
       memoizedValue = getter(...args)
       memoized = true
     }
     return memoizedValue
   }
-
-  return fn
 }
 
 /**

--- a/packages/lib/src/utils/index.ts
+++ b/packages/lib/src/utils/index.ts
@@ -374,23 +374,23 @@ export function logWarning(type: "warn" | "error", msg: string, uniqueKey?: stri
   }
 }
 
-const notMemoized = Symbol("notMemoized")
-
 /**
  * @ignore
  * @internal
  */
-export function lateVal<TF extends (...args: any[]) => any>(getter: TF): TF {
-  let memoized: TF | typeof notMemoized = notMemoized
+export function lateVal<A extends unknown[], R>(getter: (...args: A) => R): typeof getter {
+  let memoizedValue: R
+  let memoized = false
 
-  const fn = (...args: any[]): any => {
-    if (memoized === notMemoized) {
-      memoized = getter(...args)
+  const fn = (...args: A): R => {
+    if (!memoized) {
+      memoizedValue = getter(...args)
+      memoized = true
     }
-    return memoized
+    return memoizedValue
   }
 
-  return fn as TF
+  return fn
 }
 
 /**


### PR DESCRIPTION
This PR fixes two typing issues related to the internal utility function `lateVal`:

1. The generic constraint in

   https://github.com/xaviergonz/mobx-keystone/blob/6900f7780b507949f768edd7801581bb11a09989/packages/lib/src/utils/index.ts#L383

   was not correct. The return type is in fact not `TF` because `getter` might be a subtype of `(...args: any[]) => any` whereas the returned function merely has the same signature as `getter`.

1. The type of the `memoized` variable

   https://github.com/xaviergonz/mobx-keystone/blob/6900f7780b507949f768edd7801581bb11a09989/packages/lib/src/utils/index.ts#L384

   is in fact not `TF` but `TF`'s return type.

Along with the typing fixes came a slightly different implementation because TS isn't able to narrow the type of `memoized` in

https://github.com/xaviergonz/mobx-keystone/blob/6900f7780b507949f768edd7801581bb11a09989/packages/lib/src/utils/index.ts#L387-L390

to omit `typeof notMemoized` when `memoized` is returned.

The new typing and implementation works without any type casts and without the use of `any`.