### PR TITLE
run test setup code via Jest's setupFilesAfterEnv option

### DIFF
--- a/packages/lib/jest.config.js
+++ b/packages/lib/jest.config.js
@@ -6,4 +6,5 @@ module.exports = {
       tsconfig: "./test/tsconfig.json",
     },
   },
+  setupFilesAfterEnv: ["./test/commonSetup.ts"],
 }

--- a/packages/lib/test/actionMiddlewares/actionSerialization.test.ts
+++ b/packages/lib/test/actionMiddlewares/actionSerialization.test.ts
@@ -18,7 +18,6 @@ import {
   SerializedActionCall,
   SerializedActionCallArgument,
 } from "../../src"
-import "../commonSetup"
 
 test("serializeActionCallArgument and deserializeActionCallArgument", () => {
   // unserializable args

--- a/packages/lib/test/actionMiddlewares/applySerializedAction.test.ts
+++ b/packages/lib/test/actionMiddlewares/applySerializedAction.test.ts
@@ -14,7 +14,6 @@ import {
   serializeActionCall,
   SerializedActionCall,
 } from "../../src"
-import "../commonSetup"
 
 describe("concurrency", () => {
   @model("Root")

--- a/packages/lib/test/actionMiddlewares/transactionMiddleware.test.ts
+++ b/packages/lib/test/actionMiddlewares/transactionMiddleware.test.ts
@@ -10,7 +10,6 @@ import {
   _async,
   _await,
 } from "../../src"
-import "../commonSetup"
 
 @model("P2")
 class P2 extends Model({

--- a/packages/lib/test/dataModel/propTransform.test.ts
+++ b/packages/lib/test/dataModel/propTransform.test.ts
@@ -9,7 +9,6 @@ import {
   tProp,
   types,
 } from "../../src"
-import "../commonSetup"
 
 test("prop with transform and required value", () => {
   @model("pwt/Trequired")

--- a/packages/lib/test/model/create.test.ts
+++ b/packages/lib/test/model/create.test.ts
@@ -1,5 +1,4 @@
 import { idProp, model, Model, modelIdKey, prop, tProp, types } from "../../src"
-import "../commonSetup"
 
 describe("create with extra properties", () => {
   const data = { value: 0, a: 2 }

--- a/packages/lib/test/model/defaultProps.test.ts
+++ b/packages/lib/test/model/defaultProps.test.ts
@@ -10,7 +10,6 @@ import {
   tProp,
   types,
 } from "../../src"
-import "../commonSetup"
 
 @model("M")
 class M extends Model({

--- a/packages/lib/test/model/factory.test.ts
+++ b/packages/lib/test/model/factory.test.ts
@@ -10,7 +10,6 @@ import {
   SnapshotInOf,
   SnapshotOutOf,
 } from "../../src"
-import "../commonSetup"
 
 test("factory pattern", () => {
   function createModelClass<TX, TY>(modelName: string, initialX: TX, initialY: TY) {

--- a/packages/lib/test/model/ids.test.ts
+++ b/packages/lib/test/model/ids.test.ts
@@ -11,7 +11,6 @@ import {
   runUnprotected,
   SnapshotOutOf,
 } from "../../src"
-import "../commonSetup"
 
 test("ids", () => {
   @model("ids")

--- a/packages/lib/test/model/modelDecorator.test.ts
+++ b/packages/lib/test/model/modelDecorator.test.ts
@@ -15,7 +15,6 @@ import {
   SnapshotInOf,
   SnapshotOutOf,
 } from "../../src"
-import "../commonSetup"
 
 test("model decorator preserves static properties", () => {
   @model("BarSimple")

--- a/packages/lib/test/model/onChildAttachedTo.test.ts
+++ b/packages/lib/test/model/onChildAttachedTo.test.ts
@@ -9,7 +9,6 @@ import {
   prop,
 } from "../../src"
 import { isArray, isObject } from "../../src/utils"
-import "../commonSetup"
 
 const name = (obj: object) => {
   if (obj instanceof BaseModel) return obj.$modelType

--- a/packages/lib/test/model/propTransform.test.ts
+++ b/packages/lib/test/model/propTransform.test.ts
@@ -15,7 +15,6 @@ import {
   tProp,
   types,
 } from "../../src"
-import "../commonSetup"
 
 test("prop with transform and required value", () => {
   @model("pwt/Trequired")

--- a/packages/lib/test/model/propsWithSameName.test.ts
+++ b/packages/lib/test/model/propsWithSameName.test.ts
@@ -1,6 +1,5 @@
 import { assert, _ } from "spec.ts"
 import { idProp, Model, model, modelIdKey, prop, runUnprotected } from "../../src"
-import "../commonSetup"
 
 @model("M")
 class M extends Model({

--- a/packages/lib/test/model/recursive.test.ts
+++ b/packages/lib/test/model/recursive.test.ts
@@ -9,7 +9,6 @@ import {
   types,
   TypeToData,
 } from "../../src"
-import "../commonSetup"
 
 beforeEach(() => {
   setGlobalConfig({

--- a/packages/lib/test/model/subclassing.test.ts
+++ b/packages/lib/test/model/subclassing.test.ts
@@ -16,7 +16,6 @@ import {
   tProp,
   types,
 } from "../../src"
-import "../commonSetup"
 
 // @model("P")
 class P extends Model({

--- a/packages/lib/test/model/tweak.test.ts
+++ b/packages/lib/test/model/tweak.test.ts
@@ -1,6 +1,5 @@
 import { isObservable, keys, set, values } from "mobx"
 import { getParent, isTreeNode, model, Model, prop, runUnprotected } from "../../src"
-import "../commonSetup"
 
 interface TestObj {
   x: number

--- a/packages/lib/test/model/valueType.test.ts
+++ b/packages/lib/test/model/valueType.test.ts
@@ -1,5 +1,4 @@
 import { Model, model, modelAction, prop } from "../../src"
-import "../commonSetup"
 
 test("value type", () => {
   @model("P")

--- a/packages/lib/test/parent/parent.test.ts
+++ b/packages/lib/test/parent/parent.test.ts
@@ -17,7 +17,6 @@ import {
   prop,
   runUnprotected,
 } from "../../src"
-import "../commonSetup"
 
 const $errorMessage = "must be the model object instance instead of the '$' sub-object"
 

--- a/packages/lib/test/parent/walkTree.test.ts
+++ b/packages/lib/test/parent/walkTree.test.ts
@@ -1,6 +1,5 @@
 import { autorun, observable, ObservableMap, runInAction } from "mobx"
 import { AnyModel, detach, model, Model, prop, walkTree, WalkTreeMode } from "../../src"
-import "../commonSetup"
 
 test("walktree should be reactive", () => {
   type Registry<K, V extends object> = ObservableMap<K, V>

--- a/packages/lib/test/patch/jsonPatch.test.ts
+++ b/packages/lib/test/patch/jsonPatch.test.ts
@@ -1,5 +1,4 @@
 import { jsonPatchToPatch, jsonPointerToPath, patchToJsonPatch, pathToJsonPointer } from "../../src"
-import "../commonSetup"
 
 test("JSON path conversion", () => {
   expect(pathToJsonPointer([])).toEqual("")

--- a/packages/lib/test/redux/connectReduxDevTools.test.ts
+++ b/packages/lib/test/redux/connectReduxDevTools.test.ts
@@ -12,7 +12,6 @@ import {
   _async,
   _await,
 } from "../../src"
-import "../commonSetup"
 
 jest.useRealTimers()
 

--- a/packages/lib/test/rootStore/rootStore.test.ts
+++ b/packages/lib/test/rootStore/rootStore.test.ts
@@ -11,7 +11,6 @@ import {
   toTreeNode,
   unregisterRootStore,
 } from "../../src"
-import "../commonSetup"
 
 const events: string[] = []
 

--- a/packages/lib/test/snapshot/modelProcessor.test.ts
+++ b/packages/lib/test/snapshot/modelProcessor.test.ts
@@ -15,7 +15,6 @@ import {
   SnapshotInOf,
   SnapshotOutOf,
 } from "../../src"
-import "../commonSetup"
 
 test("input snapshot processor", () => {
   @model("customInputSnapshot")

--- a/packages/lib/test/snapshot/noModelType.test.ts
+++ b/packages/lib/test/snapshot/noModelType.test.ts
@@ -11,7 +11,6 @@ import {
   tProp,
   types,
 } from "../../src"
-import "../commonSetup"
 
 test("model without model type thanks to a tProp", () => {
   @model("m1/1")

--- a/packages/lib/test/snapshot/propProcessor.test.ts
+++ b/packages/lib/test/snapshot/propProcessor.test.ts
@@ -14,7 +14,6 @@ import {
   SnapshotInOf,
   SnapshotOutOf,
 } from "../../src"
-import "../commonSetup"
 
 test("input snapshot processor", () => {
   @model("customInputSnapshot")

--- a/packages/lib/test/spread/spread.test.ts
+++ b/packages/lib/test/spread/spread.test.ts
@@ -10,7 +10,6 @@ import {
   Patch,
   prop,
 } from "../../src"
-import "../commonSetup"
 
 test("reassigning an array via spreading", () => {
   @model("SpreadArr_Obj")

--- a/packages/lib/test/standardActions/arrayActions.test.ts
+++ b/packages/lib/test/standardActions/arrayActions.test.ts
@@ -1,5 +1,4 @@
 import { arrayActions, isTreeNode } from "../../src"
-import "../commonSetup"
 
 test("typed array", () => {
   const arr = arrayActions.create([1, 2])

--- a/packages/lib/test/standardActions/objectActions.test.ts
+++ b/packages/lib/test/standardActions/objectActions.test.ts
@@ -1,5 +1,4 @@
 import { Model, model, modelAction, objectActions, prop } from "../../src"
-import "../commonSetup"
 
 test("typed object", () => {
   const obj = objectActions.create({ a: 1 })

--- a/packages/lib/test/treeUtils/draft.test.ts
+++ b/packages/lib/test/treeUtils/draft.test.ts
@@ -8,7 +8,6 @@ import {
   prop,
   SnapshotOutOf,
 } from "../../src"
-import "../commonSetup"
 
 @model("M")
 class M extends Model({

--- a/packages/lib/test/wrappers/asMap.test.ts
+++ b/packages/lib/test/wrappers/asMap.test.ts
@@ -9,7 +9,6 @@ import {
   prop,
   runUnprotected,
 } from "../../src"
-import "../commonSetup"
 
 test("asMap - object", () => {
   @model(test.name)

--- a/packages/lib/test/wrappers/asSet.test.ts
+++ b/packages/lib/test/wrappers/asSet.test.ts
@@ -1,6 +1,5 @@
 import { computed, reaction } from "mobx"
 import { asSet, Model, model, modelAction, prop, runUnprotected, setToArray } from "../../src"
-import "../commonSetup"
 
 test("asSet", () => {
   @model(test.name)


### PR DESCRIPTION
I think this way it's more idiomatic and less error-prone.