### PR TITLE
remove internal function lazy and use lateVal instead

### DIFF
--- a/packages/lib/src/action/applyDelete.ts
+++ b/packages/lib/src/action/applyDelete.ts
@@ -1,6 +1,6 @@
 import { remove } from "mobx"
 import { assertTweakedObject } from "../tweaker/core"
-import { lazy } from "../utils"
+import { lateVal } from "../utils"
 import { BuiltInAction } from "./builtInActions"
 import { ActionContextActionType } from "./context"
 import { wrapInAction } from "./wrapInAction"
@@ -25,7 +25,7 @@ export function internalApplyDelete<O extends object>(this: O, fieldName: string
   remove(this, "" + fieldName)
 }
 
-const wrappedInternalApplyDelete = lazy(() =>
+const wrappedInternalApplyDelete = lateVal(() =>
   wrapInAction({
     nameOrNameFn: BuiltInAction.ApplyDelete,
     fn: internalApplyDelete,

--- a/packages/lib/src/action/applyMethodCall.ts
+++ b/packages/lib/src/action/applyMethodCall.ts
@@ -1,5 +1,5 @@
 import { assertTweakedObject } from "../tweaker/core"
-import { lazy } from "../utils"
+import { lateVal } from "../utils"
 import { BuiltInAction } from "./builtInActions"
 import { ActionContextActionType } from "./context"
 import { wrapInAction } from "./wrapInAction"
@@ -30,7 +30,7 @@ export function internalApplyMethodCall(this: any, methodName: string | number, 
   return this[methodName](...args)
 }
 
-const wrappedInternalApplyMethodCall = lazy(() =>
+const wrappedInternalApplyMethodCall = lateVal(() =>
   wrapInAction({
     nameOrNameFn: BuiltInAction.ApplyMethodCall,
     fn: internalApplyMethodCall,

--- a/packages/lib/src/action/applySet.ts
+++ b/packages/lib/src/action/applySet.ts
@@ -1,7 +1,7 @@
 import { isObservable, set } from "mobx"
 import { isModel } from "../model/utils"
 import { assertTweakedObject } from "../tweaker/core"
-import { lazy } from "../utils"
+import { lateVal } from "../utils"
 import { BuiltInAction } from "./builtInActions"
 import { ActionContextActionType } from "./context"
 import { wrapInAction } from "./wrapInAction"
@@ -33,7 +33,7 @@ function internalApplySet<O extends object>(this: O, fieldName: string | number,
   }
 }
 
-const wrappedInternalApplySet = lazy(() =>
+const wrappedInternalApplySet = lateVal(() =>
   wrapInAction({
     nameOrNameFn: BuiltInAction.ApplySet,
     fn: internalApplySet,

--- a/packages/lib/src/parent/detach.ts
+++ b/packages/lib/src/parent/detach.ts
@@ -3,7 +3,7 @@ import { BuiltInAction } from "../action/builtInActions"
 import { ActionContextActionType } from "../action/context"
 import { wrapInAction } from "../action/wrapInAction"
 import { assertTweakedObject } from "../tweaker/core"
-import { failure, lazy } from "../utils"
+import { failure, lateVal } from "../utils"
 import { fastGetParentPathIncludingDataObjects } from "./path"
 
 /**
@@ -20,7 +20,7 @@ export function detach(node: object): void {
   wrappedInternalDetach().call(node)
 }
 
-const wrappedInternalDetach = lazy(() =>
+const wrappedInternalDetach = lateVal(() =>
   wrapInAction({
     nameOrNameFn: BuiltInAction.Detach,
     fn: internalDetach,

--- a/packages/lib/src/patch/applyPatches.ts
+++ b/packages/lib/src/patch/applyPatches.ts
@@ -7,7 +7,7 @@ import type { PathElement } from "../parent/pathTypes"
 import type { Patch } from "../patch/Patch"
 import { reconcileSnapshot } from "../snapshot/reconcileSnapshot"
 import { assertTweakedObject } from "../tweaker/core"
-import { failure, inDevMode, isArray, lazy } from "../utils"
+import { failure, inDevMode, isArray, lateVal } from "../utils"
 import { ModelPool } from "../utils/ModelPool"
 
 /**
@@ -72,7 +72,7 @@ export function internalApplyPatches(
   }
 }
 
-const wrappedInternalApplyPatches = lazy(() =>
+const wrappedInternalApplyPatches = lateVal(() =>
   wrapInAction({
     nameOrNameFn: BuiltInAction.ApplyPatches,
     fn: internalApplyPatches,

--- a/packages/lib/src/snapshot/applySnapshot.ts
+++ b/packages/lib/src/snapshot/applySnapshot.ts
@@ -10,7 +10,7 @@ import { isModel, isModelSnapshot } from "../model/utils"
 import type { ModelClass } from "../modelShared/BaseModelShared"
 import { getModelInfoForName, modelInfoByClass } from "../modelShared/modelInfo"
 import { assertTweakedObject } from "../tweaker/core"
-import { assertIsObject, failure, inDevMode, isArray, isPlainObject, lazy } from "../utils"
+import { assertIsObject, failure, inDevMode, isArray, isPlainObject, lateVal } from "../utils"
 import { ModelPool } from "../utils/ModelPool"
 import { reconcileSnapshot } from "./reconcileSnapshot"
 import type { SnapshotInOf, SnapshotOutOf } from "./SnapshotOf"
@@ -128,7 +128,7 @@ export function internalApplySnapshot<T extends object>(
   throw failure(`unsupported snapshot - ${sn}`)
 }
 
-const wrappedInternalApplySnapshot = lazy(() =>
+const wrappedInternalApplySnapshot = lateVal(() =>
   wrapInAction({
     nameOrNameFn: BuiltInAction.ApplySnapshot,
     fn: internalApplySnapshot,

--- a/packages/lib/src/utils/index.ts
+++ b/packages/lib/src/utils/index.ts
@@ -397,23 +397,6 @@ export function lateVal<TF extends (...args: any[]) => any>(getter: TF): TF {
  * @ignore
  * @internal
  */
-export function lazy<V>(valueGen: () => V): () => V {
-  let inited = false
-  let val: V | undefined
-
-  return (): V => {
-    if (!inited) {
-      val = valueGen()
-      inited = true
-    }
-    return val!
-  }
-}
-
-/**
- * @ignore
- * @internal
- */
 export const mobx6 = {
   // eslint-disable-next-line no-useless-concat
   makeObservable: (mobx as any)[


### PR DESCRIPTION
This PR replaces uses of the internal utility function `lazy` by `lateVal` because `lateVal` is a more general version of `lazy`, so there's no need to have both.

Do you want to rename `lateVal` to `lazy` or keep it as `lateVal`?