### PR TITLE
improve CI matrix job name format

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -36,7 +36,7 @@ jobs:
       - run: yarn lib:build && yarn lib:build-docs && yarn site:build
 
   lib-test:
-    name: lib-test (${{ matrix.compiler }} - MobX v${{ matrix.mobx-version }})
+    name: lib-test (${{ matrix.compiler }} - mobx${{ matrix.mobx-version }})
     runs-on: ubuntu-latest
 
     strategy:


### PR DESCRIPTION
Just a tiny cosmetic change to the CI job name format that I had actually introduced myself. I think, e.g., `babel - mobx6` looks more consistent than `babel - MobX v6`.