### PR TITLE
use enum instead of string literals for action tracking middleware state

### DIFF
--- a/packages/lib/src/actionMiddlewares/actionTrackingMiddleware.ts
+++ b/packages/lib/src/actionMiddlewares/actionTrackingMiddleware.ts
@@ -141,12 +141,12 @@ export function actionTrackingMiddleware(
 
   const dataSymbol = Symbol("actionTrackingMiddlewareData")
   enum State {
-    Idle,
-    Started,
-    RealResumed,
-    FakeResumed,
-    Suspended,
-    Finished,
+    Idle = "idle",
+    Started = "started",
+    RealResumed = "realResumed",
+    FakeResumed = "fakeResumed",
+    Suspended = "suspended",
+    Finished = "finished",
   }
   interface Data {
     startAccepted: boolean

--- a/packages/lib/src/actionMiddlewares/actionTrackingMiddleware.ts
+++ b/packages/lib/src/actionMiddlewares/actionTrackingMiddleware.ts
@@ -140,9 +140,17 @@ export function actionTrackingMiddleware(
   assertTweakedObject(subtreeRoot, "subtreeRoot")
 
   const dataSymbol = Symbol("actionTrackingMiddlewareData")
+  enum State {
+    Idle,
+    Started,
+    RealResumed,
+    FakeResumed,
+    Suspended,
+    Finished,
+  }
   interface Data {
     startAccepted: boolean
-    state: "idle" | "started" | "realResumed" | "fakeResumed" | "suspended" | "finished"
+    state: State
   }
   function getCtxData(ctx: ActionContext | SimpleActionContext): Data | undefined {
     return ctx.data[dataSymbol]
@@ -173,7 +181,7 @@ export function actionTrackingMiddleware(
       if (accepted) {
         setCtxData(ctx, {
           startAccepted: true,
-          state: "idle",
+          state: State.Idle,
         })
       }
       return accepted
@@ -184,7 +192,7 @@ export function actionTrackingMiddleware(
           if (accepted) {
             setCtxData(ctx, {
               startAccepted: true,
-              state: "idle",
+              state: State.Idle,
             })
           }
           return accepted
@@ -213,7 +221,7 @@ export function actionTrackingMiddleware(
 
   const start = (simpleCtx: SimpleActionContext): ActionTrackingReturn | undefined => {
     setCtxData(simpleCtx, {
-      state: "started",
+      state: State.Started,
     })
     if (hooks.onStart) {
       return hooks.onStart(simpleCtx) || undefined
@@ -230,14 +238,14 @@ export function actionTrackingMiddleware(
     let parentResumed = false
     if (parentCtx) {
       const parentData = getCtxData(parentCtx)
-      if (parentData && parentData.startAccepted && parentData.state === "suspended") {
+      if (parentData && parentData.startAccepted && parentData.state === State.Suspended) {
         parentResumed = true
         resume(parentCtx, false)
       }
     }
 
     setCtxData(simpleCtx, {
-      state: "finished",
+      state: State.Finished,
     })
 
     if (hooks.onFinish) {
@@ -256,13 +264,13 @@ export function actionTrackingMiddleware(
     const parentCtx = simpleCtx.parentContext
     if (parentCtx) {
       const parentData = getCtxData(parentCtx)
-      if (parentData && parentData.startAccepted && parentData.state === "suspended") {
+      if (parentData && parentData.startAccepted && parentData.state === State.Suspended) {
         resume(parentCtx, false)
       }
     }
 
     setCtxData(simpleCtx, {
-      state: real ? "realResumed" : "fakeResumed",
+      state: real ? State.RealResumed : State.FakeResumed,
     })
     if (hooks.onResume) {
       hooks.onResume(simpleCtx)
@@ -271,7 +279,7 @@ export function actionTrackingMiddleware(
 
   const suspend = (simpleCtx: SimpleActionContext) => {
     setCtxData(simpleCtx, {
-      state: "suspended",
+      state: State.Suspended,
     })
     if (hooks.onSuspend) {
       hooks.onSuspend(simpleCtx)
@@ -281,7 +289,7 @@ export function actionTrackingMiddleware(
     const parentCtx = simpleCtx.parentContext
     if (parentCtx) {
       const parentData = getCtxData(parentCtx)
-      if (parentData && parentData.startAccepted && parentData.state === "fakeResumed") {
+      if (parentData && parentData.startAccepted && parentData.state === State.FakeResumed) {
         suspend(parentCtx)
       }
     }


### PR DESCRIPTION
Certainly a matter of taste/style, but I think enums are preferable to string literals for representing state. Feel free to prefer keeping it as it is now if you disagree. :slightly_smiling_face: 