### PR TITLE
factor out built-in namespace into a constant

### DIFF
--- a/packages/lib/src/actionMiddlewares/actionSerialization/arraySerializer.ts
+++ b/packages/lib/src/actionMiddlewares/actionSerialization/arraySerializer.ts
@@ -1,9 +1,9 @@
 import type { IObservableArray } from "mobx"
-import { isArray } from "../../utils"
+import { isArray, namespace } from "../../utils"
 import { ActionCallArgumentSerializer, cannotSerialize } from "./core"
 
 export const arraySerializer: ActionCallArgumentSerializer<any[] | IObservableArray<any>, any[]> = {
-  id: "mobx-keystone/array",
+  id: `${namespace}/array`,
 
   serialize(value, serialize) {
     if (!isArray(value)) return cannotSerialize

--- a/packages/lib/src/actionMiddlewares/actionSerialization/dateSerializer.ts
+++ b/packages/lib/src/actionMiddlewares/actionSerialization/dateSerializer.ts
@@ -1,7 +1,8 @@
+import { namespace } from "../../utils"
 import { ActionCallArgumentSerializer, cannotSerialize } from "./core"
 
 export const dateSerializer: ActionCallArgumentSerializer<Date, number> = {
-  id: "mobx-keystone/dateAsTimestamp",
+  id: `${namespace}/dateAsTimestamp`,
 
   serialize(date) {
     if (!(date instanceof Date)) return cannotSerialize

--- a/packages/lib/src/actionMiddlewares/actionSerialization/mapSerializer.ts
+++ b/packages/lib/src/actionMiddlewares/actionSerialization/mapSerializer.ts
@@ -1,11 +1,12 @@
 import { isObservableMap, ObservableMap } from "mobx"
+import { namespace } from "../../utils"
 import { ActionCallArgumentSerializer, cannotSerialize } from "./core"
 
 export const mapSerializer: ActionCallArgumentSerializer<
   Map<any, any> | ObservableMap<any, any>,
   [any, any][]
 > = {
-  id: "mobx-keystone/mapAsArray",
+  id: `${namespace}/mapAsArray`,
 
   serialize(map, serialize) {
     if (!(map instanceof Map) && !isObservableMap(map)) return cannotSerialize

--- a/packages/lib/src/actionMiddlewares/actionSerialization/objectPathSerializer.ts
+++ b/packages/lib/src/actionMiddlewares/actionSerialization/objectPathSerializer.ts
@@ -1,7 +1,7 @@
 import { fastGetRootPath, resolvePathCheckingIds } from "../../parent/path"
 import { Path } from "../../parent/pathTypes"
 import { isTweakedObject } from "../../tweaker/core"
-import { failure } from "../../utils"
+import { failure, namespace } from "../../utils"
 import { rootPathToTargetPathIds } from "../utils"
 import { ActionCallArgumentSerializer, cannotSerialize } from "./core"
 
@@ -11,7 +11,7 @@ interface ObjectPath {
 }
 
 export const objectPathSerializer: ActionCallArgumentSerializer<object, ObjectPath> = {
-  id: "mobx-keystone/objectPath",
+  id: `${namespace}/objectPath`,
 
   serialize(value, _, targetRoot) {
     if (typeof value !== "object" || value === null || !isTweakedObject(value, false))

--- a/packages/lib/src/actionMiddlewares/actionSerialization/objectSnapshotSerializer.ts
+++ b/packages/lib/src/actionMiddlewares/actionSerialization/objectSnapshotSerializer.ts
@@ -1,10 +1,11 @@
 import { fromSnapshot } from "../../snapshot/fromSnapshot"
 import { getSnapshot } from "../../snapshot/getSnapshot"
 import { isTweakedObject } from "../../tweaker/core"
+import { namespace } from "../../utils"
 import { ActionCallArgumentSerializer, cannotSerialize } from "./core"
 
 export const objectSnapshotSerializer: ActionCallArgumentSerializer<object, object> = {
-  id: "mobx-keystone/objectSnapshot",
+  id: `${namespace}/objectSnapshot`,
 
   serialize(value) {
     if (typeof value !== "object" || value === null || !isTweakedObject(value, false))

--- a/packages/lib/src/actionMiddlewares/actionSerialization/plainObjectSerializer.ts
+++ b/packages/lib/src/actionMiddlewares/actionSerialization/plainObjectSerializer.ts
@@ -1,9 +1,9 @@
 import { isObservableObject } from "mobx"
-import { isPlainObject } from "../../utils"
+import { isPlainObject, namespace } from "../../utils"
 import { ActionCallArgumentSerializer, cannotSerialize } from "./core"
 
 export const plainObjectSerializer: ActionCallArgumentSerializer<object, object> = {
-  id: "mobx-keystone/plainObject",
+  id: `${namespace}/plainObject`,
 
   serialize(value, serialize) {
     if (!isPlainObject(value) && !isObservableObject(value)) return cannotSerialize

--- a/packages/lib/src/actionMiddlewares/actionSerialization/setSerializer.ts
+++ b/packages/lib/src/actionMiddlewares/actionSerialization/setSerializer.ts
@@ -1,8 +1,9 @@
 import type { ObservableSet } from "mobx"
+import { namespace } from "../../utils"
 import { ActionCallArgumentSerializer, cannotSerialize } from "./core"
 
 export const setSerializer: ActionCallArgumentSerializer<Set<any> | ObservableSet<any>, any[]> = {
-  id: "mobx-keystone/setAsArray",
+  id: `${namespace}/setAsArray`,
 
   serialize(set, serialize) {
     if (!(set instanceof Set)) return cannotSerialize

--- a/packages/lib/src/actionMiddlewares/undoMiddleware.ts
+++ b/packages/lib/src/actionMiddlewares/undoMiddleware.ts
@@ -10,7 +10,7 @@ import { assertTweakedObject } from "../tweaker/core"
 import { typesArray } from "../types/arrayBased/array"
 import { tProp } from "../types/tProp"
 import { typesUnchecked } from "../types/utility/unchecked"
-import { failure, getMobxVersion, mobx6 } from "../utils"
+import { failure, getMobxVersion, mobx6, namespace } from "../utils"
 import { actionTrackingMiddleware, SimpleActionContext } from "./actionTrackingMiddleware"
 
 /**
@@ -113,7 +113,7 @@ function toSingleEvents(
  * Store model instance for undo/redo actions.
  * Do not manipulate directly, other that creating it.
  */
-@model("mobx-keystone/UndoStore")
+@model(`${namespace}/UndoStore`)
 export class UndoStore extends Model({
   // TODO: add proper type checking to undo store
   undoEvents: tProp(typesArray(typesUnchecked<UndoEvent>()), () => []),

--- a/packages/lib/src/standardActions/arrayActions.ts
+++ b/packages/lib/src/standardActions/arrayActions.ts
@@ -1,5 +1,6 @@
 import { remove, set } from "mobx"
 import { toTreeNode } from "../tweaker/tweak"
+import { namespace as ns } from "../utils"
 import { standaloneAction } from "./standaloneActions"
 
 function _splice(array: any[], start: number, deleteCount?: number): any[]
@@ -8,7 +9,7 @@ function _splice(array: any[], ...args: any[]): any[] {
   return (array.splice as any)(...args)
 }
 
-const namespace = "mobx-keystone/arrayActions"
+const namespace = `${ns}/arrayActions`
 
 export const arrayActions = {
   set: standaloneAction(`${namespace}::set`, <T>(array: T[], index: number, value: any): void => {

--- a/packages/lib/src/standardActions/objectActions.ts
+++ b/packages/lib/src/standardActions/objectActions.ts
@@ -1,9 +1,9 @@
 import { remove, set } from "mobx"
 import { toTreeNode } from "../tweaker/tweak"
-import { assertIsObject } from "../utils"
+import { assertIsObject, namespace as ns } from "../utils"
 import { standaloneAction } from "./standaloneActions"
 
-const namespace = "mobx-keystone/objectActions"
+const namespace = `${ns}/objectActions`
 
 export const objectActions = {
   set: standaloneAction(

--- a/packages/lib/src/utils/index.ts
+++ b/packages/lib/src/utils/index.ts
@@ -441,3 +441,9 @@ export function getMobxVersion(): number {
     return 5
   }
 }
+
+/**
+ * @ignore
+ * @internal
+ */
+export const namespace = "mobx-keystone"

--- a/packages/lib/src/wrappers/ArraySet.ts
+++ b/packages/lib/src/wrappers/ArraySet.ts
@@ -7,12 +7,13 @@ import { idProp } from "../modelShared/prop"
 import { typesArray } from "../types/arrayBased/array"
 import { tProp } from "../types/tProp"
 import { typesUnchecked } from "../types/utility/unchecked"
+import { namespace } from "../utils"
 
 /**
  * A set that is backed by an array.
  * Use `arraySet` to create it.
  */
-@model("mobx-keystone/ArraySet")
+@model(`${namespace}/ArraySet`)
 export class ArraySet<V>
   extends Model({
     [modelIdKey]: idProp,

--- a/packages/lib/src/wrappers/ObjectMap.ts
+++ b/packages/lib/src/wrappers/ObjectMap.ts
@@ -7,12 +7,13 @@ import { idProp } from "../modelShared/prop"
 import { typesRecord } from "../types/objectBased/record"
 import { tProp } from "../types/tProp"
 import { typesUnchecked } from "../types/utility/unchecked"
+import { namespace } from "../utils"
 
 /**
  * A map that is backed by an object-like map.
  * Use `objectMap` to create it.
  */
-@model("mobx-keystone/ObjectMap")
+@model(`${namespace}/ObjectMap`)
 export class ObjectMap<V>
   extends Model({
     [modelIdKey]: idProp,

--- a/packages/lib/test/actionMiddlewares/actionSerialization.test.ts
+++ b/packages/lib/test/actionMiddlewares/actionSerialization.test.ts
@@ -10,6 +10,7 @@ import {
   Model,
   modelAction,
   modelIdKey,
+  namespace,
   onActionMiddleware,
   prop,
   serializeActionCall,
@@ -34,14 +35,14 @@ test("serializeActionCallArgument and deserializeActionCallArgument", () => {
   expect(deserializeActionCallArgument(serPrim)).toBe(42)
 
   // date
-  const serDate = { $mobxKeystoneSerializer: "mobx-keystone/dateAsTimestamp", value: 1000 }
+  const serDate = { $mobxKeystoneSerializer: `${namespace}/dateAsTimestamp`, value: 1000 }
   expect(serializeActionCallArgument(new Date(1000))).toEqual(serDate)
   expect(deserializeActionCallArgument(serDate)).toEqual(new Date(1000))
 
   // plain obj
   const obj = { x: 10 }
   const serObj = {
-    $mobxKeystoneSerializer: "mobx-keystone/plainObject",
+    $mobxKeystoneSerializer: `${namespace}/plainObject`,
     value: {
       x: 10,
     },
@@ -60,7 +61,7 @@ test("serializeActionCallArgument and deserializeActionCallArgument", () => {
   // array
   const arr = [obj, 20]
   const serArr = {
-    $mobxKeystoneSerializer: "mobx-keystone/array",
+    $mobxKeystoneSerializer: `${namespace}/array`,
     value: [serObj, 20],
   }
 
@@ -83,7 +84,7 @@ test("serializeActionCallArgument and deserializeActionCallArgument", () => {
   ]
   const map = new Map<any, any>(mapKV)
   const serMap = {
-    $mobxKeystoneSerializer: "mobx-keystone/mapAsArray",
+    $mobxKeystoneSerializer: `${namespace}/mapAsArray`,
     value: [
       ["x", 10],
       ["y", serializeActionCallArgument({ z: 20 })],
@@ -99,7 +100,7 @@ test("serializeActionCallArgument and deserializeActionCallArgument", () => {
   const setK: any[] = ["x", { z: 20 }]
   const set = new Set<any>(setK)
   const serSet = {
-    $mobxKeystoneSerializer: "mobx-keystone/setAsArray",
+    $mobxKeystoneSerializer: `${namespace}/setAsArray`,
     value: ["x", serializeActionCallArgument({ z: 20 })],
   }
 
@@ -125,7 +126,7 @@ test("serializeActionCallArgument and deserializeActionCallArgument", () => {
 
   {
     expect(serializeActionCallArgument(r2, r1)).toEqual({
-      $mobxKeystoneSerializer: "mobx-keystone/objectSnapshot",
+      $mobxKeystoneSerializer: `${namespace}/objectSnapshot`,
       value: getSnapshot(r2),
     })
 
@@ -145,7 +146,7 @@ test("serializeActionCallArgument and deserializeActionCallArgument", () => {
   {
     const serializedR2Child = serializeActionCallArgument(r2.child, r2)
     expect(serializedR2Child).toEqual({
-      $mobxKeystoneSerializer: "mobx-keystone/objectPath",
+      $mobxKeystoneSerializer: `${namespace}/objectPath`,
       value: {
         targetPath: ["child"],
         targetPathIds: [r2.child!.$modelId],
@@ -160,7 +161,7 @@ test("serializeActionCallArgument and deserializeActionCallArgument", () => {
   {
     const serializedR2Child = serializeActionCallArgument(r2, r2)
     expect(serializedR2Child).toEqual({
-      $mobxKeystoneSerializer: "mobx-keystone/objectPath",
+      $mobxKeystoneSerializer: `${namespace}/objectPath`,
       value: {
         targetPath: [],
         targetPathIds: [],


### PR DESCRIPTION
Just a minor refactoring to have the built-in namespace "mobx-keystone" in a single place.