### PR TITLE
fix typos

### DIFF
--- a/packages/lib/src/actionMiddlewares/actionTrackingMiddleware.ts
+++ b/packages/lib/src/actionMiddlewares/actionTrackingMiddleware.ts
@@ -316,7 +316,7 @@ export function actionTrackingMiddleware(
       let retObj = start(simpleCtx)
 
       if (retObj) {
-        // action cancelled / overriden by onStart
+        // action canceled / overridden by onStart
         resume(simpleCtx, true)
         suspend(simpleCtx)
         retObj = finish(simpleCtx, retObj)
@@ -336,7 +336,7 @@ export function actionTrackingMiddleware(
         case ActionContextAsyncStepType.Spawn: {
           let retObj = start(simpleCtx)
           if (retObj) {
-            // action cancelled / overriden by onStart
+            // action canceled / overridden by onStart
             resume(simpleCtx, true)
             suspend(simpleCtx)
             retObj = finish(simpleCtx, retObj)
@@ -376,13 +376,13 @@ export function actionTrackingMiddleware(
             return next()
           } else {
             throw failure(
-              `asssertion error: async step should have been filtered out - ${ctx.asyncStepType}`
+              `assertion error: async step should have been filtered out - ${ctx.asyncStepType}`
             )
           }
 
         default:
           throw failure(
-            `asssertion error: async step should have been filtered out - ${ctx.asyncStepType}`
+            `assertion error: async step should have been filtered out - ${ctx.asyncStepType}`
           )
       }
     }

--- a/packages/lib/src/model/BaseModel.ts
+++ b/packages/lib/src/model/BaseModel.ts
@@ -73,7 +73,7 @@ export abstract class BaseModel<
   }
 
   /**
-   * Can be overriden to offer a reference id to be used in reference resolution.
+   * Can be overridden to offer a reference id to be used in reference resolution.
    * By default it will use the `idProp` if available or return `undefined` otherwise.
    */
   getRefId(): string | undefined {


### PR DESCRIPTION
Just a couple of typo fixes.

AFAIK "cancelled" is BE and "canceled" is AE.