### PR TITLE
improve readonly middleware's allowWrite typing

### DIFF
--- a/packages/lib/src/actionMiddlewares/readonlyMiddleware.ts
+++ b/packages/lib/src/actionMiddlewares/readonlyMiddleware.ts
@@ -12,7 +12,7 @@ import {
  * Return type for readonly middleware.
  */
 export interface ReadonlyMiddlewareReturn {
-  allowWrite<FN extends () => any>(fn: FN): ReturnType<FN>
+  allowWrite<R>(fn: () => R): R
 
   dispose: ActionMiddlewareDisposer
 }


### PR DESCRIPTION
I think this typing is simpler and more to the point. Although there's no difference in what it does in this case, is there? :thinking: