### PR TITLE
fix typo in computed trees docs

### DIFF
--- a/packages/site/docs/computedTrees.mdx
+++ b/packages/site/docs/computedTrees.mdx
@@ -48,7 +48,7 @@ Computed trees have the following properties:
 - **Action middlewares** are never applied to a computed tree because of its immutability.
 - **Contexts** are available within a computed tree, across computed trees, and across the boundary between a regular and a computed tree.
 - **Tree traversal methods** can be used on computed tree nodes within a computed tree, across computed trees, and across the boundary between a regular and a computed tree. However, most [utility methods](./treeLikeStructure.mdx#utility-methods) do not work on computed tree nodes because of their immutability except for `onChildAttachedTo` whose listener callback gets called upon re-computation of a computed tree child.
-- **References** are available within a computed tree, across computed trees, and across the boundary between a regular and a computed tree. When referencing a model instances in a computed tree, it is important that the ID of the referenced model instance is _stable_ across re-computations of the computed tree.
+- **References** are available within a computed tree, across computed trees, and across the boundary between a regular and a computed tree. When referencing a model instance in a computed tree, it is important that the ID of the referenced model instance is _stable_ across re-computations of the computed tree.
 - **Back-references** are available within a computed tree, across computed trees, and across the boundary between a regular and a computed tree.
 - **Life-cycle event hooks** are available and work as expected. `onAttachedToRootStore` is called upon each re-computation of the computed tree when it is part of a root store tree.
 - **Snapshots** do not contain data of computed trees.


### PR DESCRIPTION
Just a minor typo in the computed trees docs I overlooked.