### PR TITLE
fix formatting and add CI job to check it

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -3,9 +3,9 @@ name: CI
 on:
   # Triggers the workflow on push or pull request events but only for the master branch
   push:
-    branches: [ master ]
+    branches: [master]
   pull_request:
-    branches: [ master ]
+    branches: [master]
 
   # Allows you to run this workflow manually from the Actions tab
   workflow_dispatch:
@@ -14,13 +14,12 @@ env:
   NODE_VERSION: "16"
 
 jobs:
-
   lib-site-build:
     runs-on: ubuntu-latest
 
     steps:
       - uses: actions/checkout@v2
-      
+
       - uses: actions/setup-node@v2
         with:
           node-version: ${{ env.NODE_VERSION }}
@@ -31,17 +30,17 @@ jobs:
           path: .yarn/cache
           key: v3-${{ runner.os }}-yarn_cache
           restore-keys: |
-            v3-${{ runner.os }}-          
+            v3-${{ runner.os }}-
 
       - run: yarn install --immutable
       - run: yarn lib:build && yarn lib:build-docs && yarn site:build
-  
+
   lib-test:
     runs-on: ubuntu-latest
 
     steps:
       - uses: actions/checkout@v2
-      
+
       - uses: actions/setup-node@v2
         with:
           node-version: ${{ env.NODE_VERSION }}
@@ -52,7 +51,28 @@ jobs:
           path: .yarn/cache
           key: v3-${{ runner.os }}-yarn_cache
           restore-keys: |
-            v3-${{ runner.os }}-          
+            v3-${{ runner.os }}-
 
       - run: yarn install --immutable
       - run: yarn lib:test -i --coverage && yarn codecov -p ./packages/lib
+
+  formatting:
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v2
+
+      - uses: actions/setup-node@v2
+        with:
+          node-version: ${{ env.NODE_VERSION }}
+
+      - name: Cache .yarn/cache
+        uses: actions/cache@v2
+        with:
+          path: .yarn/cache
+          key: v3-${{ runner.os }}-yarn_cache
+          restore-keys: |
+            v3-${{ runner.os }}-
+
+      - run: yarn install --immutable
+      - run: yarn prettier --check .

--- a/.prettierignore
+++ b/.prettierignore
@@ -10,7 +10,7 @@ dist/
 /packages/site/build/
 /packages/site/static/api/
 
-.yarn/*
+.yarn/
 !.yarn/patches
 !.yarn/releases
 !.yarn/plugins

--- a/.vscode/extensions.json
+++ b/.vscode/extensions.json
@@ -1,7 +1,3 @@
 {
-  "recommendations": [
-    "dbaeumer.vscode-eslint",
-    "esbenp.prettier-vscode",
-    "arcanis.vscode-zipfs"
-  ]
+  "recommendations": ["dbaeumer.vscode-eslint", "esbenp.prettier-vscode", "arcanis.vscode-zipfs"]
 }


### PR DESCRIPTION
Prettier was also unhappy with some files outside `packages/**`. I've fixed those and added a CI job to check formatting automatically.

Did the Prettier check from https://github.com/xaviergonz/mobx-keystone/pull/196 not make it intentionally or accidentally during the migration to GitHub Actions? I think a while ago, Prettier didn't support the complete TS syntax and that CI job was failing all the time (starting with https://github.com/xaviergonz/mobx-keystone/pull/220).

Feel free to to decline this PR if you don't want a CI job that checks formatting. :slightly_smiling_face: