### PR TITLE
use "unknown" type for type guard argument

### DIFF
--- a/packages/lib/src/action/modelFlow.ts
+++ b/packages/lib/src/action/modelFlow.ts
@@ -187,8 +187,8 @@ export interface FlowFinisher {
  * @param fn Function to check.
  * @returns
  */
-export function isModelFlow(fn: any) {
-  return typeof fn === "function" && fn[modelFlowSymbol]
+export function isModelFlow(fn: unknown) {
+  return typeof fn === "function" && modelFlowSymbol in fn
 }
 
 /**

--- a/packages/lib/src/dataModel/utils.ts
+++ b/packages/lib/src/dataModel/utils.ts
@@ -9,7 +9,7 @@ import { _BaseDataModel } from "./_BaseDataModel"
  * @param model
  * @returns
  */
-export function isDataModel(model: any): model is AnyDataModel {
+export function isDataModel(model: unknown): model is AnyDataModel {
   return model instanceof _BaseDataModel
 }
 
@@ -36,7 +36,7 @@ export function assertIsDataModel(
  * @ignore
  * @internal
  */
-export function isDataModelClass(modelClass: any): modelClass is ModelClass<AnyDataModel> {
+export function isDataModelClass(modelClass: unknown): modelClass is ModelClass<AnyDataModel> {
   if (typeof modelClass !== "function") {
     return false
   }

--- a/packages/lib/src/frozen/Frozen.ts
+++ b/packages/lib/src/frozen/Frozen.ts
@@ -126,6 +126,6 @@ function checkDataIsSerializableAndFreeze(data: any) {
  * @param snapshot
  * @returns
  */
-export function isFrozenSnapshot(snapshot: any): snapshot is SnapshotInOfFrozen<Frozen<any>> {
-  return isPlainObject(snapshot) && !!snapshot[frozenKey]
+export function isFrozenSnapshot(snapshot: unknown): snapshot is SnapshotInOfFrozen<Frozen<any>> {
+  return isPlainObject(snapshot) && frozenKey in snapshot
 }

--- a/packages/lib/src/model/utils.ts
+++ b/packages/lib/src/model/utils.ts
@@ -10,7 +10,7 @@ import { _BaseModel } from "./_BaseModel"
  * @param model
  * @returns
  */
-export function isModel(model: any): model is AnyModel {
+export function isModel(model: unknown): model is AnyModel {
   return model instanceof _BaseModel
 }
 
@@ -37,7 +37,7 @@ export function assertIsModel(
  * @ignore
  * @internal
  */
-export function isModelClass(modelClass: any): modelClass is ModelClass<AnyModel> {
+export function isModelClass(modelClass: unknown): modelClass is ModelClass<AnyModel> {
   if (typeof modelClass !== "function") {
     return false
   }
@@ -70,6 +70,6 @@ export function assertIsModelClass(
  * @ignore
  * @internal
  */
-export function isModelSnapshot(sn: any): sn is { [modelTypeKey]: string } {
-  return isPlainObject(sn) && !!sn[modelTypeKey]
+export function isModelSnapshot(sn: unknown): sn is { [modelTypeKey]: string } {
+  return isPlainObject(sn) && modelTypeKey in sn
 }

--- a/packages/lib/src/types/TypeChecker.ts
+++ b/packages/lib/src/types/TypeChecker.ts
@@ -212,8 +212,8 @@ export function lateTypeChecker(fn: () => TypeChecker, typeInfoGen: TypeInfoGen)
  * @ignore
  * @internal
  */
-export function isLateTypeChecker(ltc: any): ltc is LateTypeChecker {
-  return typeof ltc === "function" && ltc[lateTypeCheckerSymbol]
+export function isLateTypeChecker(ltc: unknown): ltc is LateTypeChecker {
+  return typeof ltc === "function" && lateTypeCheckerSymbol in ltc
 }
 
 /**

--- a/packages/lib/src/utils/index.ts
+++ b/packages/lib/src/utils/index.ts
@@ -76,7 +76,7 @@ export function makePropReadonly<T>(object: T, propName: keyof T, enumerable: bo
  * @ignore
  * @internal
  */
-export function isPlainObject(value: any): value is Object {
+export function isPlainObject(value: unknown): value is Object {
   if (!isObject(value)) return false
   const proto = Object.getPrototypeOf(value)
   return proto === Object.prototype || proto === null
@@ -86,7 +86,7 @@ export function isPlainObject(value: any): value is Object {
  * @ignore
  * @internal
  */
-export function isObject(value: any): value is Record<PropertyKey, unknown> {
+export function isObject(value: unknown): value is Record<PropertyKey, unknown> {
   return value !== null && typeof value === "object"
 }
 
@@ -94,7 +94,7 @@ export function isObject(value: any): value is Record<PropertyKey, unknown> {
  * @ignore
  * @internal
  */
-export function isPrimitive(value: any): value is PrimitiveValue {
+export function isPrimitive(value: unknown): value is PrimitiveValue {
   switch (typeof value) {
     case "number":
     case "string":
@@ -110,7 +110,7 @@ export function isPrimitive(value: any): value is PrimitiveValue {
  * @ignore
  * @internal
  */
-export function isJSONPrimitive(value: any): value is JSONPrimitiveValue {
+export function isJSONPrimitive(value: unknown): value is JSONPrimitiveValue {
   switch (typeof value) {
     case "number":
       return isFinite(value)
@@ -148,7 +148,7 @@ export function deleteFromArray<T>(array: T[], value: T): boolean {
  * @ignore
  * @internal
  */
-export function isMap(val: any): val is Map<any, any> | ObservableMap {
+export function isMap(val: unknown): val is Map<any, any> | ObservableMap {
   return val instanceof Map || isObservableMap(val)
 }
 
@@ -156,7 +156,7 @@ export function isMap(val: any): val is Map<any, any> | ObservableMap {
  * @ignore
  * @internal
  */
-export function isSet(val: any): val is Set<any> | ObservableSet {
+export function isSet(val: unknown): val is Set<any> | ObservableSet {
   return val instanceof Set || isObservableSet(val)
 }
 
@@ -164,7 +164,7 @@ export function isSet(val: any): val is Set<any> | ObservableSet {
  * @ignore
  * @internal
  */
-export function isArray(val: any): val is any[] | IObservableArray {
+export function isArray(val: unknown): val is any[] | IObservableArray {
   return Array.isArray(val) || isObservableArray(val)
 }
 


### PR DESCRIPTION
I think it's better style to type the type guard argument with `unknown` instead of `any`. This requires replacing bracket notation accessor syntax for checking the presence of some symbol on an object by the `in` operator to satisfy TypeScript. I think this change is correct, but please double-check.