### PR TITLE
use "in" operator instead of comparing with "undefined"

### DIFF
--- a/packages/lib/src/action/isModelAction.ts
+++ b/packages/lib/src/action/isModelAction.ts
@@ -10,5 +10,5 @@ export const modelActionSymbol = Symbol("modelAction")
  * @returns
  */
 export function isModelAction(fn: (...args: any[]) => any): boolean {
-  return typeof fn === "function" && !!(fn as any)[modelActionSymbol]
+  return typeof fn === "function" && modelActionSymbol in fn
 }

--- a/packages/lib/src/modelShared/Model.ts
+++ b/packages/lib/src/modelShared/Model.ts
@@ -48,7 +48,7 @@ function createModelPropDescriptor(
       // hack to only permit setting these values once fully constructed
       // this is to ignore abstract properties being set by babel
       // see https://github.com/xaviergonz/mobx-keystone/issues/18
-      if (!(this as any)[modelInitializedSymbol]) {
+      if (!(modelInitializedSymbol in this)) {
         return
       }
       setModelInstanceDataField(this, modelProp, modelPropName, v)

--- a/packages/lib/src/modelShared/modelDecorator.ts
+++ b/packages/lib/src/modelShared/modelDecorator.ts
@@ -54,7 +54,7 @@ const internalModel =
       }
     }
 
-    if ((clazz as any)[modelUnwrappedClassSymbol]) {
+    if (modelUnwrappedClassSymbol in clazz) {
       throw failure("a class already decorated with `@model` cannot be re-decorated")
     }
 

--- a/packages/lib/src/snapshot/applySnapshot.ts
+++ b/packages/lib/src/snapshot/applySnapshot.ts
@@ -73,7 +73,7 @@ export function internalApplySnapshot<T extends object>(
   }
 
   // adapt snapshot to target model if possible
-  if (isPlainObject(sn) && (sn as any)[modelTypeKey] === undefined && isModel(obj)) {
+  if (isPlainObject(sn) && !(modelTypeKey in sn) && isModel(obj)) {
     const modelInfo = modelInfoByClass.get((obj as any).constructor)!
     sn = { ...(sn as any), [modelTypeKey]: modelInfo.name }
   }

--- a/packages/lib/src/snapshot/applySnapshot.ts
+++ b/packages/lib/src/snapshot/applySnapshot.ts
@@ -73,7 +73,7 @@ export function internalApplySnapshot<T extends object>(
   }
 
   // adapt snapshot to target model if possible
-  if (isPlainObject(sn) && !(modelTypeKey in sn) && isModel(obj)) {
+  if (isPlainObject(sn) && (sn as any)[modelTypeKey] === undefined && isModel(obj)) {
     const modelInfo = modelInfoByClass.get((obj as any).constructor)!
     sn = { ...sn, [modelTypeKey]: modelInfo.name }
   }

--- a/packages/lib/src/snapshot/fromModelSnapshot.ts
+++ b/packages/lib/src/snapshot/fromModelSnapshot.ts
@@ -23,7 +23,7 @@ function fromModelSnapshot(sn: SnapshotInOfModel<AnyModel>, ctx: FromSnapshotCon
   }
 
   const modelIdPropertyName = getModelIdPropertyName(modelInfo.class as ModelClass<AnyModel>)
-  if (modelIdPropertyName && !(sn as any)[modelIdPropertyName]) {
+  if (modelIdPropertyName && !(modelIdPropertyName in sn)) {
     throw failure(
       `a model snapshot of type '${type}' must contain an id key (${modelIdPropertyName}), but none was found`
     )

--- a/packages/lib/src/snapshot/fromModelSnapshot.ts
+++ b/packages/lib/src/snapshot/fromModelSnapshot.ts
@@ -23,7 +23,7 @@ function fromModelSnapshot(sn: SnapshotInOfModel<AnyModel>, ctx: FromSnapshotCon
   }
 
   const modelIdPropertyName = getModelIdPropertyName(modelInfo.class as ModelClass<AnyModel>)
-  if (modelIdPropertyName && !(modelIdPropertyName in sn)) {
+  if (modelIdPropertyName && (sn as any)[modelIdPropertyName] === undefined) {
     throw failure(
       `a model snapshot of type '${type}' must contain an id key (${modelIdPropertyName}), but none was found`
     )


### PR DESCRIPTION
I think the `in` operator is more readable and it's more type-safe (no `any` assertions).