### PR TITLE
improve [Simple]ActionContext data property typing

### DIFF
--- a/packages/lib/src/action/context.ts
+++ b/packages/lib/src/action/context.ts
@@ -42,10 +42,9 @@ export interface ActionContext {
   readonly asyncStepType?: ActionContextAsyncStepType
   /**
    * Custom data for the action context to be set by middlewares, an object.
-   * It is advised to use symbols as keys whenever possible to avoid name
-   * clashing between middlewares.
+   * Symbols must be used as keys to avoid name clashing between middlewares.
    */
-  readonly data: any
+  readonly data: Record<symbol, any>
 }
 
 /**

--- a/packages/lib/src/actionMiddlewares/actionTrackingMiddleware.ts
+++ b/packages/lib/src/actionMiddlewares/actionTrackingMiddleware.ts
@@ -43,10 +43,9 @@ export interface SimpleActionContext {
   readonly rootContext: SimpleActionContext
   /**
    * Custom data for the action context to be set by middlewares, an object.
-   * It is advised to use symbols as keys whenever possible to avoid name
-   * clashing between middlewares.
+   * Symbols must be used as keys to avoid name clashing between middlewares.
    */
-  readonly data: any
+  readonly data: Record<symbol, any>
 }
 
 /**


### PR DESCRIPTION
Are you aware of any situation in which `data` should not be an object with `symbol` keys? If not, I think the typing should enforce it.