### PR TITLE
fix internal hook action typing

### DIFF
--- a/packages/lib/src/action/hookActions.ts
+++ b/packages/lib/src/action/hookActions.ts
@@ -20,7 +20,7 @@ export enum HookAction {
   OnAttachedToRootStoreDisposer = "$$onAttachedToRootStoreDisposer",
 }
 
-const hookActionValues = new Set(Object.values(HookAction))
+const hookActionValues: ReadonlySet<string> = new Set(Object.values(HookAction))
 
 /**
  * Returns if a given action name corresponds to a hook, this is, one of:
@@ -33,5 +33,5 @@ const hookActionValues = new Set(Object.values(HookAction))
  * @returns true if it is a hook, false otherwise.
  */
 export function isHookAction(actionName: string): actionName is HookAction {
-  return hookActionValues.has(actionName as HookAction)
+  return hookActionValues.has(actionName)
 }


### PR DESCRIPTION
Just a minor internal typing fix.

That said, the `actionName as HookAction` type assertion was semantically not correct because `actionName` could be any string. On the other hand, declaring the `hookActionValues` set as `Set<HookAction>` was correct but too narrowly typed for the membership check later which led to the type assertion. I think my proposed change is more sound and doesn't require the type assertion.