### PR TITLE
add action serialization for non-JSON primitive values

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 # Change Log
 
 - Added property transform `stringToBigIntTransform`.
+- Added action serialization for non-JSON primitive values `undefined`, `bigint` and special `number` values `NaN`/`+Infinity`/`-Infinity`.
 
 ## 0.64.1
 

--- a/packages/lib/src/actionMiddlewares/actionSerialization/actionSerialization.ts
+++ b/packages/lib/src/actionMiddlewares/actionSerialization/actionSerialization.ts
@@ -1,8 +1,8 @@
 import type { O } from "ts-toolbelt"
 import type { ActionCall } from "../../action/applyAction"
 import { assertTweakedObject } from "../../tweaker/core"
-import { failure, isPlainObject, isPrimitive } from "../../utils"
-import type { PrimitiveValue } from "../../utils/types"
+import { failure, isJSONPrimitive, isPlainObject } from "../../utils"
+import type { JSONPrimitiveValue } from "../../utils/types"
 import { arraySerializer } from "./arraySerializer"
 import { ActionCallArgumentSerializer, cannotSerialize } from "./core"
 import { dateSerializer } from "./dateSerializer"
@@ -10,6 +10,7 @@ import { mapSerializer } from "./mapSerializer"
 import { objectPathSerializer } from "./objectPathSerializer"
 import { objectSnapshotSerializer } from "./objectSnapshotSerializer"
 import { plainObjectSerializer } from "./plainObjectSerializer"
+import { primitiveSerializer } from "./primitiveSerializer"
 import { setSerializer } from "./setSerializer"
 
 const serializersArray: ActionCallArgumentSerializer<any, any>[] = []
