### PR TITLE
fix conflict between Prettier and VS Code's organize imports

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,8 +1,6 @@
 {
+  "editor.defaultFormatter": "esbenp.prettier-vscode",
   "editor.formatOnSave": true,
-  "editor.codeActionsOnSave": {
-    "source.organizeImports": true
-  },
   "typescript.tsdk": "./node_modules/typescript/lib",
   "eslint.validate": ["javascript", "javascriptreact", "typescript", "typescriptreact"],
   "peacock.color": "#68217A",

--- a/package.json
+++ b/package.json
@@ -30,6 +30,7 @@
     "eslint-config-react-app": "^7.0.0",
     "netlify-cli": "^8.15.0",
     "prettier": "^2.5.1",
+    "prettier-plugin-organize-imports": "^2.3.4",
     "typescript": "^4.5.5"
   },
   "packageManager": "yarn@3.1.1"

--- a/yarn.lock
+++ b/yarn.lock
@@ -16207,6 +16207,16 @@ __metadata:
   languageName: node
   linkType: hard
 
+"prettier-plugin-organize-imports@npm:^2.3.4":
+  version: 2.3.4
+  resolution: "prettier-plugin-organize-imports@npm:2.3.4"
+  peerDependencies:
+    prettier: ">=2.0"
+    typescript: ">=2.9"
+  checksum: 2298fcae0f16fd1a095cc3a33ba5d51b679b291518d404ad5eaca56fdcfbd55d35e26c5adffcb8664bfb45c2339b551b385cf03f48888c46d0348843d96024e1
+  languageName: node
+  linkType: hard
+
 "prettier@npm:^2.5.1":
   version: 2.5.1
   resolution: "prettier@npm:2.5.1"
@@ -17512,6 +17522,7 @@ __metadata:
     eslint-config-react-app: ^7.0.0
     netlify-cli: ^8.15.0
     prettier: ^2.5.1
+    prettier-plugin-organize-imports: ^2.3.4
     typescript: ^4.5.5
     utf-8-validate: ^5.0.8
   languageName: unknown


### PR DESCRIPTION
Not sure whether it has been the same for you, but I've been having a slightly annoying issue with auto-formatting imports for a long time. Format on save organizes my imports but removes the trailing comma in the last import of a multi-line import statement which conflicts with what Prettier expects.

I've tracked this issue to https://github.com/prettier/prettier-vscode/issues/716 where the conclusion seems to be using [`prettier-plugin-organize-imports`](https://github.com/simonhaenisch/prettier-plugin-organize-imports) and removing VS Code's built-in import organizer:

```json
"editor.codeActionsOnSave": {
  "source.organizeImports": true
}
```

That's what I've done and now it works for me. What do you think?