### PR TITLE
add docs on transpiler configs

### DIFF
--- a/packages/site/docs/installation.mdx
+++ b/packages/site/docs/installation.mdx
@@ -1,0 +1,79 @@
+---
+title: Installation
+slug: /installation
+---
+
+import Tabs from "@theme/Tabs"
+import TabItem from "@theme/TabItem"
+
+<Tabs>
+<TabItem value="yarn" label="Yarn">
+
+```bash
+yarn add mobx-keystone
+```
+
+</TabItem>
+<TabItem value="npm" label="npm">
+
+```bash
+npm install --save mobx-keystone
+```
+
+</TabItem>
+</Tabs>
+
+This library requires a more or less modern JavaScript environment to work, namely one with support for:
+
+- MobX 6, 5, or 4 (with its gotchas)
+- Proxies (when using MobX 5, or MobX 6 with the proxies setting enabled)
+- Symbols
+- WeakMap/WeakSet
+
+In other words, it should work on mostly anything except _it won't work in Internet Explorer_.
+
+If you are using TypeScript, then version 4.2.0+ is recommended, though it _might_ work with older versions.
+
+## Transpiler configuration
+
+This library uses JavaScript decorators and class properties which are supported via the following transpiler configurations:
+
+<Tabs>
+<TabItem value="ts" label="TypeScript">
+
+```json
+{
+  // ...
+  "compilerOptions": {
+    // ...
+    "experimentalDecorators": true,
+    // MobX 5/6
+    "useDefineForClassFields": true
+    // MobX 4
+    "useDefineForClassFields": false
+  }
+}
+```
+
+</TabItem>
+<TabItem value="babel" label="Babel">
+
+```json
+{
+  "presets": [
+    // ...
+    // If you use TypeScript
+    ["@babel/preset-typescript", { "allowDeclareFields": true }]
+  ],
+  "plugins": [
+    ["@babel/plugin-proposal-decorators", { "version": "legacy" }],
+    // MobX 5/6
+    ["@babel/plugin-proposal-class-properties"]
+    // MobX 4
+    ["@babel/plugin-proposal-class-properties", { "loose": true }]
+  ]
+}
+```
+
+</TabItem>
+</Tabs>

--- a/packages/site/docs/installation.mdx
+++ b/packages/site/docs/installation.mdx
@@ -39,7 +39,7 @@ If you are using TypeScript, then version 4.2.0+ is recommended, though it _migh
 This library uses JavaScript decorators and class properties which are supported via the following transpiler configurations:
 
 <Tabs>
-<TabItem value="ts" label="TypeScript">
+<TabItem value="tsc" label="TypeScript Compiler">
 
 ```json
 {

--- a/packages/site/docs/installation.mdx
+++ b/packages/site/docs/installation.mdx
@@ -41,7 +41,7 @@ This library uses JavaScript decorators and class properties which are supported
 <Tabs>
 <TabItem value="tsc" label="TypeScript Compiler">
 
-```json
+```json title="tsconfig.json"
 {
   // ...
   "compilerOptions": {
@@ -58,7 +58,7 @@ This library uses JavaScript decorators and class properties which are supported
 </TabItem>
 <TabItem value="babel" label="Babel">
 
-```json
+```json title="babel.config.json"
 {
   "presets": [
     // ...

--- a/packages/site/docs/intro.mdx
+++ b/packages/site/docs/intro.mdx
@@ -39,22 +39,3 @@ Even cooler, because it supports snapshots, action middlewares and replayable ac
 This makes it possible to connect the Redux devtools to `mobx-keystone`.
 
 Like React, `mobx-keystone` consists of composable components, called _models_, which capture small pieces of state. They are instantiated from props and after that manage and protect their own internal state (using actions). Moreover, when applying snapshots, tree nodes are reconciled as much as possible.
-
-## Requirements
-
-This library requires a more or less modern JavaScript environment to work, namely one with support for:
-
-- MobX 6, 5, or 4 (with its gotchas)
-- Proxies (when using MobX 5, or MobX 6 with the proxies setting enabled)
-- Symbols
-- WeakMap/WeakSet
-
-In other words, it should work on mostly anything except _it won't work in Internet Explorer_.
-
-If you are using TypeScript, then version >= 4.2.0 is recommended, though it _might_ work with older versions.
-
-## Installation
-
-> `npm install mobx-keystone`
-
-> `yarn add mobx-keystone`

--- a/packages/site/sidebars.js
+++ b/packages/site/sidebars.js
@@ -4,6 +4,7 @@
 module.exports = {
   docs: [
     "intro",
+    "installation",
     "mstComparison",
     "classModels",
     "dataModels",


### PR DESCRIPTION
This PR adds documentation about transpiler configurations. I've intentionally not added these instructions to `README.md` because I felt it would be a bit verbose and not as nice without tabs.

What do you think?