@@ -66,7 +67,7 @@ export interface SerializedActionCall extends Omit<ActionCall, "serialized"> {
   /**
    * Serialized action arguments.
    */
-  readonly args: ReadonlyArray<SerializedActionCallArgument | PrimitiveValue>
+  readonly args: ReadonlyArray<SerializedActionCallArgument | JSONPrimitiveValue>
 
   /**
    * Marks this action call as serialized.
@@ -96,8 +97,8 @@ export interface SerializedActionCall extends Omit<ActionCall, "serialized"> {
 export function serializeActionCallArgument(
   argValue: any,
   targetRoot?: object
-): SerializedActionCallArgument | PrimitiveValue {
-  if (isPrimitive(argValue)) {
+): SerializedActionCallArgument | JSONPrimitiveValue {
+  if (isJSONPrimitive(argValue)) {
     return argValue
   }
 
@@ -157,10 +158,10 @@ export function serializeActionCall(
  * @returns The deserialized form of the passed value.
  */
 export function deserializeActionCallArgument(
-  argValue: SerializedActionCallArgument | PrimitiveValue,
+  argValue: SerializedActionCallArgument | JSONPrimitiveValue,
   targetRoot?: object
 ): any {
-  if (isPrimitive(argValue)) {
+  if (isJSONPrimitive(argValue)) {
     return argValue
   }
 
@@ -213,6 +214,7 @@ export function deserializeActionCall(
 
 // serializer registration (from low priority to high priority)
 
+registerActionCallArgumentSerializer(primitiveSerializer)
 registerActionCallArgumentSerializer(plainObjectSerializer)
 registerActionCallArgumentSerializer(setSerializer)
 registerActionCallArgumentSerializer(mapSerializer)

--- a/packages/lib/src/actionMiddlewares/actionSerialization/primitiveSerializer.ts
+++ b/packages/lib/src/actionMiddlewares/actionSerialization/primitiveSerializer.ts
@@ -1,0 +1,46 @@
+import { namespace } from "../../utils"
+import { ActionCallArgumentSerializer, cannotSerialize } from "./core"
+
+export const primitiveSerializer: ActionCallArgumentSerializer<number | bigint | undefined, string>  = {
+  id: `${namespace}/primitiveAsString`,
+
+  serialize(value) {
+    // number
+    if (Number.isNaN(value)) {
+      return "nan"
+    }
+    switch (value) {
+      case +Infinity:
+        return "+inf"
+      case -Infinity:
+        return "-inf"
+    }
+
+    // bigint
+    if (typeof value === "bigint") {
+      return value.toString()
+    }
+
+    // undefined
+    if (value === undefined) {
+      return "undefined"
+    }
+
+    return cannotSerialize
+  },
+
+  deserialize(str) {
+    switch (str) {
+      case "nan":
+        return NaN
+      case "+inf":
+        return +Infinity
+      case "-inf":
+        return -Infinity
+      case "undefined":
+        return undefined
+      default:
+        return BigInt(str)
+    }
+  },
+}

--- a/packages/lib/src/utils/index.ts
+++ b/packages/lib/src/utils/index.ts
@@ -8,7 +8,7 @@ import {
   ObservableMap,
   ObservableSet,
 } from "mobx"
-import { PrimitiveValue } from "./types"
+import { JSONPrimitiveValue, PrimitiveValue } from "./types"
 
 /**
  * A mobx-keystone error.
@@ -101,6 +101,21 @@ export function isPrimitive(value: any): value is PrimitiveValue {
     case "boolean":
     case "undefined":
     case "bigint":
+      return true
+  }
+  return value === null
+}
+
+/**
+ * @ignore
+ * @internal
+ */
+ export function isJSONPrimitive(value: any): value is JSONPrimitiveValue {
+  switch (typeof value) {
+    case "number":
+      return isFinite(value)
+    case "string":
+    case "boolean":
       return true
   }
   return value === null

--- a/packages/lib/src/utils/types.ts
+++ b/packages/lib/src/utils/types.ts
@@ -8,6 +8,13 @@ export type PrimitiveValue = undefined | null | boolean | number | string | bigi
 /**
  * @ignore
  *
+ * A JSON-compatible primitive value.
+ */
+ export type JSONPrimitiveValue = null | boolean | number | string
+
+/**
+ * @ignore
+ *
  * Checks if a value is optional (undefined or any).
  *
  * Examples:

--- a/packages/lib/test/actionMiddlewares/actionSerialization.test.ts
+++ b/packages/lib/test/actionMiddlewares/actionSerialization.test.ts
@@ -29,10 +29,61 @@ test("serializeActionCallArgument and deserializeActionCallArgument", () => {
     "serializeActionCallArgument could not serialize the given value"
   )
 
-  // primitive
-  const serPrim = 42
-  expect(serializeActionCallArgument(42)).toEqual(serPrim)
-  expect(deserializeActionCallArgument(serPrim)).toBe(42)
+  // primitives
+
+  // number
+  const serNumber = 42
+  expect(serializeActionCallArgument(42)).toEqual(serNumber)
+  expect(deserializeActionCallArgument(serNumber)).toBe(42)
+
+  // number (NaN)
+  const serNumberNaN = { $mobxKeystoneSerializer: `${namespace}/primitiveAsString`, value: "nan" }
+  expect(serializeActionCallArgument(NaN)).toEqual(serNumberNaN)
+  expect(deserializeActionCallArgument(serNumberNaN)).toBeNaN()
+
+  // number (+Infinity)
+  const serNumberPosInf = {
+    $mobxKeystoneSerializer: `${namespace}/primitiveAsString`,
+    value: "+inf",
+  }
+  expect(serializeActionCallArgument(+Infinity)).toEqual(serNumberPosInf)
+  expect(deserializeActionCallArgument(serNumberPosInf)).toBe(+Infinity)
+
+  // number (-Infinity)
+  const serNumberNegInf = {
+    $mobxKeystoneSerializer: `${namespace}/primitiveAsString`,
+    value: "-inf",
+  }
+  expect(serializeActionCallArgument(-Infinity)).toEqual(serNumberNegInf)
+  expect(deserializeActionCallArgument(serNumberNegInf)).toBe(-Infinity)
+
+  // bigint
+  const serBigInt = { $mobxKeystoneSerializer: `${namespace}/primitiveAsString`, value: "42" }
+  expect(serializeActionCallArgument(42n)).toEqual(serBigInt)
+  expect(deserializeActionCallArgument(serBigInt)).toBe(42n)
+
+  // undefined
+  const serUndefined = {
+    $mobxKeystoneSerializer: `${namespace}/primitiveAsString`,
+    value: "undefined",
+  }
+  expect(serializeActionCallArgument(undefined)).toEqual(serUndefined)
+  expect(deserializeActionCallArgument(serUndefined)).toBeUndefined()
+
+  // string
+  const serString = "ho"
+  expect(serializeActionCallArgument("ho")).toEqual(serString)
+  expect(deserializeActionCallArgument(serString)).toBe("ho")
+
+  // boolean
+  const serBoolean = true
+  expect(serializeActionCallArgument(true)).toEqual(serBoolean)
+  expect(deserializeActionCallArgument(serBoolean)).toBe(true)
+
+  // null
+  const serNull = null
+  expect(serializeActionCallArgument(null)).toEqual(serNull)
+  expect(deserializeActionCallArgument(serNull)).toBe(null)
 
   // date
   const serDate = { $mobxKeystoneSerializer: `${namespace}/dateAsTimestamp`, value: 1000 }

--- a/packages/site/docs/actionMiddlewares/onActionMiddleware.mdx
+++ b/packages/site/docs/actionMiddlewares/onActionMiddleware.mdx
@@ -56,7 +56,7 @@ const disposer = onActionMiddleware(myTodoList, {
 
 Action serialization (via `serializeActionCall` and `deserializeActionCall`) supports many cases by default:
 
-- Primitives.
+- Primitives (including `undefined`, `bigint` and special `number` values `NaN`/`+Infinity`/`-Infinity`, but not `symbol`).
 - Tree nodes as paths if they are under the same root node as the model that holds the action being called.
 - Tree nodes as snapshots if not.
 - Arrays and observable arrays.


### PR DESCRIPTION
This PR adds support for action serialization of non-JSON primitive values (`undefined`, `bigint`, and special `number` values `NaN`/`+Infinity`/`-Infinity`, but not `symbol` because I think there's no general way to serialize them) including tests.

There are likely several ways to implement it (single vs. multiple (de)serializer(s), encoding of those primitive values etc.). This is my suggestion, but feel free to request a different approach. :slightly_smiling_face: