### PR TITLE
update deps

### DIFF
--- a/packages/site/package.json
+++ b/packages/site/package.json
@@ -10,8 +10,8 @@
     "serve": "docusaurus serve"
   },
   "dependencies": {
-    "@docusaurus/core": "2.0.0-beta.15",
-    "@docusaurus/preset-classic": "2.0.0-beta.15",
+    "@docusaurus/core": "2.0.0-beta.16",
+    "@docusaurus/preset-classic": "2.0.0-beta.16",
     "@easyops-cn/docusaurus-search-local": "^0.21.4",
     "bootstrap-icons": "^1.8.1",
     "mobx": "^6.4.1",
@@ -24,7 +24,7 @@
   },
   "devDependencies": {
     "@babel/plugin-proposal-decorators": "^7.17.2",
-    "@docusaurus/module-type-aliases": "2.0.0-beta.15",
+    "@docusaurus/module-type-aliases": "2.0.0-beta.16",
     "@svgr/webpack": "^6.2.1",
     "@tsconfig/docusaurus": "^1.0.4",
     "@types/react": "^17.0.39",

--- a/yarn.lock
+++ b/yarn.lock
@@ -5,31 +5,31 @@ __metadata:
   version: 5
   cacheKey: 8
 
-"@algolia/autocomplete-core@npm:1.2.2":
-  version: 1.2.2
-  resolution: "@algolia/autocomplete-core@npm:1.2.2"
+"@algolia/autocomplete-core@npm:1.5.2":
+  version: 1.5.2
+  resolution: "@algolia/autocomplete-core@npm:1.5.2"
   dependencies:
-    "@algolia/autocomplete-shared": 1.2.2
-  checksum: 1998e272109f4da40c104de50e7e63b2859d053908f049cd8779285a95bedc1f3266f40e2f784c4e8022981f83b523aa2c65ae7d190e06ce6c02823e08998fc3
+    "@algolia/autocomplete-shared": 1.5.2
+  checksum: a8ab49c689c7fe7782980af167dfd9bea0feb9fe9809d003da509096550852f48abff27b59e0bc9909a455fb998ff4b8a7ce45b7dd42cef42f675c81340a47e9
   languageName: node
   linkType: hard
 
-"@algolia/autocomplete-preset-algolia@npm:1.2.2":
-  version: 1.2.2
-  resolution: "@algolia/autocomplete-preset-algolia@npm:1.2.2"
+"@algolia/autocomplete-preset-algolia@npm:1.5.2":
+  version: 1.5.2
+  resolution: "@algolia/autocomplete-preset-algolia@npm:1.5.2"
   dependencies:
-    "@algolia/autocomplete-shared": 1.2.2
+    "@algolia/autocomplete-shared": 1.5.2
   peerDependencies:
     "@algolia/client-search": ^4.9.1
     algoliasearch: ^4.9.1
-  checksum: 7fc74c4783c1081cd06da0e442f46a8588b6e1983aca2d3560beded9e4bda71c1c9a9750669c9c560e8d7f9a55c9d1c091ec1b734708cb3e25cdb08de6f9d07e
+  checksum: 56da97955467414b381cd93cb2d693aeda5f908e7c2b13afeda10c5919abb994cf75db7d9d08eb327d8e7475f018ad13da53a76733ed6094723f6f11fee01dc3
   languageName: node
   linkType: hard
 
-"@algolia/autocomplete-shared@npm:1.2.2":
-  version: 1.2.2
-  resolution: "@algolia/autocomplete-shared@npm:1.2.2"
-  checksum: fdb6f60b7155f6f2cf9d9e4b78a003c4b34274a0483c7ac53b742b029656a098617dee35595cbaa60470e7f55401b76280252ea8f8c3b3e8eafbc5462f3d7398
+"@algolia/autocomplete-shared@npm:1.5.2":
+  version: 1.5.2
+  resolution: "@algolia/autocomplete-shared@npm:1.5.2"
+  checksum: 35d60ea6c38d0cae79e431460e3014da5a71408061fafa9bb5882e91de26dd923c18b5ed905fbea87639875f1d0c0857057a27eac6e786856646b8553a2aa61f
   languageName: node
   linkType: hard
 
@@ -42,10 +42,26 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@algolia/cache-browser-local-storage@npm:4.12.1":
+  version: 4.12.1
+  resolution: "@algolia/cache-browser-local-storage@npm:4.12.1"
+  dependencies:
+    "@algolia/cache-common": 4.12.1
+  checksum: 5710f1c0b7c9ea02bcaed400e4acf3695ef5a224fba6e520c13d7ecc39f64281cf4cb69e44ccfecea5f64b054822cab7c7dec85e9efad4e49b6d64cf4b8aed0e
+  languageName: node
+  linkType: hard
+
 "@algolia/cache-common@npm:4.11.0":
   version: 4.11.0
   resolution: "@algolia/cache-common@npm:4.11.0"
   checksum: d69a0f4e1b3baeebd0cea77568ac4911f2053536be14ca7676e8c4b9d4022f9122f78ba2f24405e308af45eff8a9a1e1c17b53079bfddc5131dd94f4d6bd3064
+  languageName: node
+  linkType: hard
+
+"@algolia/cache-common@npm:4.12.1":
+  version: 4.12.1
+  resolution: "@algolia/cache-common@npm:4.12.1"
+  checksum: ff6435e08c6d5091b3869313e0dde2671f85949127dfbb10015d06ae48c0d4e4441692ac2e2cd0a5ca734a5338c81fb3edddc92da0729393177846514be0c590
   languageName: node
   linkType: hard
 
@@ -58,6 +74,15 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@algolia/cache-in-memory@npm:4.12.1":
+  version: 4.12.1
+  resolution: "@algolia/cache-in-memory@npm:4.12.1"
+  dependencies:
+    "@algolia/cache-common": 4.12.1
+  checksum: b9aee16ffbf7e6f72d917a7b5d8c4e62b3457cffd689489a71a1c171bc324f2b82346bc4cf7fe5720fc51c681991d864f5f17e0dc3d31cb9d3cbc47d1e6f622f
+  languageName: node
+  linkType: hard
+
 "@algolia/client-account@npm:4.11.0":
   version: 4.11.0
   resolution: "@algolia/client-account@npm:4.11.0"
@@ -66,6 +91,17 @@ __metadata:
     "@algolia/client-search": 4.11.0
     "@algolia/transporter": 4.11.0
   checksum: a35833bfedaf3d3588588c635167c6c1293b91597940d4ef897ca83203da3b9bf33990165b4bf486f663356799277076a5f31364e97397e93c666898a0985842
+  languageName: node
+  linkType: hard
+
+"@algolia/client-account@npm:4.12.1":
+  version: 4.12.1
+  resolution: "@algolia/client-account@npm:4.12.1"
+  dependencies:
+    "@algolia/client-common": 4.12.1
+    "@algolia/client-search": 4.12.1
+    "@algolia/transporter": 4.12.1
+  checksum: 4986045591e802ddd19a03e53a7ce3bdfdf7ac92da8f875641d0732158a776d2abaab7bf04b6713f8e9cb00d02a2e279ec45c68e4272cb919a62cbb81380198c
   languageName: node
   linkType: hard
 
@@ -81,6 +117,18 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@algolia/client-analytics@npm:4.12.1":
+  version: 4.12.1
+  resolution: "@algolia/client-analytics@npm:4.12.1"
+  dependencies:
+    "@algolia/client-common": 4.12.1
+    "@algolia/client-search": 4.12.1
+    "@algolia/requester-common": 4.12.1
+    "@algolia/transporter": 4.12.1
+  checksum: 6a96d42b4b2a7378e9d010f583776ba443ca1da0f901120cf2ac516a146f82ba35ae31f36503f5baef8b08e7b4aaddbf9aa2a434041ee64ee102765ff1a1da2b
+  languageName: node
+  linkType: hard
+
 "@algolia/client-common@npm:4.11.0":
   version: 4.11.0
   resolution: "@algolia/client-common@npm:4.11.0"
@@ -88,6 +136,16 @@ __metadata:
     "@algolia/requester-common": 4.11.0
     "@algolia/transporter": 4.11.0
   checksum: 791fda2cc2c8d86012b72c5e1d22bdd7a89f37a497f176e875105b55297112ac41f735e53b1980aac35b13d908b791d4de7c017a5b74e73358c46b9f728f03b3
+  languageName: node
+  linkType: hard
+
+"@algolia/client-common@npm:4.12.1":
+  version: 4.12.1
+  resolution: "@algolia/client-common@npm:4.12.1"
+  dependencies:
+    "@algolia/requester-common": 4.12.1
+    "@algolia/transporter": 4.12.1
+  checksum: 17b0f80cc6e8af55277be7aeb735271804bee478bc7633500d48b21bbda739c04b97554a50996a7dd57f9c2f768a4f956fdd79c2de4dbcfefd58debebedd1cc7
   languageName: node
   linkType: hard
 
@@ -102,6 +160,17 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@algolia/client-personalization@npm:4.12.1":
+  version: 4.12.1
+  resolution: "@algolia/client-personalization@npm:4.12.1"
+  dependencies:
+    "@algolia/client-common": 4.12.1
+    "@algolia/requester-common": 4.12.1
+    "@algolia/transporter": 4.12.1
+  checksum: 9c4b2eb871d9faf6d1d9ecc8ca7ba8351404c36627ebfc808bc1915249414fe48aa79807f3c983f773807f6d75318f74e00c697a68fab287d6bee14e321d839d
+  languageName: node
+  linkType: hard
+
 "@algolia/client-search@npm:4.11.0":
   version: 4.11.0
   resolution: "@algolia/client-search@npm:4.11.0"
@@ -113,10 +182,35 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@algolia/client-search@npm:4.12.1":
+  version: 4.12.1
+  resolution: "@algolia/client-search@npm:4.12.1"
+  dependencies:
+    "@algolia/client-common": 4.12.1
+    "@algolia/requester-common": 4.12.1
+    "@algolia/transporter": 4.12.1
+  checksum: ee05278a54f8f991ea6c9ebd7ec65cb4b2fb5c37216bdc76502e0aad898167ea839a7a7ffe6d0d3c3e45dfe41ff238dfd7c6963e89c20f6b4ec326d6176c1249
+  languageName: node
+  linkType: hard
+
+"@algolia/events@npm:^4.0.1":
+  version: 4.0.1
+  resolution: "@algolia/events@npm:4.0.1"
+  checksum: 4f63943f4554cfcfed91d8b8c009a49dca192b81056d8c75e532796f64828cd69899852013e81ff3fff07030df8782b9b95c19a3da0845786bdfe22af42442c2
+  languageName: node
+  linkType: hard
+
 "@algolia/logger-common@npm:4.11.0":
   version: 4.11.0
   resolution: "@algolia/logger-common@npm:4.11.0"
   checksum: 1b081abbf80e36bb4e43e4b30a09e31443a1b79f71096226a647f5fa2e653876f0f4215951435c7151a63b6a0537e69cfc158f573583128b2bbf148452055f8e
+  languageName: node
+  linkType: hard
+
+"@algolia/logger-common@npm:4.12.1":
+  version: 4.12.1
+  resolution: "@algolia/logger-common@npm:4.12.1"
+  checksum: 4b7d4859a45414b011fe6f8f334526cca02c9ed18e6ab089b8621847895b3549dffb79a3e9ee86d3aaf3d67123f3c543f08dd94fa86bade276055616f7bca501
   languageName: node
   linkType: hard
 
@@ -129,6 +223,15 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@algolia/logger-console@npm:4.12.1":
+  version: 4.12.1
+  resolution: "@algolia/logger-console@npm:4.12.1"
+  dependencies:
+    "@algolia/logger-common": 4.12.1
+  checksum: d4c92851678f31667f684d31a11a85c1d3681d5f94800257a8f375b5968d365b9a56094f7dfce391f698ce23eb03fde9bb73e80a110b09449430043ab7431e5b
+  languageName: node
+  linkType: hard
+
 "@algolia/requester-browser-xhr@npm:4.11.0":
   version: 4.11.0
   resolution: "@algolia/requester-browser-xhr@npm:4.11.0"
@@ -138,10 +241,26 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@algolia/requester-browser-xhr@npm:4.12.1":
+  version: 4.12.1
+  resolution: "@algolia/requester-browser-xhr@npm:4.12.1"
+  dependencies:
+    "@algolia/requester-common": 4.12.1
+  checksum: c31687ccf5acf6cd59a14cde94cd5d9cf5ff9d7efe2876a37e31a87363781778e44bad96ac33bbc942039ea3460018e99aa82045d342a953434c4e1eea59bf45
+  languageName: node
+  linkType: hard
+
 "@algolia/requester-common@npm:4.11.0":
   version: 4.11.0
   resolution: "@algolia/requester-common@npm:4.11.0"
   checksum: d503d488c582cc126cb35076a28671aba7fcb8658f5a69995f1fd2f22bb4cc1b63de6e255791306c142877503830ab17fd7cacde6e9430c8b0b1da2e5f32ed38
+  languageName: node
+  linkType: hard
+
+"@algolia/requester-common@npm:4.12.1":
+  version: 4.12.1
+  resolution: "@algolia/requester-common@npm:4.12.1"
+  checksum: 3a05fbc5ab1fcb59a78f485093ddbdd9ec96edad30c1d62e90f7e5d90a1af5339803faf3f3585c15994f4fdea0f59be73af574a02af46245385efda93e514956
   languageName: node
   linkType: hard
 
@@ -154,6 +273,15 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@algolia/requester-node-http@npm:4.12.1":
+  version: 4.12.1
+  resolution: "@algolia/requester-node-http@npm:4.12.1"
+  dependencies:
+    "@algolia/requester-common": 4.12.1
+  checksum: 10dbb85acf6ca856d96c3e88fef2848f5573a275ac21d3519c1f2bfc4fa359cc57160f9337e2cdb425aca960f690f22a1ef0d79d44c0ac854a327819b32d2836
+  languageName: node
+  linkType: hard
+
 "@algolia/transporter@npm:4.11.0":
   version: 4.11.0
   resolution: "@algolia/transporter@npm:4.11.0"
@@ -162,6 +290,17 @@ __metadata:
     "@algolia/logger-common": 4.11.0
     "@algolia/requester-common": 4.11.0
   checksum: 650eee6c5ac7792baf7b10b63afd006ca51e62b6827a0b09b5b45d2b7af9dcf5d68dd9cdb2ffec25febe3a9e5549df0460a32f775b8efa24162b01df2b16e884
+  languageName: node
+  linkType: hard
+
+"@algolia/transporter@npm:4.12.1":
+  version: 4.12.1
+  resolution: "@algolia/transporter@npm:4.12.1"
+  dependencies:
+    "@algolia/cache-common": 4.12.1
+    "@algolia/logger-common": 4.12.1
+    "@algolia/requester-common": 4.12.1
+  checksum: 1d9c82d4ce43167923b0f97c3d7de251c2015a6c2f698cd050abedb4b2639cebe987dae83a6add0d8712621ca2eac004f7ee2daf7a471b5a37dd58ee30a329ae
   languageName: node
   linkType: hard
 
@@ -251,7 +390,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@babel/generator@npm:^7.12.5, @babel/generator@npm:^7.16.0, @babel/generator@npm:^7.17.3, @babel/generator@npm:^7.7.2":
+"@babel/generator@npm:^7.12.5, @babel/generator@npm:^7.17.3, @babel/generator@npm:^7.7.2":
   version: 7.17.3
   resolution: "@babel/generator@npm:7.17.3"
   dependencies:
@@ -554,7 +693,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@babel/parser@npm:^7.0.0, @babel/parser@npm:^7.1.0, @babel/parser@npm:^7.12.7, @babel/parser@npm:^7.14.7, @babel/parser@npm:^7.16.4, @babel/parser@npm:^7.16.7, @babel/parser@npm:^7.17.3":
+"@babel/parser@npm:^7.0.0, @babel/parser@npm:^7.1.0, @babel/parser@npm:^7.12.7, @babel/parser@npm:^7.14.7, @babel/parser@npm:^7.16.7, @babel/parser@npm:^7.17.3":
   version: 7.17.3
   resolution: "@babel/parser@npm:7.17.3"
   bin:
@@ -932,6 +1071,17 @@ __metadata:
   peerDependencies:
     "@babel/core": ^7.0.0-0
   checksum: 34afe4030c249ed5a559c7d164b317a6209f3fca2db7dee7ecb8413af84167381d82f23517bf8e41d359da07da9b0fd2c0472e81c4389e5cc9d1997a308d49de
+  languageName: node
+  linkType: hard
+
+"@babel/plugin-syntax-jsx@npm:^7.16.7":
+  version: 7.16.7
+  resolution: "@babel/plugin-syntax-jsx@npm:7.16.7"
+  dependencies:
+    "@babel/helper-plugin-utils": ^7.16.7
+  peerDependencies:
+    "@babel/core": ^7.0.0-0
+  checksum: cd9b0e53c50e8ddb0afaf0f42e0b221a94e4f59aee32a591364266a31195c48cac5fef288d02c1c935686bda982d2e0f1ed61cceb995fc9f6fb09ef5ebecdd2b
   languageName: node
   linkType: hard
 
@@ -1345,6 +1495,17 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@babel/plugin-transform-react-display-name@npm:^7.16.7":
+  version: 7.16.7
+  resolution: "@babel/plugin-transform-react-display-name@npm:7.16.7"
+  dependencies:
+    "@babel/helper-plugin-utils": ^7.16.7
+  peerDependencies:
+    "@babel/core": ^7.0.0-0
+  checksum: 483154413671ab0a25ae37520b7cf5bfab0958c484a3707c6799b1f1436d1e51481bcc03fbfcdbf90bf6b46818d931ae35e515141d8354c3287351b4467376ba
+  languageName: node
+  linkType: hard
+
 "@babel/plugin-transform-react-jsx-development@npm:^7.16.0":
   version: 7.16.0
   resolution: "@babel/plugin-transform-react-jsx-development@npm:7.16.0"
@@ -1353,6 +1514,17 @@ __metadata:
   peerDependencies:
     "@babel/core": ^7.0.0-0
   checksum: 2724db0d24779107a6e019f4be17e894e26dc23e33f797b3cd750afc0db33d477db27d6aafb63eb459e3514fdd9f408b9487c7db3d7c6858129382e9c26352dc
+  languageName: node
+  linkType: hard
+
+"@babel/plugin-transform-react-jsx-development@npm:^7.16.7":
+  version: 7.16.7
+  resolution: "@babel/plugin-transform-react-jsx-development@npm:7.16.7"
+  dependencies:
+    "@babel/plugin-transform-react-jsx": ^7.16.7
+  peerDependencies:
+    "@babel/core": ^7.0.0-0
+  checksum: 697c71cb0ac9647a9b8c6f1aca99767cf06197f6c0b5d1f2e0c01f641e0706a380779f06836fdb941d3aa171f868091270fbe9fcfbfbcc2a24df5e60e04545e8
   languageName: node
   linkType: hard
 
@@ -1371,6 +1543,21 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@babel/plugin-transform-react-jsx@npm:^7.16.7":
+  version: 7.17.3
+  resolution: "@babel/plugin-transform-react-jsx@npm:7.17.3"
+  dependencies:
+    "@babel/helper-annotate-as-pure": ^7.16.7
+    "@babel/helper-module-imports": ^7.16.7
+    "@babel/helper-plugin-utils": ^7.16.7
+    "@babel/plugin-syntax-jsx": ^7.16.7
+    "@babel/types": ^7.17.0
+  peerDependencies:
+    "@babel/core": ^7.0.0-0
+  checksum: 7e33a3fb78a3b7352b56f48211160ae60dc3654bae314ea0352bfc179d10eaac789792ccb3701172388ec4e4dbdb94952cdf3386980f3af402d99ceadd91149b
+  languageName: node
+  linkType: hard
+
 "@babel/plugin-transform-react-pure-annotations@npm:^7.16.0":
   version: 7.16.0
   resolution: "@babel/plugin-transform-react-pure-annotations@npm:7.16.0"
@@ -1380,6 +1567,18 @@ __metadata:
   peerDependencies:
     "@babel/core": ^7.0.0-0
   checksum: b06c0f5efd7bc6118d43ad1e3a8cb94ebe01b19cff6fbeab0941801d1013b7bc372d2db9742b1ed746a89828a955f8dab9eb460d21fc3af352038de4cb0c6184
+  languageName: node
+  linkType: hard
+
+"@babel/plugin-transform-react-pure-annotations@npm:^7.16.7":
+  version: 7.16.7
+  resolution: "@babel/plugin-transform-react-pure-annotations@npm:7.16.7"
+  dependencies:
+    "@babel/helper-annotate-as-pure": ^7.16.7
+    "@babel/helper-plugin-utils": ^7.16.7
+  peerDependencies:
+    "@babel/core": ^7.0.0-0
+  checksum: 715fe9c5fd10c5605a6de1d4436d29087878924758969427ba4d0b2bc274a436d3ac8f2777b744c988bdbb90f7e68dc2a82491db333ae7e0079fab776b543fae
   languageName: node
   linkType: hard
 
@@ -1405,7 +1604,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@babel/plugin-transform-runtime@npm:^7.16.0, @babel/plugin-transform-runtime@npm:^7.16.4":
+"@babel/plugin-transform-runtime@npm:^7.16.4":
   version: 7.16.5
   resolution: "@babel/plugin-transform-runtime@npm:7.16.5"
   dependencies:
@@ -1418,6 +1617,22 @@ __metadata:
   peerDependencies:
     "@babel/core": ^7.0.0-0
   checksum: f46443fd79d29120e97a3494633eb857990c7222c6bde91c4940f835f5e2a19df3cae3660884bbc4138719b66fbd203b26f68b761062cefabfd68700734164cc
+  languageName: node
+  linkType: hard
+
+"@babel/plugin-transform-runtime@npm:^7.17.0":
+  version: 7.17.0
+  resolution: "@babel/plugin-transform-runtime@npm:7.17.0"
+  dependencies:
+    "@babel/helper-module-imports": ^7.16.7
+    "@babel/helper-plugin-utils": ^7.16.7
+    babel-plugin-polyfill-corejs2: ^0.3.0
+    babel-plugin-polyfill-corejs3: ^0.5.0
+    babel-plugin-polyfill-regenerator: ^0.3.0
+    semver: ^6.3.0
+  peerDependencies:
+    "@babel/core": ^7.0.0-0
+  checksum: 9a469d4389cb265d50f1e83e6b524ceda7abd24a0bd7cda57e54a1e6103ca7c36efc99eebd485cf0a468f048739e21d940126df40b11db34f4692bdd2d5beacd
   languageName: node
   linkType: hard
 
@@ -1628,6 +1843,22 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@babel/preset-react@npm:^7.16.7":
+  version: 7.16.7
+  resolution: "@babel/preset-react@npm:7.16.7"
+  dependencies:
+    "@babel/helper-plugin-utils": ^7.16.7
+    "@babel/helper-validator-option": ^7.16.7
+    "@babel/plugin-transform-react-display-name": ^7.16.7
+    "@babel/plugin-transform-react-jsx": ^7.16.7
+    "@babel/plugin-transform-react-jsx-development": ^7.16.7
+    "@babel/plugin-transform-react-pure-annotations": ^7.16.7
+  peerDependencies:
+    "@babel/core": ^7.0.0-0
+  checksum: d0a052a418891ab6a02df9c75f0202964ad3b936c20bc44c81bcf3f02c057383f2fa329e0cc79baaac1b4e5e5c8924d3df93a2dd9319efe8042e3b33849978b3
+  languageName: node
+  linkType: hard
+
 "@babel/preset-typescript@npm:^7.15.0, @babel/preset-typescript@npm:^7.16.0, @babel/preset-typescript@npm:^7.16.7":
   version: 7.16.7
   resolution: "@babel/preset-typescript@npm:7.16.7"
@@ -1641,7 +1872,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@babel/runtime-corejs3@npm:^7.10.2, @babel/runtime-corejs3@npm:^7.16.3":
+"@babel/runtime-corejs3@npm:^7.10.2":
   version: 7.16.3
   resolution: "@babel/runtime-corejs3@npm:7.16.3"
   dependencies:
@@ -1651,12 +1882,31 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@babel/runtime-corejs3@npm:^7.17.2":
+  version: 7.17.2
+  resolution: "@babel/runtime-corejs3@npm:7.17.2"
+  dependencies:
+    core-js-pure: ^3.20.2
+    regenerator-runtime: ^0.13.4
+  checksum: fc7ba261913c66347434051c74b00f320fb5fda7c72f4a4378045b39e31a39420bba2b2cf3fd59367834b43689215b12cb0587a599c95e9619562e1ebec071a7
+  languageName: node
+  linkType: hard
+
 "@babel/runtime@npm:^7.1.2, @babel/runtime@npm:^7.10.2, @babel/runtime@npm:^7.10.3, @babel/runtime@npm:^7.12.1, @babel/runtime@npm:^7.12.13, @babel/runtime@npm:^7.12.5, @babel/runtime@npm:^7.16.3, @babel/runtime@npm:^7.8.4":
   version: 7.16.5
   resolution: "@babel/runtime@npm:7.16.5"
   dependencies:
     regenerator-runtime: ^0.13.4
   checksum: b96e67280efe581c6147b4fe984dfe08a8fbea048934a092f3cbf4dcf61725f6b221cb0c879b6e6e98671f83a104c9e8cfbd24c683e5ebcc886a731aa8984ad0
+  languageName: node
+  linkType: hard
+
+"@babel/runtime@npm:^7.17.2":
+  version: 7.17.2
+  resolution: "@babel/runtime@npm:7.17.2"
+  dependencies:
+    regenerator-runtime: ^0.13.4
+  checksum: a48702d271ecc59c09c397856407afa29ff980ab537b3da58eeee1aeaa0f545402d340a1680c9af58aec94dfdcbccfb6abb211991b74686a86d03d3f6956cacd
   languageName: node
   linkType: hard
 
@@ -1671,7 +1921,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@babel/traverse@npm:^7.12.9, @babel/traverse@npm:^7.13.0, @babel/traverse@npm:^7.16.3, @babel/traverse@npm:^7.16.7, @babel/traverse@npm:^7.16.8, @babel/traverse@npm:^7.17.0, @babel/traverse@npm:^7.17.3, @babel/traverse@npm:^7.7.2":
+"@babel/traverse@npm:^7.12.9, @babel/traverse@npm:^7.13.0, @babel/traverse@npm:^7.16.7, @babel/traverse@npm:^7.16.8, @babel/traverse@npm:^7.17.0, @babel/traverse@npm:^7.17.3, @babel/traverse@npm:^7.7.2":
   version: 7.17.3
   resolution: "@babel/traverse@npm:7.17.3"
   dependencies:
@@ -1793,84 +2043,86 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@docsearch/css@npm:3.0.0-alpha.41":
-  version: 3.0.0-alpha.41
-  resolution: "@docsearch/css@npm:3.0.0-alpha.41"
-  checksum: 47454c3400612ab6a8789a3c0445a3260cd22445e8c842652e81e6c0c01e475fcb6c1686ba505e2f7b73993099019a3686cb250d5004fccde730c15c548c89e1
+"@docsearch/css@npm:3.0.0":
+  version: 3.0.0
+  resolution: "@docsearch/css@npm:3.0.0"
+  checksum: 1a02fb808369908f9ae0174cd18fd152fa1cbebe5725d197fd52588696794ecfd384c504c09be55926cc2b36360173216365b46aae72769d581496d0418a0f16
   languageName: node
   linkType: hard
 
-"@docsearch/react@npm:^3.0.0-alpha.39":
-  version: 3.0.0-alpha.41
-  resolution: "@docsearch/react@npm:3.0.0-alpha.41"
+"@docsearch/react@npm:^3.0.0":
+  version: 3.0.0
+  resolution: "@docsearch/react@npm:3.0.0"
   dependencies:
-    "@algolia/autocomplete-core": 1.2.2
-    "@algolia/autocomplete-preset-algolia": 1.2.2
-    "@docsearch/css": 3.0.0-alpha.41
+    "@algolia/autocomplete-core": 1.5.2
+    "@algolia/autocomplete-preset-algolia": 1.5.2
+    "@docsearch/css": 3.0.0
     algoliasearch: ^4.0.0
   peerDependencies:
     "@types/react": ">= 16.8.0 < 18.0.0"
     react: ">= 16.8.0 < 18.0.0"
     react-dom: ">= 16.8.0 < 18.0.0"
-  checksum: 1ddd04f2b12e386ce6f71010e7fe2bc5414b916fdec195994baa0d5f0b7a8e2f631883ecc0672e80237cdc4951e6b87ff050e4a9caeb2368bc1dc7d82bdc4096
+  checksum: 965ce14e4df8b63d32235d79a35241c40cbaa2e87f6513bf86d79467cb3940b8ba1111ec0a37c5e9f5a27d10b2d7f6a2b1e73910320091dbf3331dac9be8c52e
   languageName: node
   linkType: hard
 
-"@docusaurus/core@npm:2.0.0-beta.15":
-  version: 2.0.0-beta.15
-  resolution: "@docusaurus/core@npm:2.0.0-beta.15"
+"@docusaurus/core@npm:2.0.0-beta.16":
+  version: 2.0.0-beta.16
+  resolution: "@docusaurus/core@npm:2.0.0-beta.16"
   dependencies:
-    "@babel/core": ^7.16.0
-    "@babel/generator": ^7.16.0
+    "@babel/core": ^7.17.5
+    "@babel/generator": ^7.17.3
     "@babel/plugin-syntax-dynamic-import": ^7.8.3
-    "@babel/plugin-transform-runtime": ^7.16.0
-    "@babel/preset-env": ^7.16.4
-    "@babel/preset-react": ^7.16.0
-    "@babel/preset-typescript": ^7.16.0
-    "@babel/runtime": ^7.16.3
-    "@babel/runtime-corejs3": ^7.16.3
-    "@babel/traverse": ^7.16.3
-    "@docusaurus/cssnano-preset": 2.0.0-beta.15
-    "@docusaurus/logger": 2.0.0-beta.15
-    "@docusaurus/mdx-loader": 2.0.0-beta.15
+    "@babel/plugin-transform-runtime": ^7.17.0
+    "@babel/preset-env": ^7.16.11
+    "@babel/preset-react": ^7.16.7
+    "@babel/preset-typescript": ^7.16.7
+    "@babel/runtime": ^7.17.2
+    "@babel/runtime-corejs3": ^7.17.2
+    "@babel/traverse": ^7.17.3
+    "@docusaurus/cssnano-preset": 2.0.0-beta.16
+    "@docusaurus/logger": 2.0.0-beta.16
+    "@docusaurus/mdx-loader": 2.0.0-beta.16
     "@docusaurus/react-loadable": 5.5.2
-    "@docusaurus/utils": 2.0.0-beta.15
-    "@docusaurus/utils-common": 2.0.0-beta.15
-    "@docusaurus/utils-validation": 2.0.0-beta.15
-    "@slorber/static-site-generator-webpack-plugin": ^4.0.0
-    "@svgr/webpack": ^6.0.0
-    autoprefixer: ^10.3.5
-    babel-loader: ^8.2.2
+    "@docusaurus/utils": 2.0.0-beta.16
+    "@docusaurus/utils-common": 2.0.0-beta.16
+    "@docusaurus/utils-validation": 2.0.0-beta.16
+    "@slorber/static-site-generator-webpack-plugin": ^4.0.1
+    "@svgr/webpack": ^6.2.1
+    autoprefixer: ^10.4.2
+    babel-loader: ^8.2.3
     babel-plugin-dynamic-import-node: 2.3.0
-    boxen: ^5.0.1
-    chokidar: ^3.5.2
-    clean-css: ^5.1.5
+    boxen: ^6.2.1
+    chokidar: ^3.5.3
+    clean-css: ^5.2.4
+    cli-table3: ^0.6.1
+    combine-promises: ^1.1.0
     commander: ^5.1.0
-    copy-webpack-plugin: ^10.2.0
-    core-js: ^3.18.0
-    css-loader: ^6.5.1
-    css-minimizer-webpack-plugin: ^3.3.1
-    cssnano: ^5.0.8
+    copy-webpack-plugin: ^10.2.4
+    core-js: ^3.21.1
+    css-loader: ^6.6.0
+    css-minimizer-webpack-plugin: ^3.4.1
+    cssnano: ^5.0.17
     del: ^6.0.0
     detect-port: ^1.3.0
     escape-html: ^1.0.3
     eta: ^1.12.3
     file-loader: ^6.2.0
-    fs-extra: ^10.0.0
-    html-minifier-terser: ^6.0.2
+    fs-extra: ^10.0.1
+    html-minifier-terser: ^6.1.0
     html-tags: ^3.1.0
-    html-webpack-plugin: ^5.4.0
+    html-webpack-plugin: ^5.5.0
     import-fresh: ^3.3.0
     is-root: ^2.1.0
     leven: ^3.1.0
-    lodash: ^4.17.20
-    mini-css-extract-plugin: ^1.6.0
+    lodash: ^4.17.21
+    mini-css-extract-plugin: ^2.5.3
     nprogress: ^0.2.0
-    postcss: ^8.3.7
-    postcss-loader: ^6.1.1
-    prompts: ^2.4.1
+    postcss: ^8.4.6
+    postcss-loader: ^6.2.1
+    prompts: ^2.4.2
     react-dev-utils: ^12.0.0
-    react-helmet: ^6.1.0
+    react-helmet-async: ^1.2.3
     react-loadable: "npm:@docusaurus/react-loadable@5.5.2"
     react-loadable-ssr-addon-v5-slorber: ^1.0.1
     react-router: ^5.2.0
@@ -1880,60 +2132,59 @@ __metadata:
     rtl-detect: ^1.0.4
     semver: ^7.3.4
     serve-handler: ^6.1.3
-    shelljs: ^0.8.4
-    strip-ansi: ^6.0.0
-    terser-webpack-plugin: ^5.2.4
+    shelljs: ^0.8.5
+    terser-webpack-plugin: ^5.3.1
     tslib: ^2.3.1
     update-notifier: ^5.1.0
     url-loader: ^4.1.1
-    wait-on: ^6.0.0
-    webpack: ^5.61.0
-    webpack-bundle-analyzer: ^4.4.2
-    webpack-dev-server: ^4.7.1
+    wait-on: ^6.0.1
+    webpack: ^5.69.1
+    webpack-bundle-analyzer: ^4.5.0
+    webpack-dev-server: ^4.7.4
     webpack-merge: ^5.8.0
     webpackbar: ^5.0.2
   peerDependencies:
     react: ^16.8.4 || ^17.0.0
     react-dom: ^16.8.4 || ^17.0.0
   bin:
-    docusaurus: bin/docusaurus.js
-  checksum: 719a71f3567d87ada256a217437fb6bf42e02cef19ce4a5d3ede6f4cd97d310b603c604e29e671448e142601d9d70dfea1030ddddfe7f9540b67f918691cf67f
+    docusaurus: bin/docusaurus.mjs
+  checksum: b9acb49d72ff993ff580482be306d553c0cfc703096382591a9a6d3a4a9433642a987eae2e45922ecea241d24342fc822e5cdf9c316176ca8ca8cf024606ebc1
   languageName: node
   linkType: hard
 
-"@docusaurus/cssnano-preset@npm:2.0.0-beta.15":
-  version: 2.0.0-beta.15
-  resolution: "@docusaurus/cssnano-preset@npm:2.0.0-beta.15"
+"@docusaurus/cssnano-preset@npm:2.0.0-beta.16":
+  version: 2.0.0-beta.16
+  resolution: "@docusaurus/cssnano-preset@npm:2.0.0-beta.16"
   dependencies:
-    cssnano-preset-advanced: ^5.1.4
-    postcss: ^8.3.7
-    postcss-sort-media-queries: ^4.1.0
-  checksum: 3bbfa04220a4d4f2dc4a1d2be304f8840850b2f0491680a0dd86ca9d44c92d0aaac5cc3198fe36e435400753954e62e5e92bc6f2115bf71ca760985d8280bba2
+    cssnano-preset-advanced: ^5.1.12
+    postcss: ^8.4.6
+    postcss-sort-media-queries: ^4.2.1
+  checksum: d9ca54e9e05206b89603835c71bb5263511dd171f8558f280227974a4348ad4d95e0be0d1cd96cda2ab3a123e6950a56ed24b72c17e5a096bff7e5d6f62bbfe3
   languageName: node
   linkType: hard
 
-"@docusaurus/logger@npm:2.0.0-beta.15":
-  version: 2.0.0-beta.15
-  resolution: "@docusaurus/logger@npm:2.0.0-beta.15"
+"@docusaurus/logger@npm:2.0.0-beta.16":
+  version: 2.0.0-beta.16
+  resolution: "@docusaurus/logger@npm:2.0.0-beta.16"
   dependencies:
     chalk: ^4.1.2
     tslib: ^2.3.1
-  checksum: 04beb48cd39c5ef0cd50d2a30dcefc80c75ad91d1cd6fbb00bf7857da02328dde0afd6f64c1338a51d636834a9415906eb0df6426f3f0c451e4203c67c18a08b
+  checksum: 38a4100c752d0a5f4765bb691ca70e61103a00465e2cfba6f59354d47524a0f41bc88cb6e4a034c784340074557d3d3dbcb5be6c8490e029a2c9b4170ff16104
   languageName: node
   linkType: hard
 
-"@docusaurus/mdx-loader@npm:2.0.0-beta.15":
-  version: 2.0.0-beta.15
-  resolution: "@docusaurus/mdx-loader@npm:2.0.0-beta.15"
+"@docusaurus/mdx-loader@npm:2.0.0-beta.16":
+  version: 2.0.0-beta.16
+  resolution: "@docusaurus/mdx-loader@npm:2.0.0-beta.16"
   dependencies:
-    "@babel/parser": ^7.16.4
-    "@babel/traverse": ^7.16.3
-    "@docusaurus/logger": 2.0.0-beta.15
-    "@docusaurus/utils": 2.0.0-beta.15
-    "@mdx-js/mdx": ^1.6.21
+    "@babel/parser": ^7.17.3
+    "@babel/traverse": ^7.17.3
+    "@docusaurus/logger": 2.0.0-beta.16
+    "@docusaurus/utils": 2.0.0-beta.16
+    "@mdx-js/mdx": ^1.6.22
     escape-html: ^1.0.3
     file-loader: ^6.2.0
-    fs-extra: ^10.0.0
+    fs-extra: ^10.0.1
     image-size: ^1.0.1
     mdast-util-to-string: ^2.0.0
     remark-emoji: ^2.1.0
@@ -1941,180 +2192,181 @@ __metadata:
     tslib: ^2.3.1
     unist-util-visit: ^2.0.2
     url-loader: ^4.1.1
-    webpack: ^5.61.0
+    webpack: ^5.69.1
   peerDependencies:
     react: ^16.8.4 || ^17.0.0
     react-dom: ^16.8.4 || ^17.0.0
-  checksum: 6dedecafdeb021f859d2761fc0728499cba94c95631e5bb9b64e8a700f70e3e6a1c724c5715f560fadde90361ff61256d4a0ff7002d37c5209425bfa4b4fea37
+  checksum: 3e9597e4bd5fc7b5cba659a4c30a8a2944cebeb64f8474ed757bbc6521131a55781347799315a92129c40ce2291a86e46360ea7320d7a83a5f7a2ebefc892f5f
   languageName: node
   linkType: hard
 
-"@docusaurus/module-type-aliases@npm:2.0.0-beta.15":
-  version: 2.0.0-beta.15
-  resolution: "@docusaurus/module-type-aliases@npm:2.0.0-beta.15"
+"@docusaurus/module-type-aliases@npm:2.0.0-beta.16":
+  version: 2.0.0-beta.16
+  resolution: "@docusaurus/module-type-aliases@npm:2.0.0-beta.16"
   dependencies:
-    "@docusaurus/types": 2.0.0-beta.15
+    "@docusaurus/types": 2.0.0-beta.16
     "@types/react": "*"
-    "@types/react-helmet": "*"
     "@types/react-router-config": "*"
     "@types/react-router-dom": "*"
-  checksum: dd7d3de46a6886d3e367b31d0107eef7a5ffc54acae557625e6fb937619152ddbabafd774ffa6beb7783e039b09a3b916655393ca1a09d3d8e36a75c12e2c569
+    react-helmet-async: "*"
+  peerDependencies:
+    react: "*"
+    react-dom: "*"
+  checksum: ce7ec1285e372944fee14aa3864148da52ce9a7e3ff55a112a155c83b4adf50fb2dbd21a8d2de8764e69c96f57c1e98ca2e0bf6a761e04f14e222f02f55c09b1
   languageName: node
   linkType: hard
 
-"@docusaurus/plugin-content-blog@npm:2.0.0-beta.15":
-  version: 2.0.0-beta.15
-  resolution: "@docusaurus/plugin-content-blog@npm:2.0.0-beta.15"
+"@docusaurus/plugin-content-blog@npm:2.0.0-beta.16":
+  version: 2.0.0-beta.16
+  resolution: "@docusaurus/plugin-content-blog@npm:2.0.0-beta.16"
   dependencies:
-    "@docusaurus/core": 2.0.0-beta.15
-    "@docusaurus/logger": 2.0.0-beta.15
-    "@docusaurus/mdx-loader": 2.0.0-beta.15
-    "@docusaurus/utils": 2.0.0-beta.15
-    "@docusaurus/utils-common": 2.0.0-beta.15
-    "@docusaurus/utils-validation": 2.0.0-beta.15
+    "@docusaurus/core": 2.0.0-beta.16
+    "@docusaurus/logger": 2.0.0-beta.16
+    "@docusaurus/mdx-loader": 2.0.0-beta.16
+    "@docusaurus/utils": 2.0.0-beta.16
+    "@docusaurus/utils-common": 2.0.0-beta.16
+    "@docusaurus/utils-validation": 2.0.0-beta.16
     cheerio: ^1.0.0-rc.10
     feed: ^4.2.2
-    fs-extra: ^10.0.0
-    lodash: ^4.17.20
+    fs-extra: ^10.0.1
+    lodash: ^4.17.21
     reading-time: ^1.5.0
     remark-admonitions: ^1.2.1
     tslib: ^2.3.1
     utility-types: ^3.10.0
-    webpack: ^5.61.0
+    webpack: ^5.69.1
   peerDependencies:
     react: ^16.8.4 || ^17.0.0
     react-dom: ^16.8.4 || ^17.0.0
-  checksum: 32349a465982ec2f1120f7264ab14d10e365d24a96c8555fd74ff4cedb1b7c52087e89cfd4ee9ca298f2795dfcddc5992d346b345e3fe34c752de15e062f5e4e
+  checksum: 00ee8c2e1335e7dd337eda99fee311548b5c84ee20459218f1a6e8a922c5a105da582934d1a72cb9cc964bea0306ffb057d75481faf2ca1c88371c1b23ee991c
   languageName: node
   linkType: hard
 
-"@docusaurus/plugin-content-docs@npm:2.0.0-beta.15":
-  version: 2.0.0-beta.15
-  resolution: "@docusaurus/plugin-content-docs@npm:2.0.0-beta.15"
+"@docusaurus/plugin-content-docs@npm:2.0.0-beta.16":
+  version: 2.0.0-beta.16
+  resolution: "@docusaurus/plugin-content-docs@npm:2.0.0-beta.16"
   dependencies:
-    "@docusaurus/core": 2.0.0-beta.15
-    "@docusaurus/logger": 2.0.0-beta.15
-    "@docusaurus/mdx-loader": 2.0.0-beta.15
-    "@docusaurus/utils": 2.0.0-beta.15
-    "@docusaurus/utils-validation": 2.0.0-beta.15
+    "@docusaurus/core": 2.0.0-beta.16
+    "@docusaurus/logger": 2.0.0-beta.16
+    "@docusaurus/mdx-loader": 2.0.0-beta.16
+    "@docusaurus/utils": 2.0.0-beta.16
+    "@docusaurus/utils-validation": 2.0.0-beta.16
     combine-promises: ^1.1.0
-    fs-extra: ^10.0.0
-    import-fresh: ^3.2.2
-    js-yaml: ^4.0.0
-    lodash: ^4.17.20
+    fs-extra: ^10.0.1
+    import-fresh: ^3.3.0
+    js-yaml: ^4.1.0
+    lodash: ^4.17.21
     remark-admonitions: ^1.2.1
-    shelljs: ^0.8.4
     tslib: ^2.3.1
     utility-types: ^3.10.0
-    webpack: ^5.61.0
+    webpack: ^5.69.1
   peerDependencies:
     react: ^16.8.4 || ^17.0.0
     react-dom: ^16.8.4 || ^17.0.0
-  checksum: 221c0bef297f7b122a0ef080f681edadc5e945d776a4900bf662d8ba8208a02e1849594d3e2756ffe982ed9e70c97c06706abb4e97f6fae6e11eab3934f2dd53
+  checksum: eb50662600d546ad9f1233ffa674b4a059b542d793f2ccb801d3999bd02f3165a621ed9aa40604da921f3adf1634304a2f5652b54a741fe804ffe39fbc88f546
   languageName: node
   linkType: hard
 
-"@docusaurus/plugin-content-pages@npm:2.0.0-beta.15":
-  version: 2.0.0-beta.15
-  resolution: "@docusaurus/plugin-content-pages@npm:2.0.0-beta.15"
+"@docusaurus/plugin-content-pages@npm:2.0.0-beta.16":
+  version: 2.0.0-beta.16
+  resolution: "@docusaurus/plugin-content-pages@npm:2.0.0-beta.16"
   dependencies:
-    "@docusaurus/core": 2.0.0-beta.15
-    "@docusaurus/mdx-loader": 2.0.0-beta.15
-    "@docusaurus/utils": 2.0.0-beta.15
-    "@docusaurus/utils-validation": 2.0.0-beta.15
-    fs-extra: ^10.0.0
-    globby: ^11.0.2
+    "@docusaurus/core": 2.0.0-beta.16
+    "@docusaurus/mdx-loader": 2.0.0-beta.16
+    "@docusaurus/utils": 2.0.0-beta.16
+    "@docusaurus/utils-validation": 2.0.0-beta.16
+    fs-extra: ^10.0.1
     remark-admonitions: ^1.2.1
     tslib: ^2.3.1
-    webpack: ^5.61.0
+    webpack: ^5.69.1
   peerDependencies:
     react: ^16.8.4 || ^17.0.0
     react-dom: ^16.8.4 || ^17.0.0
-  checksum: a93bb81f1c9e9a2665d7c4ff27145db3f6e8a16a32e93885d28d4607ced2bfc74543814b10fd95b09ea4355c4f47c7293fb1358a1da9fa45452bec39fb64f977
+  checksum: 721bb81e2d5f00a07f4f09ce7c2a9baf72f8aaf9600974804ab06996f401b5853782b129268798d9820d238db6bf9ecb8a8809fc26320493aeb75dddbbf41652
   languageName: node
   linkType: hard
 
-"@docusaurus/plugin-debug@npm:2.0.0-beta.15":
-  version: 2.0.0-beta.15
-  resolution: "@docusaurus/plugin-debug@npm:2.0.0-beta.15"
+"@docusaurus/plugin-debug@npm:2.0.0-beta.16":
+  version: 2.0.0-beta.16
+  resolution: "@docusaurus/plugin-debug@npm:2.0.0-beta.16"
   dependencies:
-    "@docusaurus/core": 2.0.0-beta.15
-    "@docusaurus/utils": 2.0.0-beta.15
-    fs-extra: ^10.0.0
+    "@docusaurus/core": 2.0.0-beta.16
+    "@docusaurus/utils": 2.0.0-beta.16
+    fs-extra: ^10.0.1
     react-json-view: ^1.21.3
     tslib: ^2.3.1
   peerDependencies:
     react: ^16.8.4 || ^17.0.0
     react-dom: ^16.8.4 || ^17.0.0
-  checksum: 37148d38bd88dc3396d35fc6312834bee1bc338c774a5e8d1777e5a2684df44435d7b837f044fea17ee5af8c4063bb38f6468f111ee1c86eb14bd989d37442b5
+  checksum: f4ef4a4bb5912398369d134e4b8e4c44726d685a9fe61664f7f204fe19272878b51ffb0f94702cb1c2d94b98599ed1f690759a2008b8463e79e50042e059b77c
   languageName: node
   linkType: hard
 
-"@docusaurus/plugin-google-analytics@npm:2.0.0-beta.15":
-  version: 2.0.0-beta.15
-  resolution: "@docusaurus/plugin-google-analytics@npm:2.0.0-beta.15"
+"@docusaurus/plugin-google-analytics@npm:2.0.0-beta.16":
+  version: 2.0.0-beta.16
+  resolution: "@docusaurus/plugin-google-analytics@npm:2.0.0-beta.16"
   dependencies:
-    "@docusaurus/core": 2.0.0-beta.15
-    "@docusaurus/utils-validation": 2.0.0-beta.15
+    "@docusaurus/core": 2.0.0-beta.16
+    "@docusaurus/utils-validation": 2.0.0-beta.16
     tslib: ^2.3.1
   peerDependencies:
     react: ^16.8.4 || ^17.0.0
     react-dom: ^16.8.4 || ^17.0.0
-  checksum: 370a050651b2e96a3d26b0e5cc23593c068c99582942e5c909254b6487230bdcf41c42a0bdf8798db79eed51049423423ee6135437acc006d3f956a4bf2eb2b2
+  checksum: 7f2c7ee6315a50e79ff98a6fd5e71de5e4797b08a2c1bbf0267970331f090786bb4a3805af0e08892970d752b3d9d18b526647e60cb95599e48cd98700973cd9
   languageName: node
   linkType: hard
 
-"@docusaurus/plugin-google-gtag@npm:2.0.0-beta.15":
-  version: 2.0.0-beta.15
-  resolution: "@docusaurus/plugin-google-gtag@npm:2.0.0-beta.15"
+"@docusaurus/plugin-google-gtag@npm:2.0.0-beta.16":
+  version: 2.0.0-beta.16
+  resolution: "@docusaurus/plugin-google-gtag@npm:2.0.0-beta.16"
   dependencies:
-    "@docusaurus/core": 2.0.0-beta.15
-    "@docusaurus/utils-validation": 2.0.0-beta.15
+    "@docusaurus/core": 2.0.0-beta.16
+    "@docusaurus/utils-validation": 2.0.0-beta.16
     tslib: ^2.3.1
   peerDependencies:
     react: ^16.8.4 || ^17.0.0
     react-dom: ^16.8.4 || ^17.0.0
-  checksum: ab6287b649e07fc30b1de96c838e9c225c85924c8e32a75a846c36175033f37d22056c1bd6b4930d6cfb0d51ccdb37e7b3067d41a87abb9bf164b1c81009c812
+  checksum: d7bf134d75cae8e8e368c286af0c1afe67ac4155936b56a842e0f1f1e0fb431082452ef4aef679290e633a0905f8dcd7952dc67d7e824b43d7046505cdb21472
   languageName: node
   linkType: hard
 
-"@docusaurus/plugin-sitemap@npm:2.0.0-beta.15":
-  version: 2.0.0-beta.15
-  resolution: "@docusaurus/plugin-sitemap@npm:2.0.0-beta.15"
+"@docusaurus/plugin-sitemap@npm:2.0.0-beta.16":
+  version: 2.0.0-beta.16
+  resolution: "@docusaurus/plugin-sitemap@npm:2.0.0-beta.16"
   dependencies:
-    "@docusaurus/core": 2.0.0-beta.15
-    "@docusaurus/utils": 2.0.0-beta.15
-    "@docusaurus/utils-common": 2.0.0-beta.15
-    "@docusaurus/utils-validation": 2.0.0-beta.15
-    fs-extra: ^10.0.0
-    sitemap: ^7.0.0
+    "@docusaurus/core": 2.0.0-beta.16
+    "@docusaurus/utils": 2.0.0-beta.16
+    "@docusaurus/utils-common": 2.0.0-beta.16
+    "@docusaurus/utils-validation": 2.0.0-beta.16
+    fs-extra: ^10.0.1
+    sitemap: ^7.1.1
     tslib: ^2.3.1
   peerDependencies:
     react: ^16.8.4 || ^17.0.0
     react-dom: ^16.8.4 || ^17.0.0
-  checksum: e1d34a05bf58345522c583da426cdd10654f10f9fe05f49c1090856858c155f4313768e6dc15b3847add19be5219e880be5ef8a08d015bd50505c96f79797eb9
+  checksum: 964b53e55845c610f22f154da16064befac179d096440e4d7d6b11516b6e6f6f2d853bd588f98431610d84c138e0d58c3c5451761e576c25760a22851b8bc04d
   languageName: node
   linkType: hard
 
-"@docusaurus/preset-classic@npm:2.0.0-beta.15":
-  version: 2.0.0-beta.15
-  resolution: "@docusaurus/preset-classic@npm:2.0.0-beta.15"
+"@docusaurus/preset-classic@npm:2.0.0-beta.16":
+  version: 2.0.0-beta.16
+  resolution: "@docusaurus/preset-classic@npm:2.0.0-beta.16"
   dependencies:
-    "@docusaurus/core": 2.0.0-beta.15
-    "@docusaurus/plugin-content-blog": 2.0.0-beta.15
-    "@docusaurus/plugin-content-docs": 2.0.0-beta.15
-    "@docusaurus/plugin-content-pages": 2.0.0-beta.15
-    "@docusaurus/plugin-debug": 2.0.0-beta.15
-    "@docusaurus/plugin-google-analytics": 2.0.0-beta.15
-    "@docusaurus/plugin-google-gtag": 2.0.0-beta.15
-    "@docusaurus/plugin-sitemap": 2.0.0-beta.15
-    "@docusaurus/theme-classic": 2.0.0-beta.15
-    "@docusaurus/theme-common": 2.0.0-beta.15
-    "@docusaurus/theme-search-algolia": 2.0.0-beta.15
+    "@docusaurus/core": 2.0.0-beta.16
+    "@docusaurus/plugin-content-blog": 2.0.0-beta.16
+    "@docusaurus/plugin-content-docs": 2.0.0-beta.16
+    "@docusaurus/plugin-content-pages": 2.0.0-beta.16
+    "@docusaurus/plugin-debug": 2.0.0-beta.16
+    "@docusaurus/plugin-google-analytics": 2.0.0-beta.16
+    "@docusaurus/plugin-google-gtag": 2.0.0-beta.16
+    "@docusaurus/plugin-sitemap": 2.0.0-beta.16
+    "@docusaurus/theme-classic": 2.0.0-beta.16
+    "@docusaurus/theme-common": 2.0.0-beta.16
+    "@docusaurus/theme-search-algolia": 2.0.0-beta.16
   peerDependencies:
     react: ^16.8.4 || ^17.0.0
     react-dom: ^16.8.4 || ^17.0.0
-  checksum: f3c456eafbbccf9c0ef9b01b50667cc7004ebe29ee4afa709655a21b44c6ada10e3604f2d5bc81f99b0385e6abc874288014953c09d211b987e24f5d68fa25c2
+  checksum: e4ce42922a0b34956fe12987c323c11dd099ceeefc8767f33ed005828c3bfd613a84f4bd4a5af40f6780627f99d73b77611a8bda7ba85dc929488f387823e625
   languageName: node
   linkType: hard
 
@@ -2130,101 +2382,103 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@docusaurus/theme-classic@npm:2.0.0-beta.15":
-  version: 2.0.0-beta.15
-  resolution: "@docusaurus/theme-classic@npm:2.0.0-beta.15"
+"@docusaurus/theme-classic@npm:2.0.0-beta.16":
+  version: 2.0.0-beta.16
+  resolution: "@docusaurus/theme-classic@npm:2.0.0-beta.16"
   dependencies:
-    "@docusaurus/core": 2.0.0-beta.15
-    "@docusaurus/plugin-content-blog": 2.0.0-beta.15
-    "@docusaurus/plugin-content-docs": 2.0.0-beta.15
-    "@docusaurus/plugin-content-pages": 2.0.0-beta.15
-    "@docusaurus/theme-common": 2.0.0-beta.15
-    "@docusaurus/theme-translations": 2.0.0-beta.15
-    "@docusaurus/utils": 2.0.0-beta.15
-    "@docusaurus/utils-common": 2.0.0-beta.15
-    "@docusaurus/utils-validation": 2.0.0-beta.15
-    "@mdx-js/react": ^1.6.21
+    "@docusaurus/core": 2.0.0-beta.16
+    "@docusaurus/plugin-content-blog": 2.0.0-beta.16
+    "@docusaurus/plugin-content-docs": 2.0.0-beta.16
+    "@docusaurus/plugin-content-pages": 2.0.0-beta.16
+    "@docusaurus/theme-common": 2.0.0-beta.16
+    "@docusaurus/theme-translations": 2.0.0-beta.16
+    "@docusaurus/utils": 2.0.0-beta.16
+    "@docusaurus/utils-common": 2.0.0-beta.16
+    "@docusaurus/utils-validation": 2.0.0-beta.16
+    "@mdx-js/react": ^1.6.22
     clsx: ^1.1.1
     copy-text-to-clipboard: ^3.0.1
     infima: 0.2.0-alpha.37
-    lodash: ^4.17.20
-    postcss: ^8.3.7
+    lodash: ^4.17.21
+    postcss: ^8.4.6
     prism-react-renderer: ^1.2.1
-    prismjs: ^1.23.0
+    prismjs: ^1.27.0
     react-router-dom: ^5.2.0
     rtlcss: ^3.3.0
   peerDependencies:
     react: ^16.8.4 || ^17.0.0
     react-dom: ^16.8.4 || ^17.0.0
-  checksum: 4daf29d87ce2ba0a6a5b01049aaa4160032e9064a6da8e83da321e985eba49bcce2bbe661e524bf4894c2e19ae704786fcd319b7f3381e4facfbb7d76c75c254
+  checksum: 9029f56f31c8c639c9dfa926fe1449fc7c7c7edc2e791d780a4ba6f7a2133d5b1c6f5d128ad3db2c6e280b06050d66eb6d7e72cfdce5b01d43872d742a464d29
   languageName: node
   linkType: hard
 
-"@docusaurus/theme-common@npm:2.0.0-beta.15":
-  version: 2.0.0-beta.15
-  resolution: "@docusaurus/theme-common@npm:2.0.0-beta.15"
+"@docusaurus/theme-common@npm:2.0.0-beta.16":
+  version: 2.0.0-beta.16
+  resolution: "@docusaurus/theme-common@npm:2.0.0-beta.16"
   dependencies:
-    "@docusaurus/plugin-content-blog": 2.0.0-beta.15
-    "@docusaurus/plugin-content-docs": 2.0.0-beta.15
-    "@docusaurus/plugin-content-pages": 2.0.0-beta.15
+    "@docusaurus/module-type-aliases": 2.0.0-beta.16
+    "@docusaurus/plugin-content-blog": 2.0.0-beta.16
+    "@docusaurus/plugin-content-docs": 2.0.0-beta.16
+    "@docusaurus/plugin-content-pages": 2.0.0-beta.16
     clsx: ^1.1.1
     parse-numeric-range: ^1.3.0
+    prism-react-renderer: ^1.3.1
     tslib: ^2.3.1
     utility-types: ^3.10.0
   peerDependencies:
-    prism-react-renderer: ^1.2.1
     react: ^16.8.4 || ^17.0.0
     react-dom: ^16.8.4 || ^17.0.0
-  checksum: 732bcacf7ad341aaa7d514a903d8c31b811ecdf4accf44e0c33a4adfd40745acc942650f2384dd95d774bc544de3f590f629812b144dbec9f943a6886d3d6dbf
+  checksum: a5d0a9cc51c9ac54f6eca2062552efb8fc2f3215380fa95edd1e8b1346d7e6fc8adcb42c22b6b81f182f6ca7fa1fcf522b738afb82c1fed42f04e0d0815e5b8e
   languageName: node
   linkType: hard
 
-"@docusaurus/theme-search-algolia@npm:2.0.0-beta.15":
-  version: 2.0.0-beta.15
-  resolution: "@docusaurus/theme-search-algolia@npm:2.0.0-beta.15"
+"@docusaurus/theme-search-algolia@npm:2.0.0-beta.16":
+  version: 2.0.0-beta.16
+  resolution: "@docusaurus/theme-search-algolia@npm:2.0.0-beta.16"
   dependencies:
-    "@docsearch/react": ^3.0.0-alpha.39
-    "@docusaurus/core": 2.0.0-beta.15
-    "@docusaurus/logger": 2.0.0-beta.15
-    "@docusaurus/theme-common": 2.0.0-beta.15
-    "@docusaurus/theme-translations": 2.0.0-beta.15
-    "@docusaurus/utils": 2.0.0-beta.15
-    "@docusaurus/utils-validation": 2.0.0-beta.15
-    algoliasearch: ^4.10.5
-    algoliasearch-helper: ^3.5.5
+    "@docsearch/react": ^3.0.0
+    "@docusaurus/core": 2.0.0-beta.16
+    "@docusaurus/logger": 2.0.0-beta.16
+    "@docusaurus/theme-common": 2.0.0-beta.16
+    "@docusaurus/theme-translations": 2.0.0-beta.16
+    "@docusaurus/utils": 2.0.0-beta.16
+    "@docusaurus/utils-validation": 2.0.0-beta.16
+    algoliasearch: ^4.12.1
+    algoliasearch-helper: ^3.7.0
     clsx: ^1.1.1
     eta: ^1.12.3
-    lodash: ^4.17.20
+    fs-extra: ^10.0.1
+    lodash: ^4.17.21
     tslib: ^2.3.1
     utility-types: ^3.10.0
   peerDependencies:
     react: ^16.8.4 || ^17.0.0
     react-dom: ^16.8.4 || ^17.0.0
-  checksum: 08ba2195fb59231a116eb3140a26d189af369037a2cbad24e02338d3f0b69b25be1226b06d834160288cfcbbe7248d0185d52dba67a951afc48b67a5c2769417
+  checksum: 8bce69975815754d4f2382425100ccb59daa65e70d83f97474410b8e7773afdd95c276667ee753f0a7dc3a3648f0ee789a48d28b2315070203422764ca8e0e5d
   languageName: node
   linkType: hard
 
-"@docusaurus/theme-translations@npm:2.0.0-beta.15":
-  version: 2.0.0-beta.15
-  resolution: "@docusaurus/theme-translations@npm:2.0.0-beta.15"
+"@docusaurus/theme-translations@npm:2.0.0-beta.16":
+  version: 2.0.0-beta.16
+  resolution: "@docusaurus/theme-translations@npm:2.0.0-beta.16"
   dependencies:
-    fs-extra: ^10.0.0
+    fs-extra: ^10.0.1
     tslib: ^2.3.1
-  checksum: ad6188c4d871b997390b039300451286a8c7ca4f82dffd8fdf1edebfb281da22391c63268ffd0f642b2fbb2f65930fd555ae38a7ae0e68b0bb9d30d2f1fc8610
+  checksum: fc42cc8a58af8fbb5394f69c844085299a80dc7623546fbf5540546fb8f48c2c9fc636d500d6e43966850755f05ee55c46cde9fa7b21bc988a5b58e27ada0336
   languageName: node
   linkType: hard
 
-"@docusaurus/types@npm:2.0.0-beta.15":
-  version: 2.0.0-beta.15
-  resolution: "@docusaurus/types@npm:2.0.0-beta.15"
+"@docusaurus/types@npm:2.0.0-beta.16":
+  version: 2.0.0-beta.16
+  resolution: "@docusaurus/types@npm:2.0.0-beta.16"
   dependencies:
     commander: ^5.1.0
-    joi: ^17.4.2
+    joi: ^17.6.0
     querystring: 0.2.1
     utility-types: ^3.10.0
-    webpack: ^5.61.0
+    webpack: ^5.69.1
     webpack-merge: ^5.8.0
-  checksum: f630b77d16ccf4b201ac473df8a65c79bbbd9735278ed85654e67d1c8810927df1034b6bfbcbc4bb153f4733329a782c2560e0032633c2bd2faa90f4c1ce0fe1
+  checksum: aff350726f1a7bff3685bff5d4e205a293d305e07d2ecb7627130818730e54734582163197bcdb4c5f4405ce1686691b7b9f16d1fb60f3af50b94abe8c16750c
   languageName: node
   linkType: hard
 
@@ -2241,27 +2495,24 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@docusaurus/utils-common@npm:2.0.0-beta.15":
-  version: 2.0.0-beta.15
-  resolution: "@docusaurus/utils-common@npm:2.0.0-beta.15"
+"@docusaurus/utils-common@npm:2.0.0-beta.16":
+  version: 2.0.0-beta.16
+  resolution: "@docusaurus/utils-common@npm:2.0.0-beta.16"
   dependencies:
     tslib: ^2.3.1
-  checksum: 152a5302056383acaa501b0de39ca1146bd2e2139396897dd66fee3e6370543a933913f507c7a9ba22afd2229cd8d8b34815e43786ce5dabea7f640a36cca6cb
+  checksum: 327d57061dfa86e1c34df24110cf65c066ffdecc198917639d895c8e08889d0138d26ab197d2bda9cf3a83d843086871c9e777cb3c434b66f0208ab550f4134a
   languageName: node
   linkType: hard
 
-"@docusaurus/utils-validation@npm:2.0.0-beta.15":
-  version: 2.0.0-beta.15
-  resolution: "@docusaurus/utils-validation@npm:2.0.0-beta.15"
+"@docusaurus/utils-validation@npm:2.0.0-beta.16":
+  version: 2.0.0-beta.16
+  resolution: "@docusaurus/utils-validation@npm:2.0.0-beta.16"
   dependencies:
-    "@docusaurus/logger": 2.0.0-beta.15
-    "@docusaurus/utils": 2.0.0-beta.15
-    joi: ^17.4.2
+    "@docusaurus/logger": 2.0.0-beta.16
+    "@docusaurus/utils": 2.0.0-beta.16
+    joi: ^17.6.0
     tslib: ^2.3.1
-  peerDependencies:
-    react: "*"
-    react-dom: "*"
-  checksum: c4f1499cd67f6f2da18f4e755177a5529f9acc2c2ca3342a714b0460041816da6f0879f670819e819883bf60a1f05cea1d43292c08ef0ff2b4b8678f44928b50
+  checksum: d2a2cdf2a7dabbc1c0c8551626d54dd1f8e7e913f559ff3f4c1fc3645831b1a005f69fd8e927022f77421ef2c8b6a0504a41538283c279897696c0d3375c1a8b
   languageName: node
   linkType: hard
 
@@ -2277,32 +2528,26 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@docusaurus/utils@npm:2.0.0-beta.15":
-  version: 2.0.0-beta.15
-  resolution: "@docusaurus/utils@npm:2.0.0-beta.15"
+"@docusaurus/utils@npm:2.0.0-beta.16":
+  version: 2.0.0-beta.16
+  resolution: "@docusaurus/utils@npm:2.0.0-beta.16"
   dependencies:
-    "@docusaurus/logger": 2.0.0-beta.15
-    "@mdx-js/runtime": ^1.6.22
+    "@docusaurus/logger": 2.0.0-beta.16
     "@svgr/webpack": ^6.0.0
     file-loader: ^6.2.0
-    fs-extra: ^10.0.0
+    fs-extra: ^10.0.1
     github-slugger: ^1.4.0
     globby: ^11.0.4
     gray-matter: ^4.0.3
-    js-yaml: ^4.0.0
-    lodash: ^4.17.20
+    js-yaml: ^4.1.0
+    lodash: ^4.17.21
     micromatch: ^4.0.4
-    remark-mdx-remove-exports: ^1.6.22
-    remark-mdx-remove-imports: ^1.6.22
     resolve-pathname: ^3.0.0
+    shelljs: ^0.8.5
     tslib: ^2.3.1
     url-loader: ^4.1.1
-  peerDependencies:
-    "@babel/core": ^7.0.0
-    react: "*"
-    react-dom: "*"
-    webpack: 5.x
-  checksum: b57f0e182e49d5f81adaabc6702576d516e3540403f2a7caba004ada5ab7ae8582b5d08e5a2e1e1d71a332e39ee3947628d755512487e17937b6a8bf1d67085a
+    webpack: ^5.69.1
+  checksum: e9b52823ca952b654932870b4a55fae2428669a9fa484e92a6cd8de54709543fd48589cb6d2d2c463b3455d275103cd54053c6c04e79296616f7d3c805773029
   languageName: node
   linkType: hard
 
@@ -2687,7 +2932,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@mdx-js/mdx@npm:1.6.22, @mdx-js/mdx@npm:^1.6.21":
+"@mdx-js/mdx@npm:^1.6.22":
   version: 1.6.22
   resolution: "@mdx-js/mdx@npm:1.6.22"
   dependencies:
@@ -2714,25 +2959,12 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@mdx-js/react@npm:1.6.22, @mdx-js/react@npm:^1.6.21":
+"@mdx-js/react@npm:^1.6.22":
   version: 1.6.22
   resolution: "@mdx-js/react@npm:1.6.22"
   peerDependencies:
     react: ^16.13.1 || ^17.0.0
   checksum: bc84bd514bc127f898819a0c6f1a6915d9541011bd8aefa1fcc1c9bea8939f31051409e546bdec92babfa5b56092a16d05ef6d318304ac029299df5181dc94c8
-  languageName: node
-  linkType: hard
-
-"@mdx-js/runtime@npm:^1.6.22":
-  version: 1.6.22
-  resolution: "@mdx-js/runtime@npm:1.6.22"
-  dependencies:
-    "@mdx-js/mdx": 1.6.22
-    "@mdx-js/react": 1.6.22
-    buble-jsx-only: ^0.19.8
-  peerDependencies:
-    react: ^16.13.1
-  checksum: 28f881891ecb514c0ae774cfae0e1a9ed84206b8797a9f961a694a79a69d0c3c312e2030934c19f350e1da36a8a0c07a7d5988520b2e4fc8505e53b3b7f39473
   languageName: node
   linkType: hard
 
@@ -3527,6 +3759,15 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@sideway/address@npm:^4.1.3":
+  version: 4.1.3
+  resolution: "@sideway/address@npm:4.1.3"
+  dependencies:
+    "@hapi/hoek": ^9.0.0
+  checksum: 3c1faf6ef37a0b59b62ce42b59c012c00ef1fc4194ad6776c65c2f9a6dd6c1710c6f6362b3ca3fa582fdb93984f0cb64ca44f9f5e02940634805f5e561279c22
+  languageName: node
+  linkType: hard
+
 "@sideway/formula@npm:^3.0.0":
   version: 3.0.0
   resolution: "@sideway/formula@npm:3.0.0"
@@ -3620,7 +3861,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@slorber/static-site-generator-webpack-plugin@npm:^4.0.0":
+"@slorber/static-site-generator-webpack-plugin@npm:^4.0.1":
   version: 4.0.1
   resolution: "@slorber/static-site-generator-webpack-plugin@npm:4.0.1"
   dependencies:
@@ -3996,6 +4237,16 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@types/eslint-scope@npm:^3.7.3":
+  version: 3.7.3
+  resolution: "@types/eslint-scope@npm:3.7.3"
+  dependencies:
+    "@types/eslint": "*"
+    "@types/estree": "*"
+  checksum: 6772b05e1b92003d1f295e81bc847a61f4fbe8ddab77ffa49e84ed3f9552513bdde677eb53ef167753901282857dd1d604d9f82eddb34a233495932b2dc3dc17
+  languageName: node
+  linkType: hard
+
 "@types/eslint@npm:*":
   version: 7.29.0
   resolution: "@types/eslint@npm:7.29.0"
@@ -4017,6 +4268,13 @@ __metadata:
   version: 0.0.39
   resolution: "@types/estree@npm:0.0.39"
   checksum: 412fb5b9868f2c418126451821833414189b75cc6bf84361156feed733e3d92ec220b9d74a89e52722e03d5e241b2932732711b7497374a404fad49087adc248
+  languageName: node
+  linkType: hard
+
+"@types/estree@npm:^0.0.51":
+  version: 0.0.51
+  resolution: "@types/estree@npm:0.0.51"
+  checksum: e56a3bcf759fd9185e992e7fdb3c6a5f81e8ff120e871641607581fb3728d16c811702a7d40fa5f869b7f7b4437ab6a87eb8d98ffafeee51e85bbe955932a189
   languageName: node
   linkType: hard
 
@@ -4218,17 +4476,10 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@types/node@npm:*, @types/node@npm:^17.0.21":
+"@types/node@npm:*, @types/node@npm:^17.0.21, @types/node@npm:^17.0.5":
   version: 17.0.21
   resolution: "@types/node@npm:17.0.21"
   checksum: 89dcd2fe82f21d3634266f8384e9c865cf8af49685639fbdbd799bdd1040480fb1e8eeda2d3b9fce41edbe704d2a4be9f427118c4ae872e8d9bb7cbeb3c41a94
-  languageName: node
-  linkType: hard
-
-"@types/node@npm:^15.0.1":
-  version: 15.14.9
-  resolution: "@types/node@npm:15.14.9"
-  checksum: 49f7f0522a3af4b8389aee660e88426490cd54b86356672a1fedb49919a8797c00d090ec2dcc4a5df34edc2099d57fc2203d796c4e7fbd382f2022ccd789eee7
   languageName: node
   linkType: hard
 
@@ -4294,15 +4545,6 @@ __metadata:
   dependencies:
     "@types/react": "*"
   checksum: 4d5730dffbef86c887cecad7e3cecda424ce6a64d0b5441c63b5b015d48219868660a2bb1aa15e897e565ad8867fa6b885d4358b04e1c4e589ba4c07c3fda55c
-  languageName: node
-  linkType: hard
-
-"@types/react-helmet@npm:*":
-  version: 6.1.4
-  resolution: "@types/react-helmet@npm:6.1.4"
-  dependencies:
-    "@types/react": "*"
-  checksum: 62f506297de26c39fc37383dccd7630253a66b2e3eb94d81ea9e6cd615fba57aee5453f6acd4b3e88dc0363f74a29305c483404899d1554f08bee8f4e716aa81
   languageName: node
   linkType: hard
 
@@ -4854,15 +5096,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"acorn-dynamic-import@npm:^4.0.0":
-  version: 4.0.0
-  resolution: "acorn-dynamic-import@npm:4.0.0"
-  peerDependencies:
-    acorn: ^6.0.0
-  checksum: ef7298e632e9d107b2be06b47d607de94d7213ca2417fced02af76b0c71e13074d98924e270c7bfec421c1049ed9001a97ed4d0f28020d9cfa1aae16ca20664a
-  languageName: node
-  linkType: hard
-
 "acorn-globals@npm:^6.0.0":
   version: 6.0.0
   resolution: "acorn-globals@npm:6.0.0"
@@ -4882,7 +5115,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"acorn-jsx@npm:^5.0.1, acorn-jsx@npm:^5.3.1":
+"acorn-jsx@npm:^5.3.1":
   version: 5.3.2
   resolution: "acorn-jsx@npm:5.3.2"
   peerDependencies:
@@ -4925,15 +5158,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"acorn@npm:^6.1.1":
-  version: 6.4.2
-  resolution: "acorn@npm:6.4.2"
-  bin:
-    acorn: bin/acorn
-  checksum: 44b07053729db7f44d28343eed32247ed56dc4a6ec6dff2b743141ecd6b861406bbc1c20bf9d4f143ea7dd08add5dc8c290582756539bc03a8db605050ce2fb4
-  languageName: node
-  linkType: hard
-
 "acorn@npm:^7.1.1":
   version: 7.4.1
   resolution: "acorn@npm:7.4.1"
@@ -4943,7 +5167,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"acorn@npm:^8.0.4, acorn@npm:^8.2.4, acorn@npm:^8.3.0, acorn@npm:^8.4.1, acorn@npm:^8.7.0":
+"acorn@npm:^8.0.4, acorn@npm:^8.2.4, acorn@npm:^8.3.0, acorn@npm:^8.4.1, acorn@npm:^8.5.0, acorn@npm:^8.7.0":
   version: 8.7.0
   resolution: "acorn@npm:8.7.0"
   bin:
@@ -5057,18 +5281,18 @@ __metadata:
   languageName: node
   linkType: hard
 
-"algoliasearch-helper@npm:^3.5.5":
-  version: 3.6.2
-  resolution: "algoliasearch-helper@npm:3.6.2"
+"algoliasearch-helper@npm:^3.7.0":
+  version: 3.7.0
+  resolution: "algoliasearch-helper@npm:3.7.0"
   dependencies:
-    events: ^1.1.1
+    "@algolia/events": ^4.0.1
   peerDependencies:
     algoliasearch: ">= 3.1 < 5"
-  checksum: 020917bc9ecf224e2fd5fe2511ed1d4a30a1b37ac9b602191f328c7217ba9c529ddb9780b8bdc9a2393c43a462face8c21dc09f04fee555e578daecfcf84ae68
+  checksum: 34afebf5aa6db2f032b6e8aab7e3a3bdd062ea2eebd9120000dbc02367126ac99e7402ea3cb4e8cdff58df0661805adc52219fd932ed4435fb1058b8e78a61d4
   languageName: node
   linkType: hard
 
-"algoliasearch@npm:^4.0.0, algoliasearch@npm:^4.10.5":
+"algoliasearch@npm:^4.0.0":
   version: 4.11.0
   resolution: "algoliasearch@npm:4.11.0"
   dependencies:
@@ -5087,6 +5311,28 @@ __metadata:
     "@algolia/requester-node-http": 4.11.0
     "@algolia/transporter": 4.11.0
   checksum: 016f5812fcd892df962ebc4b3788443352618ea882698a15c5f0c3c6f4bb72c50754156cb960e21fa8dcfe7234f96cb4d07605b3ea930a59de9b683f16fe33bc
+  languageName: node
+  linkType: hard
+
+"algoliasearch@npm:^4.12.1":
+  version: 4.12.1
+  resolution: "algoliasearch@npm:4.12.1"
+  dependencies:
+    "@algolia/cache-browser-local-storage": 4.12.1
+    "@algolia/cache-common": 4.12.1
+    "@algolia/cache-in-memory": 4.12.1
+    "@algolia/client-account": 4.12.1
+    "@algolia/client-analytics": 4.12.1
+    "@algolia/client-common": 4.12.1
+    "@algolia/client-personalization": 4.12.1
+    "@algolia/client-search": 4.12.1
+    "@algolia/logger-common": 4.12.1
+    "@algolia/logger-console": 4.12.1
+    "@algolia/requester-browser-xhr": 4.12.1
+    "@algolia/requester-common": 4.12.1
+    "@algolia/requester-node-http": 4.12.1
+    "@algolia/transporter": 4.12.1
+  checksum: ae3dad1c2c7c165ed4531f4f58327c6a02a73564dc4eb74ea0614818faf1c018bd73af927ba5930515b765bcbd1485f122366db0b0709f7c320e928d5a9930a1
   languageName: node
   linkType: hard
 
@@ -5113,7 +5359,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"ansi-align@npm:^3.0.0":
+"ansi-align@npm:^3.0.0, ansi-align@npm:^3.0.1":
   version: 3.0.1
   resolution: "ansi-align@npm:3.0.1"
   dependencies:
@@ -5595,7 +5841,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"autoprefixer@npm:^10.3.5, autoprefixer@npm:^10.3.7":
+"autoprefixer@npm:^10.3.7":
   version: 10.4.0
   resolution: "autoprefixer@npm:10.4.0"
   dependencies:
@@ -5613,6 +5859,24 @@ __metadata:
   languageName: node
   linkType: hard
 
+"autoprefixer@npm:^10.4.2":
+  version: 10.4.2
+  resolution: "autoprefixer@npm:10.4.2"
+  dependencies:
+    browserslist: ^4.19.1
+    caniuse-lite: ^1.0.30001297
+    fraction.js: ^4.1.2
+    normalize-range: ^0.1.2
+    picocolors: ^1.0.0
+    postcss-value-parser: ^4.2.0
+  peerDependencies:
+    postcss: ^8.1.0
+  bin:
+    autoprefixer: bin/autoprefixer
+  checksum: dbd13e641eaa7d7e3121769c22cc439222f1a9d0371a583d12300849de7287ece1e793767ff9902842dbfd56c4b7c19ed9fe1947c9f343ba2f4f3519dbddfdef
+  languageName: node
+  linkType: hard
+
 "axe-core@npm:^4.3.5":
   version: 4.3.5
   resolution: "axe-core@npm:4.3.5"
@@ -5620,12 +5884,12 @@ __metadata:
   languageName: node
   linkType: hard
 
-"axios@npm:^0.21.1":
-  version: 0.21.4
-  resolution: "axios@npm:0.21.4"
+"axios@npm:^0.25.0":
+  version: 0.25.0
+  resolution: "axios@npm:0.25.0"
   dependencies:
-    follow-redirects: ^1.14.0
-  checksum: 44245f24ac971e7458f3120c92f9d66d1fc695e8b97019139de5b0cc65d9b8104647db01e5f46917728edfc0cfd88eb30fc4c55e6053eef4ace76768ce95ff3c
+    follow-redirects: ^1.14.7
+  checksum: 2a8a3787c05f2a0c9c3878f49782357e2a9f38945b93018fb0c4fd788171c43dceefbb577988628e09fea53952744d1ecebde234b561f1e703aa43e0a598a3ad
   languageName: node
   linkType: hard
 
@@ -5654,7 +5918,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"babel-loader@npm:^8.2.2":
+"babel-loader@npm:^8.2.3":
   version: 8.2.3
   resolution: "babel-loader@npm:8.2.3"
   dependencies:
@@ -6070,7 +6334,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"boxen@npm:^5.0.0, boxen@npm:^5.0.1":
+"boxen@npm:^5.0.0":
   version: 5.1.2
   resolution: "boxen@npm:5.1.2"
   dependencies:
@@ -6083,6 +6347,22 @@ __metadata:
     widest-line: ^3.1.0
     wrap-ansi: ^7.0.0
   checksum: 82d03e42a72576ff235123f17b7c505372fe05c83f75f61e7d4fa4bcb393897ec95ce766fecb8f26b915f0f7a7227d66e5ec7cef43f5b2bd9d3aeed47ec55877
+  languageName: node
+  linkType: hard
+
+"boxen@npm:^6.2.1":
+  version: 6.2.1
+  resolution: "boxen@npm:6.2.1"
+  dependencies:
+    ansi-align: ^3.0.1
+    camelcase: ^6.2.0
+    chalk: ^4.1.2
+    cli-boxes: ^3.0.0
+    string-width: ^5.0.1
+    type-fest: ^2.5.0
+    widest-line: ^4.0.1
+    wrap-ansi: ^8.0.1
+  checksum: 2b3226092f1ff8e149c02979098c976552afa15f9e0231c9ed2dfcaaf84604494d16a6f13b647f718439f64d3140a088e822d47c7db00d2266e9ffc8d7321774
   languageName: node
   linkType: hard
 
@@ -6160,23 +6440,6 @@ __metadata:
   dependencies:
     node-int64: ^0.4.0
   checksum: 9ba4dc58ce86300c862bffc3ae91f00b2a03b01ee07f3564beeeaf82aa243b8b03ba53f123b0b842c190d4399b94697970c8e7cf7b1ea44b61aa28c3526a4449
-  languageName: node
-  linkType: hard
-
-"buble-jsx-only@npm:^0.19.8":
-  version: 0.19.8
-  resolution: "buble-jsx-only@npm:0.19.8"
-  dependencies:
-    acorn: ^6.1.1
-    acorn-dynamic-import: ^4.0.0
-    acorn-jsx: ^5.0.1
-    chalk: ^2.4.2
-    magic-string: ^0.25.3
-    minimist: ^1.2.0
-    regexpu-core: ^4.5.4
-  bin:
-    buble: ./bin/buble
-  checksum: 27f8b666065ec97f17cbbe5a599931154d99c4ad9bd6be59552ff83432f3f2649da90fa14cb7b690705c86fa38fca102c9031cc14b8c2bc968ac23785c8b8ed3
   languageName: node
   linkType: hard
 
@@ -6480,6 +6743,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"caniuse-lite@npm:^1.0.30001297":
+  version: 1.0.30001312
+  resolution: "caniuse-lite@npm:1.0.30001312"
+  checksum: 753fb9ea1e02e999430b323a71b5acab5120f3b5fc0161b01669f54a3ef5c5296240b6ae9b79b12a3742e3aed216aa9ee3d5398a23c16d08625ccd376b79545d
+  languageName: node
+  linkType: hard
+
 "ccount@npm:^1.0.0, ccount@npm:^1.0.3":
   version: 1.1.0
   resolution: "ccount@npm:1.1.0"
@@ -6645,7 +6915,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"chokidar@npm:^3.0.2, chokidar@npm:^3.4.2, chokidar@npm:^3.5.2, chokidar@npm:^3.5.3":
+"chokidar@npm:^3.0.2, chokidar@npm:^3.4.2, chokidar@npm:^3.5.3":
   version: 3.5.3
   resolution: "chokidar@npm:3.5.3"
   dependencies:
@@ -6727,6 +6997,15 @@ __metadata:
   languageName: node
   linkType: hard
 
+"clean-css@npm:^5.2.2, clean-css@npm:^5.2.4":
+  version: 5.2.4
+  resolution: "clean-css@npm:5.2.4"
+  dependencies:
+    source-map: ~0.6.0
+  checksum: 16f4e9de6368c7fdacee3c62f6a3bf96488620e0d5a9ad7c943c2acf8f194ea96d3b98d3cf5dbdb3fad1fdc713baa99d146722b5a48d0ba9f4ad3a7fe702d883
+  languageName: node
+  linkType: hard
+
 "clean-deep@npm:^3.0.2":
   version: 3.4.0
   resolution: "clean-deep@npm:3.4.0"
@@ -6758,6 +7037,13 @@ __metadata:
   version: 2.2.1
   resolution: "cli-boxes@npm:2.2.1"
   checksum: be79f8ec23a558b49e01311b39a1ea01243ecee30539c880cf14bf518a12e223ef40c57ead0cb44f509bffdffc5c129c746cd50d863ab879385370112af4f585
+  languageName: node
+  linkType: hard
+
+"cli-boxes@npm:^3.0.0":
+  version: 3.0.0
+  resolution: "cli-boxes@npm:3.0.0"
+  checksum: 637d84419d293a9eac40a1c8c96a2859e7d98b24a1a317788e13c8f441be052fc899480c6acab3acc82eaf1bccda6b7542d7cdcf5c9c3cc39227175dc098d5b2
   languageName: node
   linkType: hard
 
@@ -6802,6 +7088,19 @@ __metadata:
   version: 2.6.1
   resolution: "cli-spinners@npm:2.6.1"
   checksum: 423409baaa7a58e5104b46ca1745fbfc5888bbd0b0c5a626e052ae1387060839c8efd512fb127e25769b3dc9562db1dc1b5add6e0b93b7ef64f477feb6416a45
+  languageName: node
+  linkType: hard
+
+"cli-table3@npm:^0.6.1":
+  version: 0.6.1
+  resolution: "cli-table3@npm:0.6.1"
+  dependencies:
+    colors: 1.4.0
+    string-width: ^4.2.0
+  dependenciesMeta:
+    colors:
+      optional: true
+  checksum: 956e175f8eb019c26465b9f1e51121c08d8978e2aab04be7f8520ea8a4e67906fcbd8516dfb77e386ae3730ef0281aa21a65613dffbfa3d62969263252bd25a9
   languageName: node
   linkType: hard
 
@@ -7014,7 +7313,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"colors@npm:^1.1.2, colors@npm:^1.2.1":
+"colors@npm:1.4.0, colors@npm:^1.1.2, colors@npm:^1.2.1":
   version: 1.4.0
   resolution: "colors@npm:1.4.0"
   checksum: 98aa2c2418ad87dedf25d781be69dc5fc5908e279d9d30c34d8b702e586a0474605b3a189511482b9d5ed0d20c867515d22749537f7bc546256c6014f3ebdcec
@@ -7309,7 +7608,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"copy-webpack-plugin@npm:^10.2.0":
+"copy-webpack-plugin@npm:^10.2.4":
   version: 10.2.4
   resolution: "copy-webpack-plugin@npm:10.2.4"
   dependencies:
@@ -7342,10 +7641,17 @@ __metadata:
   languageName: node
   linkType: hard
 
-"core-js@npm:^3.18.0":
-  version: 3.20.0
-  resolution: "core-js@npm:3.20.0"
-  checksum: 4dca42f27553e1068b5329fbe133bca9256be819b64b4d0e244b8dc0db69181430d79aed3c33eeb7388f8ec019ea125e76fbd0c28523d112779f9bb5147a0939
+"core-js-pure@npm:^3.20.2":
+  version: 3.21.1
+  resolution: "core-js-pure@npm:3.21.1"
+  checksum: 00a5dff599b7fb0b30746a638b9d0edbdc0df24ed1580ca56be595fbe3c78c375d37fc4e1bff23627109229702c9ee8ea2587a66b8280eb33b85160aa4e401e9
+  languageName: node
+  linkType: hard
+
+"core-js@npm:^3.21.1":
+  version: 3.21.1
+  resolution: "core-js@npm:3.21.1"
+  checksum: d68eddd831340ad5b24ac29c72fda022a43b17f194c4278b6b875a843283d316502cb4abd07f28631d6ebc4387f66aa06e2b1b3c8fd7e08096a751b5c63f6889
   languageName: node
   linkType: hard
 
@@ -7511,7 +7817,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"css-loader@npm:^6.5.1":
+"css-loader@npm:^6.6.0":
   version: 6.6.0
   resolution: "css-loader@npm:6.6.0"
   dependencies:
@@ -7529,7 +7835,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"css-minimizer-webpack-plugin@npm:^3.3.1":
+"css-minimizer-webpack-plugin@npm:^3.4.1":
   version: 3.4.1
   resolution: "css-minimizer-webpack-plugin@npm:3.4.1"
   dependencies:
@@ -7612,19 +7918,58 @@ __metadata:
   languageName: node
   linkType: hard
 
-"cssnano-preset-advanced@npm:^5.1.4":
-  version: 5.1.7
-  resolution: "cssnano-preset-advanced@npm:5.1.7"
+"cssnano-preset-advanced@npm:^5.1.12":
+  version: 5.1.12
+  resolution: "cssnano-preset-advanced@npm:5.1.12"
   dependencies:
     autoprefixer: ^10.3.7
-    cssnano-preset-default: ^5.1.7
-    postcss-discard-unused: ^5.0.1
-    postcss-merge-idents: ^5.0.1
-    postcss-reduce-idents: ^5.0.1
-    postcss-zindex: ^5.0.1
+    cssnano-preset-default: ^5.1.12
+    postcss-discard-unused: ^5.0.3
+    postcss-merge-idents: ^5.0.3
+    postcss-reduce-idents: ^5.0.3
+    postcss-zindex: ^5.0.2
   peerDependencies:
     postcss: ^8.2.15
-  checksum: 63a18853e81054c6ad562d879ec1dbe140fc37e21ab1327106c5cce12e101295035764c4d1ad075699dec836545a40c5183d082d392ed8fae5b14d3e7d1c00df
+  checksum: 875678aa09ed84204bebd87fd07c1ccc049a9e989b04c9fb68e82eba8ca239ed0badad68263b4e53e1c842084a9ea4d4f1ea4088610b47a80e4382275d6c1722
+  languageName: node
+  linkType: hard
+
+"cssnano-preset-default@npm:^5.1.12":
+  version: 5.1.12
+  resolution: "cssnano-preset-default@npm:5.1.12"
+  dependencies:
+    css-declaration-sorter: ^6.0.3
+    cssnano-utils: ^3.0.2
+    postcss-calc: ^8.2.0
+    postcss-colormin: ^5.2.5
+    postcss-convert-values: ^5.0.4
+    postcss-discard-comments: ^5.0.3
+    postcss-discard-duplicates: ^5.0.3
+    postcss-discard-empty: ^5.0.3
+    postcss-discard-overridden: ^5.0.4
+    postcss-merge-longhand: ^5.0.6
+    postcss-merge-rules: ^5.0.6
+    postcss-minify-font-values: ^5.0.4
+    postcss-minify-gradients: ^5.0.6
+    postcss-minify-params: ^5.0.5
+    postcss-minify-selectors: ^5.1.3
+    postcss-normalize-charset: ^5.0.3
+    postcss-normalize-display-values: ^5.0.3
+    postcss-normalize-positions: ^5.0.4
+    postcss-normalize-repeat-style: ^5.0.4
+    postcss-normalize-string: ^5.0.4
+    postcss-normalize-timing-functions: ^5.0.3
+    postcss-normalize-unicode: ^5.0.4
+    postcss-normalize-url: ^5.0.5
+    postcss-normalize-whitespace: ^5.0.4
+    postcss-ordered-values: ^5.0.5
+    postcss-reduce-initial: ^5.0.3
+    postcss-reduce-transforms: ^5.0.4
+    postcss-svgo: ^5.0.4
+    postcss-unique-selectors: ^5.0.4
+  peerDependencies:
+    postcss: ^8.2.15
+  checksum: 0ccbc5f6490dd58ceb50d3cbc781523f1d4a21926fb4b9cfc89f74bf5c0e636713c3926d32c7a2c264db97aaf036a306278a36290fcad388b3854c95ce8d8138
   languageName: node
   linkType: hard
 
@@ -7676,7 +8021,29 @@ __metadata:
   languageName: node
   linkType: hard
 
-"cssnano@npm:^5.0.6, cssnano@npm:^5.0.8":
+"cssnano-utils@npm:^3.0.2":
+  version: 3.0.2
+  resolution: "cssnano-utils@npm:3.0.2"
+  peerDependencies:
+    postcss: ^8.2.15
+  checksum: 9bef6ec0164220114d24c920a7f3454359bcb54d95a2e4bba549b5fe3e26d66b621f27a1fd2bb5bc88a667182b64fdf5a7eaace1d7d85c3cb1805ec488087cc9
+  languageName: node
+  linkType: hard
+
+"cssnano@npm:^5.0.17":
+  version: 5.0.17
+  resolution: "cssnano@npm:5.0.17"
+  dependencies:
+    cssnano-preset-default: ^5.1.12
+    lilconfig: ^2.0.3
+    yaml: ^1.10.2
+  peerDependencies:
+    postcss: ^8.2.15
+  checksum: dfdde9cecd7b4a7b7842c758458595670101c55a1a9d733feec078a76618060f468e412d0c1b18900770992588cc9d50b2d1a4ada32c380376409331c2228d67
+  languageName: node
+  linkType: hard
+
+"cssnano@npm:^5.0.6":
   version: 5.0.11
   resolution: "cssnano@npm:5.0.11"
   dependencies:
@@ -9405,13 +9772,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"events@npm:^1.1.1":
-  version: 1.1.1
-  resolution: "events@npm:1.1.1"
-  checksum: 40431eb005cc4c57861b93d44c2981a49e7feb99df84cf551baed299ceea4444edf7744733f6a6667e942af687359b1f4a87ec1ec4f21d5127dac48a782039b9
-  languageName: node
-  linkType: hard
-
 "events@npm:^3.2.0":
   version: 3.3.0
   resolution: "events@npm:3.3.0"
@@ -10102,13 +10462,23 @@ __metadata:
   languageName: node
   linkType: hard
 
-"follow-redirects@npm:^1.0.0, follow-redirects@npm:^1.14.0":
+"follow-redirects@npm:^1.0.0":
   version: 1.14.5
   resolution: "follow-redirects@npm:1.14.5"
   peerDependenciesMeta:
     debug:
       optional: true
   checksum: f004a76b2ee3a849772c2816e30928253bf47537b0f00184d89f4966413add96a228a4d96ca8c702bc045a683c52c2ba41545c915cc1a5e33bf8fd9d07b59aee
+  languageName: node
+  linkType: hard
+
+"follow-redirects@npm:^1.14.7":
+  version: 1.14.9
+  resolution: "follow-redirects@npm:1.14.9"
+  peerDependenciesMeta:
+    debug:
+      optional: true
+  checksum: f5982e0eb481818642492d3ca35a86989c98af1128b8e1a62911a3410621bc15d2b079e8170b35b19d3bdee770b73ed431a257ed86195af773771145baa57845
   languageName: node
   linkType: hard
 
@@ -10184,6 +10554,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"fraction.js@npm:^4.1.2":
+  version: 4.1.3
+  resolution: "fraction.js@npm:4.1.3"
+  checksum: d00065afce4814998b6e42fd439bbed17edbd9616b134927dbd75ebe1b94d6eb0820c0ce0e2cf8f26100e552cb72aff83f4816ef90cb1b329b6d12a531a26aaa
+  languageName: node
+  linkType: hard
+
 "fragment-cache@npm:^0.2.1":
   version: 0.2.1
   resolution: "fragment-cache@npm:0.2.1"
@@ -10234,6 +10611,17 @@ __metadata:
     jsonfile: ^6.0.1
     universalify: ^2.0.0
   checksum: 5285a3d8f34b917cf2b66af8c231a40c1623626e9d701a20051d3337be16c6d7cac94441c8b3732d47a92a2a027886ca93c69b6a4ae6aee3c89650d2a8880c0a
+  languageName: node
+  linkType: hard
+
+"fs-extra@npm:^10.0.1":
+  version: 10.0.1
+  resolution: "fs-extra@npm:10.0.1"
+  dependencies:
+    graceful-fs: ^4.2.0
+    jsonfile: ^6.0.1
+    universalify: ^2.0.0
+  checksum: c1faaa5eb9e1c5c7c7ff09f966e93922ecb068ae1b04801cfc983ef05fcc1f66bfbb8d8d0b745c910014c7a2e7317fb6cf3bfe7390450c1157e3cc1a218f221d
   languageName: node
   linkType: hard
 
@@ -10633,7 +11021,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"globby@npm:^11.0.0, globby@npm:^11.0.1, globby@npm:^11.0.2, globby@npm:^11.0.3, globby@npm:^11.0.4":
+"globby@npm:^11.0.0, globby@npm:^11.0.1, globby@npm:^11.0.3, globby@npm:^11.0.4":
   version: 11.0.4
   resolution: "globby@npm:11.0.4"
   dependencies:
@@ -11172,6 +11560,23 @@ __metadata:
   languageName: node
   linkType: hard
 
+"html-minifier-terser@npm:^6.1.0":
+  version: 6.1.0
+  resolution: "html-minifier-terser@npm:6.1.0"
+  dependencies:
+    camel-case: ^4.1.2
+    clean-css: ^5.2.2
+    commander: ^8.3.0
+    he: ^1.2.0
+    param-case: ^3.0.4
+    relateurl: ^0.2.7
+    terser: ^5.10.0
+  bin:
+    html-minifier-terser: cli.js
+  checksum: ac52c14006476f773204c198b64838477859dc2879490040efab8979c0207424da55d59df7348153f412efa45a0840a1ca3c757bf14767d23a15e3e389d37a93
+  languageName: node
+  linkType: hard
+
 "html-tags@npm:^3.1.0":
   version: 3.1.0
   resolution: "html-tags@npm:3.1.0"
@@ -11186,7 +11591,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"html-webpack-plugin@npm:^5.4.0":
+"html-webpack-plugin@npm:^5.5.0":
   version: 5.5.0
   resolution: "html-webpack-plugin@npm:5.5.0"
   dependencies:
@@ -11456,7 +11861,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"import-fresh@npm:^3.0.0, import-fresh@npm:^3.1.0, import-fresh@npm:^3.2.1, import-fresh@npm:^3.2.2, import-fresh@npm:^3.3.0":
+"import-fresh@npm:^3.0.0, import-fresh@npm:^3.1.0, import-fresh@npm:^3.2.1, import-fresh@npm:^3.3.0":
   version: 3.3.0
   resolution: "import-fresh@npm:3.3.0"
   dependencies:
@@ -11640,6 +12045,15 @@ __metadata:
     from2: ^2.1.1
     p-is-promise: ^1.1.0
   checksum: e6e1a202227b20c446c251ef95348b3e8503cdc75aa2a09076f8821fc42c1b7fd43fabaeb8ed3cf9eb875942cfa4510b66949c5317997aa640921cc9bbadcd17
+  languageName: node
+  linkType: hard
+
+"invariant@npm:^2.2.4":
+  version: 2.2.4
+  resolution: "invariant@npm:2.2.4"
+  dependencies:
+    loose-envify: ^1.0.0
+  checksum: cc3182d793aad82a8d1f0af697b462939cb46066ec48bbf1707c150ad5fad6406137e91a262022c269702e01621f35ef60269f6c0d7fd178487959809acdfb14
   languageName: node
   linkType: hard
 
@@ -12909,7 +13323,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"jest-worker@npm:^27.0.2, jest-worker@npm:^27.4.1, jest-worker@npm:^27.5.1":
+"jest-worker@npm:^27.0.2, jest-worker@npm:^27.4.1, jest-worker@npm:^27.4.5, jest-worker@npm:^27.5.1":
   version: 27.5.1
   resolution: "jest-worker@npm:27.5.1"
   dependencies:
@@ -12938,7 +13352,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"joi@npm:^17.4.0, joi@npm:^17.4.2":
+"joi@npm:^17.4.0":
   version: 17.4.2
   resolution: "joi@npm:17.4.2"
   dependencies:
@@ -12948,6 +13362,19 @@ __metadata:
     "@sideway/formula": ^3.0.0
     "@sideway/pinpoint": ^2.0.0
   checksum: 977ada1f9d38c2762689b61cec1272176968ccea731a16b71713ebaa067f140460e0b6f7eccff6fc12206fddce22e7f4ed74724651bc1b24b1e26d43280633d0
+  languageName: node
+  linkType: hard
+
+"joi@npm:^17.6.0":
+  version: 17.6.0
+  resolution: "joi@npm:17.6.0"
+  dependencies:
+    "@hapi/hoek": ^9.0.0
+    "@hapi/topo": ^5.0.0
+    "@sideway/address": ^4.1.3
+    "@sideway/formula": ^3.0.0
+    "@sideway/pinpoint": ^2.0.0
+  checksum: eaf62f6c02f2edb1042f1ab04fc23a5918a2cb8f54bec84c6e1033624d8a462c10ae9518af55a3ba84f1793960450d58094eda308e7ef93c17edd4e3c8ef31d5
   languageName: node
   linkType: hard
 
@@ -14318,16 +14745,14 @@ __metadata:
   languageName: node
   linkType: hard
 
-"mini-css-extract-plugin@npm:^1.6.0":
-  version: 1.6.2
-  resolution: "mini-css-extract-plugin@npm:1.6.2"
+"mini-css-extract-plugin@npm:^2.5.3":
+  version: 2.5.3
+  resolution: "mini-css-extract-plugin@npm:2.5.3"
   dependencies:
-    loader-utils: ^2.0.0
-    schema-utils: ^3.0.0
-    webpack-sources: ^1.1.0
+    schema-utils: ^4.0.0
   peerDependencies:
-    webpack: ^4.4.0 || ^5.0.0
-  checksum: c2c1f3d7e5bc206b5bece0f37b65467ee58e0bb0b61d5e031bb818682b02db2552b296f5018af9058b18eb7127e00f6462fb718712a3d4432079dfa848b510cc
+    webpack: ^5.0.0
+  checksum: de53fbded09fd2ae81174b11754bc955fcf0e0a85b2c4df7e179fcc8a81533362498824395d43d50960b0bc93550eb2bd9cd1ded113eaa21bd84ab50ef29e65c
   languageName: node
   linkType: hard
 
@@ -16293,6 +16718,18 @@ __metadata:
   languageName: node
   linkType: hard
 
+"postcss-calc@npm:^8.2.0":
+  version: 8.2.4
+  resolution: "postcss-calc@npm:8.2.4"
+  dependencies:
+    postcss-selector-parser: ^6.0.9
+    postcss-value-parser: ^4.2.0
+  peerDependencies:
+    postcss: ^8.2.2
+  checksum: 314b4cebb0c4ed0cf8356b4bce71eca78f5a7842e6a3942a3bba49db168d5296b2bd93c3f735ae1c616f2651d94719ade33becc03c73d2d79c7394fb7f73eabb
+  languageName: node
+  linkType: hard
+
 "postcss-colormin@npm:^5.2.1":
   version: 5.2.1
   resolution: "postcss-colormin@npm:5.2.1"
@@ -16307,6 +16744,20 @@ __metadata:
   languageName: node
   linkType: hard
 
+"postcss-colormin@npm:^5.2.5":
+  version: 5.2.5
+  resolution: "postcss-colormin@npm:5.2.5"
+  dependencies:
+    browserslist: ^4.16.6
+    caniuse-api: ^3.0.0
+    colord: ^2.9.1
+    postcss-value-parser: ^4.2.0
+  peerDependencies:
+    postcss: ^8.2.15
+  checksum: deb5f7703e73e78d0856ed64afa404c06facfe786c17df0db01e9a0f1230eb43d53ede72767f89e59ea5b2fe1ce6f1a51c50fad96198b262632f4ff538bb6eb3
+  languageName: node
+  linkType: hard
+
 "postcss-convert-values@npm:^5.0.2":
   version: 5.0.2
   resolution: "postcss-convert-values@npm:5.0.2"
@@ -16315,6 +16766,17 @@ __metadata:
   peerDependencies:
     postcss: ^8.2.15
   checksum: 02a31f72b3365345db8aa1d83b084c96975d99a6494359378069431fd810e78ebf3bd96d03a598255daa8f6e2cd63722f119ddec9d24f66b6974b57819feb034
+  languageName: node
+  linkType: hard
+
+"postcss-convert-values@npm:^5.0.4":
+  version: 5.0.4
+  resolution: "postcss-convert-values@npm:5.0.4"
+  dependencies:
+    postcss-value-parser: ^4.2.0
+  peerDependencies:
+    postcss: ^8.2.15
+  checksum: f6edfd6c034266eeceb125e4ab6e93b35b3cc5bffac5f7c4270b55bb8762f5495e437f2f35228a5989ec8e7b5fbd686b079f652303e098fa17f1f512a48b8661
   languageName: node
   linkType: hard
 
@@ -16327,12 +16789,30 @@ __metadata:
   languageName: node
   linkType: hard
 
+"postcss-discard-comments@npm:^5.0.3":
+  version: 5.0.3
+  resolution: "postcss-discard-comments@npm:5.0.3"
+  peerDependencies:
+    postcss: ^8.2.15
+  checksum: 6131e692a1b03fcb0a1807fdee0cbba43db50a3003b9876a154b41c8d3e6e1610bcd790b46f17e5b47f70de31aad6e3495389dd094beda353e492805daf0758a
+  languageName: node
+  linkType: hard
+
 "postcss-discard-duplicates@npm:^5.0.1":
   version: 5.0.1
   resolution: "postcss-discard-duplicates@npm:5.0.1"
   peerDependencies:
     postcss: ^8.2.15
   checksum: becb68fd5ccd632fe51413a6ab4fd5c8aa3aae9d12947238014c2fb7816a2e0eb9a5454ee7207cac19f4a093c799be6053f13bf4048e97e20d88d5af4a0656bc
+  languageName: node
+  linkType: hard
+
+"postcss-discard-duplicates@npm:^5.0.3":
+  version: 5.0.3
+  resolution: "postcss-discard-duplicates@npm:5.0.3"
+  peerDependencies:
+    postcss: ^8.2.15
+  checksum: 2afd559910ec29469a20f2dc6862ad7a699140967df7b43405b06064ffa656a3fefd1dc04e5f0fe70b7753e29d092b836a23bee51d509878549ce17123b2a09f
   languageName: node
   linkType: hard
 
@@ -16345,6 +16825,15 @@ __metadata:
   languageName: node
   linkType: hard
 
+"postcss-discard-empty@npm:^5.0.3":
+  version: 5.0.3
+  resolution: "postcss-discard-empty@npm:5.0.3"
+  peerDependencies:
+    postcss: ^8.2.15
+  checksum: b164411aeaa896422f5f34c2e92d4f27af21af7bff8a5e7ba7077f84494542a7fe44540a8793d78aa9ed65afdd9c2203c73a86188bb720ec35c8aac639c4b6be
+  languageName: node
+  linkType: hard
+
 "postcss-discard-overridden@npm:^5.0.1":
   version: 5.0.1
   resolution: "postcss-discard-overridden@npm:5.0.1"
@@ -16354,18 +16843,27 @@ __metadata:
   languageName: node
   linkType: hard
 
-"postcss-discard-unused@npm:^5.0.1":
-  version: 5.0.1
-  resolution: "postcss-discard-unused@npm:5.0.1"
+"postcss-discard-overridden@npm:^5.0.4":
+  version: 5.0.4
+  resolution: "postcss-discard-overridden@npm:5.0.4"
+  peerDependencies:
+    postcss: ^8.2.15
+  checksum: 85887026ce5b67bddf96a7bed73eb5c0b94727c9517663dba89da1f610cf65ddb8856653b180780fab773bb74d6d249b89fb46c2a63ec965bdad2dd4a332ff78
+  languageName: node
+  linkType: hard
+
+"postcss-discard-unused@npm:^5.0.3":
+  version: 5.0.3
+  resolution: "postcss-discard-unused@npm:5.0.3"
   dependencies:
     postcss-selector-parser: ^6.0.5
   peerDependencies:
     postcss: ^8.2.15
-  checksum: e8cd31ddca65bf5fba22c920cd8984ae8e7f504a1c1b91a2eb39851507b947677c366fd9d6a9e07b29293cb7ec887e1010aa499d2b5455819c5cd1fe304b065e
+  checksum: 36074e7ce881915a574322ab4b04691582fb580065edcb929e208c253b9ca9c890f435ac99cc3ccee5d4308a77dd32e754cea0124c5217e13da645ea1af1346a
   languageName: node
   linkType: hard
 
-"postcss-loader@npm:^6.1.1":
+"postcss-loader@npm:^6.2.1":
   version: 6.2.1
   resolution: "postcss-loader@npm:6.2.1"
   dependencies:
@@ -16379,15 +16877,15 @@ __metadata:
   languageName: node
   linkType: hard
 
-"postcss-merge-idents@npm:^5.0.1":
-  version: 5.0.1
-  resolution: "postcss-merge-idents@npm:5.0.1"
+"postcss-merge-idents@npm:^5.0.3":
+  version: 5.0.3
+  resolution: "postcss-merge-idents@npm:5.0.3"
   dependencies:
-    cssnano-utils: ^2.0.1
-    postcss-value-parser: ^4.1.0
+    cssnano-utils: ^3.0.2
+    postcss-value-parser: ^4.2.0
   peerDependencies:
     postcss: ^8.2.15
-  checksum: d2c221bfc48a3a00671dbd4d9daf7016dacbce05216fc141e0dbbe26cab9aa268da1b623be21c91f5bb4f96603d86d45f8edcaa1fc5caaae69a5955318bb2ad4
+  checksum: ed211d59dff06633a6e98f5df5baf12c75311b4070e178bce9b2864790d0ce5740cbd10e29784e00dc3b2a7f1f7c92e8728c299c750b3eabba116dc1307f139d
   languageName: node
   linkType: hard
 
@@ -16400,6 +16898,18 @@ __metadata:
   peerDependencies:
     postcss: ^8.2.15
   checksum: 6c5ff2ae0e9def05a59cbb432b5cbbdb968816b83c4e38fdf14fa596ef21e36442f61b53984d56dca6165d91e74eadc720270b2887a4a1ef5e25ee171b7d7ea0
+  languageName: node
+  linkType: hard
+
+"postcss-merge-longhand@npm:^5.0.6":
+  version: 5.0.6
+  resolution: "postcss-merge-longhand@npm:5.0.6"
+  dependencies:
+    postcss-value-parser: ^4.2.0
+    stylehacks: ^5.0.3
+  peerDependencies:
+    postcss: ^8.2.15
+  checksum: 6080d7f4f6673e340aaaa182d46b6feac1148f2970fbc4d95e1e89c38b87ed2588aa7043b2dbf40624674a83c2dd5defdb7b279657cfe887f292f984e2bfced3
   languageName: node
   linkType: hard
 
@@ -16417,6 +16927,20 @@ __metadata:
   languageName: node
   linkType: hard
 
+"postcss-merge-rules@npm:^5.0.6":
+  version: 5.0.6
+  resolution: "postcss-merge-rules@npm:5.0.6"
+  dependencies:
+    browserslist: ^4.16.6
+    caniuse-api: ^3.0.0
+    cssnano-utils: ^3.0.2
+    postcss-selector-parser: ^6.0.5
+  peerDependencies:
+    postcss: ^8.2.15
+  checksum: 917b052deb4f08e0242b56113ed48bf9b391898a479fea1343c7ed660e8fac1e80fa58f35ec0944e2f79e4dd2c579c0c8fd7326634df7c6d469365ab128f1b9a
+  languageName: node
+  linkType: hard
+
 "postcss-minify-font-values@npm:^5.0.1":
   version: 5.0.1
   resolution: "postcss-minify-font-values@npm:5.0.1"
@@ -16425,6 +16949,17 @@ __metadata:
   peerDependencies:
     postcss: ^8.2.15
   checksum: 56aeb2cad5b3c4ca736b7fd7fa331d82281fbecc47e0e275a6a1203b436dbaa9f0772f668c3265dbf7ea2026c68d77c752cf9abe65bd3c65a53e696ae277e6e6
+  languageName: node
+  linkType: hard
+
+"postcss-minify-font-values@npm:^5.0.4":
+  version: 5.0.4
+  resolution: "postcss-minify-font-values@npm:5.0.4"
+  dependencies:
+    postcss-value-parser: ^4.2.0
+  peerDependencies:
+    postcss: ^8.2.15
+  checksum: 602b11beb62bf35cc5d26d4f8d6dc445e4f004855e60730f7b514752cac731e43a11fcf5e40a6f503b1a922a694c5b41ec4ddf5a07186db5b626ae99936f058c
   languageName: node
   linkType: hard
 
@@ -16438,6 +16973,19 @@ __metadata:
   peerDependencies:
     postcss: ^8.2.15
   checksum: 9ba5f28baeff45da8a5e759a748d5c26792e955d2cc061975c54f07d18f81518595353ddcd53dc5587342856425eefe909886b0a47bca392a9c9fcff297aab9e
+  languageName: node
+  linkType: hard
+
+"postcss-minify-gradients@npm:^5.0.6":
+  version: 5.0.6
+  resolution: "postcss-minify-gradients@npm:5.0.6"
+  dependencies:
+    colord: ^2.9.1
+    cssnano-utils: ^3.0.2
+    postcss-value-parser: ^4.2.0
+  peerDependencies:
+    postcss: ^8.2.15
+  checksum: 33359ce32f06f8bb38f254cb2f43792cc660a828dbe06d1c88de1a622ed05041f5f3d11af604f250da11e8ea690c6549b1d9635ca42ac09ebcd2aef3d6118c7d
   languageName: node
   linkType: hard
 
@@ -16455,6 +17003,19 @@ __metadata:
   languageName: node
   linkType: hard
 
+"postcss-minify-params@npm:^5.0.5":
+  version: 5.0.5
+  resolution: "postcss-minify-params@npm:5.0.5"
+  dependencies:
+    browserslist: ^4.16.6
+    cssnano-utils: ^3.0.2
+    postcss-value-parser: ^4.2.0
+  peerDependencies:
+    postcss: ^8.2.15
+  checksum: f49305cdca132dd1c07cfa2bd40a65790eb96e67f9ccb506f34a0fb3e0b7a340b6230b223f89fe6197327c7adf6552f79ec338e2439ff1db032230e406036705
+  languageName: node
+  linkType: hard
+
 "postcss-minify-selectors@npm:^5.1.0":
   version: 5.1.0
   resolution: "postcss-minify-selectors@npm:5.1.0"
@@ -16464,6 +17025,17 @@ __metadata:
   peerDependencies:
     postcss: ^8.2.15
   checksum: bf938e70a77b54d68709ec5e9a500b932e177b2278b5c405c3b59fb6f8315f2013e7b327ba76105949bf3c9ba6d6bef80ced4077cababb8e0015d87b4a086b50
+  languageName: node
+  linkType: hard
+
+"postcss-minify-selectors@npm:^5.1.3":
+  version: 5.1.3
+  resolution: "postcss-minify-selectors@npm:5.1.3"
+  dependencies:
+    postcss-selector-parser: ^6.0.5
+  peerDependencies:
+    postcss: ^8.2.15
+  checksum: 81f8ae32f9e50bc66c9c7875fcce2e45c92fff57bb509afb5922e67b37a245ce70f69107f5aa2f17e8a115de846356e43d7eda86c0f0c7a45ccbfd8d9e4e5d3e
   languageName: node
   linkType: hard
 
@@ -16520,6 +17092,15 @@ __metadata:
   languageName: node
   linkType: hard
 
+"postcss-normalize-charset@npm:^5.0.3":
+  version: 5.0.3
+  resolution: "postcss-normalize-charset@npm:5.0.3"
+  peerDependencies:
+    postcss: ^8.2.15
+  checksum: 04e60c55d138a4e28a2a8bc59f5dae540e3991417bfef870fe1872877d37659b8869459eab98566d30ef54daa5d83f11a902b0621d56ad17cc5e210f1c7e2caa
+  languageName: node
+  linkType: hard
+
 "postcss-normalize-display-values@npm:^5.0.1":
   version: 5.0.1
   resolution: "postcss-normalize-display-values@npm:5.0.1"
@@ -16532,6 +17113,17 @@ __metadata:
   languageName: node
   linkType: hard
 
+"postcss-normalize-display-values@npm:^5.0.3":
+  version: 5.0.3
+  resolution: "postcss-normalize-display-values@npm:5.0.3"
+  dependencies:
+    postcss-value-parser: ^4.2.0
+  peerDependencies:
+    postcss: ^8.2.15
+  checksum: 8fdf0e23e39f775f9100037d6b8e4344c5fd0bfe1b228f0c608479abd7783e1bdf964f8b8fa06735e5c0c1ece26ea74ba90b973666b9a7fc7aba552f6340215f
+  languageName: node
+  linkType: hard
+
 "postcss-normalize-positions@npm:^5.0.1":
   version: 5.0.1
   resolution: "postcss-normalize-positions@npm:5.0.1"
@@ -16540,6 +17132,17 @@ __metadata:
   peerDependencies:
     postcss: ^8.2.15
   checksum: 71a97ff851b78cdce8cc1ef21f91d40ddb2aca55d1bdc56056df27037efd9c208290f863ce0adf58a3060f8bb6eb3d66b4cf6d9a1e3ccbb03ba4eb0a0d1b6da4
+  languageName: node
+  linkType: hard
+
+"postcss-normalize-positions@npm:^5.0.4":
+  version: 5.0.4
+  resolution: "postcss-normalize-positions@npm:5.0.4"
+  dependencies:
+    postcss-value-parser: ^4.2.0
+  peerDependencies:
+    postcss: ^8.2.15
+  checksum: ab84f9c8ca950b0f1b45fc8067565a9f8271cbe6d26a5168738fcf866553b7ea87f91114e13f9638311df2c4455fea6ec66c5eecc3d71ad3d562c96477fff31c
   languageName: node
   linkType: hard
 
@@ -16555,6 +17158,17 @@ __metadata:
   languageName: node
   linkType: hard
 
+"postcss-normalize-repeat-style@npm:^5.0.4":
+  version: 5.0.4
+  resolution: "postcss-normalize-repeat-style@npm:5.0.4"
+  dependencies:
+    postcss-value-parser: ^4.2.0
+  peerDependencies:
+    postcss: ^8.2.15
+  checksum: cba6efd147c24f3f21faa808bacecce4ddbf047f57b63cc51cc2bf973de40d1dc95cbb38f126da5b89d0509d9110e93c01603964ad5563d33b22ef1eb850031b
+  languageName: node
+  linkType: hard
+
 "postcss-normalize-string@npm:^5.0.1":
   version: 5.0.1
   resolution: "postcss-normalize-string@npm:5.0.1"
@@ -16563,6 +17177,17 @@ __metadata:
   peerDependencies:
     postcss: ^8.2.15
   checksum: 4b42d41a05780517647b9a55888d314bfdfda2042f7a84050555e64da5eccade966fdca645c4ef66503fa95d642e89f2950e5b556b2a38a1a8f3120a24816c73
+  languageName: node
+  linkType: hard
+
+"postcss-normalize-string@npm:^5.0.4":
+  version: 5.0.4
+  resolution: "postcss-normalize-string@npm:5.0.4"
+  dependencies:
+    postcss-value-parser: ^4.2.0
+  peerDependencies:
+    postcss: ^8.2.15
+  checksum: c5af01ebff0a8c5781f8d1635c1078abbf3770c68d6b81d92a1d4deb56cdb8fb1f7d494cc380c23fe6125984e2ad2cc7d4ee3fca0e8394f6a3725184ea54fc5d
   languageName: node
   linkType: hard
 
@@ -16578,6 +17203,17 @@ __metadata:
   languageName: node
   linkType: hard
 
+"postcss-normalize-timing-functions@npm:^5.0.3":
+  version: 5.0.3
+  resolution: "postcss-normalize-timing-functions@npm:5.0.3"
+  dependencies:
+    postcss-value-parser: ^4.2.0
+  peerDependencies:
+    postcss: ^8.2.15
+  checksum: 75cf79b0d658fd72a5f198723195d55761d813663953f66222ddcae1892ae69a5d754bbb6563b31fc91b93be4db22b66bf606edbb26b9d047562d4560308bc52
+  languageName: node
+  linkType: hard
+
 "postcss-normalize-unicode@npm:^5.0.1":
   version: 5.0.1
   resolution: "postcss-normalize-unicode@npm:5.0.1"
@@ -16587,6 +17223,18 @@ __metadata:
   peerDependencies:
     postcss: ^8.2.15
   checksum: d5a0e0c107639847709c1e9badf09267ee7c67206ac4c19df4f9479308866f0592773ff4063e58d48a6a1d638637a0f7b187ec429ddd3385bab32a06e2d020fd
+  languageName: node
+  linkType: hard
+
+"postcss-normalize-unicode@npm:^5.0.4":
+  version: 5.0.4
+  resolution: "postcss-normalize-unicode@npm:5.0.4"
+  dependencies:
+    browserslist: ^4.16.6
+    postcss-value-parser: ^4.2.0
+  peerDependencies:
+    postcss: ^8.2.15
+  checksum: cb10547c82b2a9d6bc3b08ed85b67c82afdef78f77a891748ab325522d4b0cf68712042ffb81973e3d7f000d90a280383c8c1a598df473fd60037ac14658b4d0
   languageName: node
   linkType: hard
 
@@ -16603,6 +17251,18 @@ __metadata:
   languageName: node
   linkType: hard
 
+"postcss-normalize-url@npm:^5.0.5":
+  version: 5.0.5
+  resolution: "postcss-normalize-url@npm:5.0.5"
+  dependencies:
+    normalize-url: ^6.0.1
+    postcss-value-parser: ^4.2.0
+  peerDependencies:
+    postcss: ^8.2.15
+  checksum: 465567a475cb7798e9e6dbeff836b6e230efed8e93973f84e6af1d2c14cfa9c28d452dd305bdb5627e1c52265b09e1b20fcfc8f6704c113c81406fc92d3f335b
+  languageName: node
+  linkType: hard
+
 "postcss-normalize-whitespace@npm:^5.0.1":
   version: 5.0.1
   resolution: "postcss-normalize-whitespace@npm:5.0.1"
@@ -16611,6 +17271,17 @@ __metadata:
   peerDependencies:
     postcss: ^8.2.15
   checksum: cefb27d2443d4a8fc34aa2a0aebd470d7d5a58d9adcf39f5e2a80455f4ab37b171a24f58dc47b3111232c1adbb1c8702f80c0ecac1cfcef03e48e00dac6a4a58
+  languageName: node
+  linkType: hard
+
+"postcss-normalize-whitespace@npm:^5.0.4":
+  version: 5.0.4
+  resolution: "postcss-normalize-whitespace@npm:5.0.4"
+  dependencies:
+    postcss-value-parser: ^4.2.0
+  peerDependencies:
+    postcss: ^8.2.15
+  checksum: 861bfbc8c37e05725f2c5f0a886c941bb8d34151f07f34d8d88c3bc18eadf8ab1f7f65b7b92a6ca36ef73fd02a50b055190f26ac310775e9e0903c43109e2f37
   languageName: node
   linkType: hard
 
@@ -16626,14 +17297,26 @@ __metadata:
   languageName: node
   linkType: hard
 
-"postcss-reduce-idents@npm:^5.0.1":
-  version: 5.0.1
-  resolution: "postcss-reduce-idents@npm:5.0.1"
+"postcss-ordered-values@npm:^5.0.5":
+  version: 5.0.5
+  resolution: "postcss-ordered-values@npm:5.0.5"
   dependencies:
-    postcss-value-parser: ^4.1.0
+    cssnano-utils: ^3.0.2
+    postcss-value-parser: ^4.2.0
   peerDependencies:
     postcss: ^8.2.15
-  checksum: eccefd99e975a41208eb14fc3626abf7228924b63ac75c675ef91881c4bba593e8f964b5ddd77b8a955253e336b9702543576d9beca8e394c461fcbf4f653bd4
+  checksum: a093f8414e9949c2dab4e6081c6da13078fce5d929a26a3f5bfd68e0c82ac79f15af9f3ec01cfda403f0ae925218ee1917cf7f6994a1b12e406a52f009d9ac38
+  languageName: node
+  linkType: hard
+
+"postcss-reduce-idents@npm:^5.0.3":
+  version: 5.0.3
+  resolution: "postcss-reduce-idents@npm:5.0.3"
+  dependencies:
+    postcss-value-parser: ^4.2.0
+  peerDependencies:
+    postcss: ^8.2.15
+  checksum: a88acaeb8a4e828b848535be3f0e4d5477d8b1dc2f4bb1af67e1262d96d583468b77db9d5688bcfc748c7c1549f4fb28558c48d0aac3af86d6b0fcb96e3dd996
   languageName: node
   linkType: hard
 
@@ -16649,6 +17332,18 @@ __metadata:
   languageName: node
   linkType: hard
 
+"postcss-reduce-initial@npm:^5.0.3":
+  version: 5.0.3
+  resolution: "postcss-reduce-initial@npm:5.0.3"
+  dependencies:
+    browserslist: ^4.16.6
+    caniuse-api: ^3.0.0
+  peerDependencies:
+    postcss: ^8.2.15
+  checksum: 1be7efc4ccea9515f0a491a39f08ddc258b645f15543c31b45ee5d3972af520a1f8ad524c3c74682fbe93af94d11650bfc9f46c8230e3c2ccd153dd732ba6426
+  languageName: node
+  linkType: hard
+
 "postcss-reduce-transforms@npm:^5.0.1":
   version: 5.0.1
   resolution: "postcss-reduce-transforms@npm:5.0.1"
@@ -16658,6 +17353,17 @@ __metadata:
   peerDependencies:
     postcss: ^8.2.15
   checksum: 89e033ba1fe92057e6196237d5ae6f30b7ca86a98d91a01aa1853baea36ea6c092d29d354d3281000a618445a780c30277868b10d517015317fdc8b97739d34e
+  languageName: node
+  linkType: hard
+
+"postcss-reduce-transforms@npm:^5.0.4":
+  version: 5.0.4
+  resolution: "postcss-reduce-transforms@npm:5.0.4"
+  dependencies:
+    postcss-value-parser: ^4.2.0
+  peerDependencies:
+    postcss: ^8.2.15
+  checksum: 0aabca4eaf7e7367aac03850b2f86da15982df5e82b503ed569ce244e0b628442a1a2d6f958e5a9e0a0844d7d17e9fde416e71e895495c937e1a145f4baddf0a
   languageName: node
   linkType: hard
 
@@ -16671,14 +17377,24 @@ __metadata:
   languageName: node
   linkType: hard
 
-"postcss-sort-media-queries@npm:^4.1.0":
-  version: 4.1.0
-  resolution: "postcss-sort-media-queries@npm:4.1.0"
+"postcss-selector-parser@npm:^6.0.9":
+  version: 6.0.9
+  resolution: "postcss-selector-parser@npm:6.0.9"
+  dependencies:
+    cssesc: ^3.0.0
+    util-deprecate: ^1.0.2
+  checksum: f8161ab4d3e5c76b8467189c6d164ba0f6b6e74677435f29e34caa1df01e052b582b4ae4f7468b2243c4befdd8bdcdb7685542d1b2fca8deae21b3e849c78802
+  languageName: node
+  linkType: hard
+
+"postcss-sort-media-queries@npm:^4.2.1":
+  version: 4.2.1
+  resolution: "postcss-sort-media-queries@npm:4.2.1"
   dependencies:
     sort-css-media-queries: 2.0.4
   peerDependencies:
-    postcss: ^8.3.6
-  checksum: 767f514c902ace8dd4bc3775c82a0945be563e283d1557ce37beb54bdcf477d3a11268921fedde63f08490c649929f3e4240687b9cb70f97cffeb58e65758dea
+    postcss: ^8.4.4
+  checksum: 56a4363ce95a32daad74a40c22741f054de11210aaa1b5efc4c2dfb6eb9a651db6363479e0fe471e0f39d30ea95d2f97a89bd76f8394b7b42a3b36ee58f133e6
   languageName: node
   linkType: hard
 
@@ -16694,6 +17410,18 @@ __metadata:
   languageName: node
   linkType: hard
 
+"postcss-svgo@npm:^5.0.4":
+  version: 5.0.4
+  resolution: "postcss-svgo@npm:5.0.4"
+  dependencies:
+    postcss-value-parser: ^4.2.0
+    svgo: ^2.7.0
+  peerDependencies:
+    postcss: ^8.2.15
+  checksum: d114f03367cdac14dcb47d845828466682b53d20c9d1de46c1d5404711d1180a10d1f19fa6f37ea937c2b55256d6496697ebbcfa14e9f38e12e5689a53c86606
+  languageName: node
+  linkType: hard
+
 "postcss-unique-selectors@npm:^5.0.2":
   version: 5.0.2
   resolution: "postcss-unique-selectors@npm:5.0.2"
@@ -16703,6 +17431,17 @@ __metadata:
   peerDependencies:
     postcss: ^8.2.15
   checksum: ad0f7a8a4f1ed958544c1ede62a1c4b0978e01627a6ef0642f7b044d0f9fdb331318a91f8312f418a773b0f2df06c50896cfaf7e5dd3d0142bd1e5ba75dc9eb7
+  languageName: node
+  linkType: hard
+
+"postcss-unique-selectors@npm:^5.0.4":
+  version: 5.0.4
+  resolution: "postcss-unique-selectors@npm:5.0.4"
+  dependencies:
+    postcss-selector-parser: ^6.0.5
+  peerDependencies:
+    postcss: ^8.2.15
+  checksum: 966b5e23581451c0c1e53b6532c032c6908f2aa621434a1a94dc8ee76299c85bc40db656012baf8224470624b7682ec9d3ff4ae4977a34703f2e85a0eed065b2
   languageName: node
   linkType: hard
 
@@ -16724,16 +17463,16 @@ __metadata:
   languageName: node
   linkType: hard
 
-"postcss-zindex@npm:^5.0.1":
-  version: 5.0.1
-  resolution: "postcss-zindex@npm:5.0.1"
+"postcss-zindex@npm:^5.0.2":
+  version: 5.0.2
+  resolution: "postcss-zindex@npm:5.0.2"
   peerDependencies:
     postcss: ^8.2.15
-  checksum: fcf3f32d490e1d5cf63d01416761f3bd81368549d256c0714f5cec9ee8a7e8eb3a950b44ea76c36ebba3678dbbbcd55f2eaadc1dd1949773146490862ac7779d
+  checksum: bdd51f57d768a4245522c712669199e977f0a4e25484d6023ebbf9b13ba941c16a5a6241ea5e8f59e5147b2c64ad58e496bb330ab9c8df03a948ed22aff1a4fb
   languageName: node
   linkType: hard
 
-"postcss@npm:^8.1.7, postcss@npm:^8.3.11, postcss@npm:^8.3.5, postcss@npm:^8.3.7, postcss@npm:^8.4.5, postcss@npm:^8.4.6":
+"postcss@npm:^8.1.7, postcss@npm:^8.3.11, postcss@npm:^8.3.5, postcss@npm:^8.4.5, postcss@npm:^8.4.6":
   version: 8.4.6
   resolution: "postcss@npm:8.4.6"
   dependencies:
@@ -16893,10 +17632,10 @@ __metadata:
   languageName: node
   linkType: hard
 
-"prismjs@npm:^1.23.0":
-  version: 1.25.0
-  resolution: "prismjs@npm:1.25.0"
-  checksum: 04d8eae9d1b26b76c350bc65621584c8f8cab80ace7da3953f8aef2f9a8dd4b4f71c1d15bc5c67f126ddc90cd5af613919dc1340589a6c57355bed86fa3ac010
+"prismjs@npm:^1.27.0":
+  version: 1.27.0
+  resolution: "prismjs@npm:1.27.0"
+  checksum: 85c7f4a3e999073502cc9e1882af01e3709706369ec254b60bff1149eda701f40d02512acab956012dc7e61cfd61743a3a34c1bd0737e8dbacd79141e5698bbc
   languageName: node
   linkType: hard
 
@@ -16940,7 +17679,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"prompts@npm:^2.0.1, prompts@npm:^2.4.1, prompts@npm:^2.4.2":
+"prompts@npm:^2.0.1, prompts@npm:^2.4.2":
   version: 2.4.2
   resolution: "prompts@npm:2.4.2"
   dependencies:
@@ -17252,24 +17991,26 @@ __metadata:
   languageName: node
   linkType: hard
 
-"react-fast-compare@npm:^3.1.1":
+"react-fast-compare@npm:^3.2.0":
   version: 3.2.0
   resolution: "react-fast-compare@npm:3.2.0"
   checksum: 8ef272c825ae329f61633ce4ce7f15aa5b84e5214d88bc0823880236e03e985a13195befa2c7a4eda7db3b017dc7985729152d88445823f652403cf36c2b86aa
   languageName: node
   linkType: hard
 
-"react-helmet@npm:^6.1.0":
-  version: 6.1.0
-  resolution: "react-helmet@npm:6.1.0"
+"react-helmet-async@npm:*, react-helmet-async@npm:^1.2.3":
+  version: 1.2.3
+  resolution: "react-helmet-async@npm:1.2.3"
   dependencies:
-    object-assign: ^4.1.1
+    "@babel/runtime": ^7.12.5
+    invariant: ^2.2.4
     prop-types: ^15.7.2
-    react-fast-compare: ^3.1.1
-    react-side-effect: ^2.1.0
+    react-fast-compare: ^3.2.0
+    shallowequal: ^1.1.0
   peerDependencies:
-    react: ">=16.3.0"
-  checksum: a4998479dab7fc1c2799eddefb1870a9d881b5f71cfdf97979a9882e42f4bb50402d55335f308f461e735e01a06f46b16cc7b4e6bcb22c7a4a6f85a753c5c106
+    react: ^16.6.0 || ^17.0.0
+    react-dom: ^16.6.0 || ^17.0.0
+  checksum: af7041314f6ebaefa64f3c06f75cf1ad62602b93228798615c2ca3365065688ee2b8c58bde98a9ae0d728aecfda5a757e9fc7695da3af2a504ff7e5291c716c9
   languageName: node
   linkType: hard
 
@@ -17367,15 +18108,6 @@ __metadata:
   peerDependencies:
     react: ">=15"
   checksum: 7daae084bf64531eb619cc5f4cc40ce5ae0a541b64f71d74ec71a38cbf6130ebdbb7cf38f157303fad5846deec259401f96c4d6c7386466dcc989719e01f9aaa
-  languageName: node
-  linkType: hard
-
-"react-side-effect@npm:^2.1.0":
-  version: 2.1.1
-  resolution: "react-side-effect@npm:2.1.1"
-  peerDependencies:
-    react: ^16.3.0 || ^17.0.0
-  checksum: 324511ea8f6669555e166b4af280cdf46034bf0e33c486711e3ce17f88f6f21fed17055098408be1347657d0cbcd614bca944cf9f8e4ecfa96a21d13893fe9fc
   languageName: node
   linkType: hard
 
@@ -17547,15 +18279,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"regenerate-unicode-properties@npm:^9.0.0":
-  version: 9.0.0
-  resolution: "regenerate-unicode-properties@npm:9.0.0"
-  dependencies:
-    regenerate: ^1.4.2
-  checksum: 62df21c274259a68c6fa1373e5ddb4d6f6374ad72c08dd488b7802880bc1c3b6de716303ec56c9f793a73d01815e9d81f03a8fbe3f32bc0f7fdf8d70d4841b64
-  languageName: node
-  linkType: hard
-
 "regenerate@npm:^1.4.2":
   version: 1.4.2
   resolution: "regenerate@npm:1.4.2"
@@ -17606,20 +18329,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"regexpu-core@npm:^4.5.4":
-  version: 4.8.0
-  resolution: "regexpu-core@npm:4.8.0"
-  dependencies:
-    regenerate: ^1.4.2
-    regenerate-unicode-properties: ^9.0.0
-    regjsgen: ^0.5.2
-    regjsparser: ^0.7.0
-    unicode-match-property-ecmascript: ^2.0.0
-    unicode-match-property-value-ecmascript: ^2.0.0
-  checksum: df92e3e6482409f0a0de162ca1b4e17897e9b0b0687caead6804f04e9b89847e47abbfd0bfc62f52a0b833acf764ea5bdb7b707bb088034824a675ee95d31dec
-  languageName: node
-  linkType: hard
-
 "regexpu-core@npm:^5.0.1":
   version: 5.0.1
   resolution: "regexpu-core@npm:5.0.1"
@@ -17652,28 +18361,10 @@ __metadata:
   languageName: node
   linkType: hard
 
-"regjsgen@npm:^0.5.2":
-  version: 0.5.2
-  resolution: "regjsgen@npm:0.5.2"
-  checksum: 87c83d8488affae2493a823904de1a29a1867a07433c5e1142ad749b5606c5589b305fe35bfcc0972cf5a3b0d66b1f7999009e541be39a5d42c6041c59e2fb52
-  languageName: node
-  linkType: hard
-
 "regjsgen@npm:^0.6.0":
   version: 0.6.0
   resolution: "regjsgen@npm:0.6.0"
   checksum: c5158ebd735e75074e41292ade1ff05d85566d205426cc61501e360c450a63baced8512ee3ae238e5c0a0e42969563c7875b08fa69d6f0402daf36bcb3e4d348
-  languageName: node
-  linkType: hard
-
-"regjsparser@npm:^0.7.0":
-  version: 0.7.0
-  resolution: "regjsparser@npm:0.7.0"
-  dependencies:
-    jsesc: ~0.5.0
-  bin:
-    regjsparser: bin/parser
-  checksum: fefff9adcab47650817d2c492aac774f11a44b824a4a814e466ebc76313e03e79c50d2babde7e04888296f6ec0fd094e3eeeafa8122c60184de92cdb30636a57
   languageName: node
   linkType: hard
 
@@ -17732,24 +18423,6 @@ __metadata:
   version: 2.0.0
   resolution: "remark-footnotes@npm:2.0.0"
   checksum: f2f87ffd6fe25892373c7164d6584a7cb03ab0ea4f186af493a73df519e24b72998a556e7f16cb996f18426cdb80556b95ff252769e252cf3ccba0fd2ca20621
-  languageName: node
-  linkType: hard
-
-"remark-mdx-remove-exports@npm:^1.6.22":
-  version: 1.6.22
-  resolution: "remark-mdx-remove-exports@npm:1.6.22"
-  dependencies:
-    unist-util-remove: 2.0.0
-  checksum: 4ab3e34167982d4e022a867cb5b5447d8cbc0a123f51f8b60839e50873239d135b4ff69a40a21c07bba08729ca144eebee6f09203e9681707e027036f57e0b9e
-  languageName: node
-  linkType: hard
-
-"remark-mdx-remove-imports@npm:^1.6.22":
-  version: 1.6.22
-  resolution: "remark-mdx-remove-imports@npm:1.6.22"
-  dependencies:
-    unist-util-remove: 2.0.0
-  checksum: ed33293fb18c9d6b93ddc1d59b07c022c8c1b1dec21c65f81e05a08bec025c7347402b589d28339eb902157438ede86d14a817ce7b927650997341e655a56dc6
   languageName: node
   linkType: hard
 
@@ -18222,12 +18895,12 @@ __metadata:
   languageName: node
   linkType: hard
 
-"rxjs@npm:^7.1.0":
-  version: 7.4.0
-  resolution: "rxjs@npm:7.4.0"
+"rxjs@npm:^7.5.4":
+  version: 7.5.4
+  resolution: "rxjs@npm:7.5.4"
   dependencies:
-    tslib: ~2.1.0
-  checksum: 6b33172a760dcad6882fdc836ee8cf1ebe160dd7eaad95c45a12338ffdaa96eb41e48e6c25bbd3d1fdf45075949ff447954bc17a9d01c688558a67967d09c114
+    tslib: ^2.1.0
+  checksum: 6f55f835f2543bc8214900f9e28b6320e6adc95875011fbca63e80a66eb18c9ff7cfdccb23b2180cbb6412762b98ed158c89fd51cb020799d127c66ea38c3c0e
   languageName: node
   linkType: hard
 
@@ -18592,6 +19265,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"shallowequal@npm:^1.1.0":
+  version: 1.1.0
+  resolution: "shallowequal@npm:1.1.0"
+  checksum: f4c1de0837f106d2dbbfd5d0720a5d059d1c66b42b580965c8f06bb1db684be8783538b684092648c981294bf817869f743a066538771dbecb293df78f765e00
+  languageName: node
+  linkType: hard
+
 "shebang-command@npm:^2.0.0":
   version: 2.0.0
   resolution: "shebang-command@npm:2.0.0"
@@ -18615,7 +19295,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"shelljs@npm:^0.8.4, shelljs@npm:^0.8.5":
+"shelljs@npm:^0.8.5":
   version: 0.8.5
   resolution: "shelljs@npm:0.8.5"
   dependencies:
@@ -18701,9 +19381,9 @@ __metadata:
   resolution: "site@workspace:packages/site"
   dependencies:
     "@babel/plugin-proposal-decorators": ^7.17.2
-    "@docusaurus/core": 2.0.0-beta.15
-    "@docusaurus/module-type-aliases": 2.0.0-beta.15
-    "@docusaurus/preset-classic": 2.0.0-beta.15
+    "@docusaurus/core": 2.0.0-beta.16
+    "@docusaurus/module-type-aliases": 2.0.0-beta.16
+    "@docusaurus/preset-classic": 2.0.0-beta.16
     "@easyops-cn/docusaurus-search-local": ^0.21.4
     "@svgr/webpack": ^6.2.1
     "@tsconfig/docusaurus": ^1.0.4
@@ -18723,17 +19403,17 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"sitemap@npm:^7.0.0":
-  version: 7.0.0
-  resolution: "sitemap@npm:7.0.0"
+"sitemap@npm:^7.1.1":
+  version: 7.1.1
+  resolution: "sitemap@npm:7.1.1"
   dependencies:
-    "@types/node": ^15.0.1
+    "@types/node": ^17.0.5
     "@types/sax": ^1.2.1
     arg: ^5.0.0
     sax: ^1.2.4
   bin:
     sitemap: dist/cli.js
-  checksum: 9dd62d8512835027074183172ced770b8f2b7c16d2c9682d6359fc11d982aa6d960570d1f01d457815a9e31957574d01c92c6b5991f2960cf2b417764b5b03a1
+  checksum: 87a6d21b0d4a33b8c611d3bb8543d02b813c0ebfce014213ef31849b5c1439005644f19ad1593ec89815f6101355f468c9a02c251d09aa03f6fddd17e23c4be4
   languageName: node
   linkType: hard
 
@@ -19481,6 +20161,18 @@ __metadata:
   languageName: node
   linkType: hard
 
+"stylehacks@npm:^5.0.3":
+  version: 5.0.3
+  resolution: "stylehacks@npm:5.0.3"
+  dependencies:
+    browserslist: ^4.16.6
+    postcss-selector-parser: ^6.0.4
+  peerDependencies:
+    postcss: ^8.2.15
+  checksum: 65242e9b439154b853f98aa97a10645c796b7a8ed6e56d7ddca9fb257d77ab1579f9bd8d5a34a47cfb76f6519b9c0fbc608ada12e769426da6d9d83e32fa6a0f
+  languageName: node
+  linkType: hard
+
 "supports-color@npm:^0.2.0":
   version: 0.2.0
   resolution: "supports-color@npm:0.2.0"
@@ -19714,7 +20406,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"terser-webpack-plugin@npm:^5.1.3, terser-webpack-plugin@npm:^5.2.4":
+"terser-webpack-plugin@npm:^5.1.3":
   version: 5.3.0
   resolution: "terser-webpack-plugin@npm:5.3.0"
   dependencies:
@@ -19736,6 +20428,28 @@ __metadata:
   languageName: node
   linkType: hard
 
+"terser-webpack-plugin@npm:^5.3.1":
+  version: 5.3.1
+  resolution: "terser-webpack-plugin@npm:5.3.1"
+  dependencies:
+    jest-worker: ^27.4.5
+    schema-utils: ^3.1.1
+    serialize-javascript: ^6.0.0
+    source-map: ^0.6.1
+    terser: ^5.7.2
+  peerDependencies:
+    webpack: ^5.1.0
+  peerDependenciesMeta:
+    "@swc/core":
+      optional: true
+    esbuild:
+      optional: true
+    uglify-js:
+      optional: true
+  checksum: 1b808fd4f58ce0b532baacc50b9a850fc69ce0077a0e9e5076d4156c52fab3d40b02d5d9148a3eba64630cf7f40057de54f6a5a87fac1849b1f11d6bfdb42072
+  languageName: node
+  linkType: hard
+
 "terser@npm:^5.0.0, terser@npm:^5.7.2":
   version: 5.9.0
   resolution: "terser@npm:5.9.0"
@@ -19746,6 +20460,20 @@ __metadata:
   bin:
     terser: bin/terser
   checksum: 11c1246b1991015a8881742878af779e3863fad42f626ffda957dbf28c94bf51e7994cffb9ffbec86ff3c23ab45ffa6d79d453c15e664306e35fc7b2c4eee5f4
+  languageName: node
+  linkType: hard
+
+"terser@npm:^5.10.0":
+  version: 5.11.0
+  resolution: "terser@npm:5.11.0"
+  dependencies:
+    acorn: ^8.5.0
+    commander: ^2.20.0
+    source-map: ~0.7.2
+    source-map-support: ~0.5.20
+  bin:
+    terser: bin/terser
+  checksum: cc72b7a0e87421b5a6ef3f8a3c86ef251f6e7f8d6327b83c63045b8991a041cc4a42ea64e07701128e1786489902c8c44b5904056b0f12ceedb52924d493db04
   languageName: node
   linkType: hard
 
@@ -20215,13 +20943,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"tslib@npm:~2.1.0":
-  version: 2.1.0
-  resolution: "tslib@npm:2.1.0"
-  checksum: aa189c8179de0427b0906da30926fd53c59d96ec239dff87d6e6bc831f608df0cbd6f77c61dabc074408bd0aa0b9ae4ec35cb2c15f729e32f37274db5730cb78
-  languageName: node
-  linkType: hard
-
 "tsutils@npm:^3.21.0":
   version: 3.21.0
   resolution: "tsutils@npm:3.21.0"
@@ -20583,15 +21304,6 @@ typescript@^3.9.7:
   dependencies:
     unist-util-visit: ^2.0.0
   checksum: 4149294969f1a78a367b5d03eb0a138aa8320a39e1b15686647a2bec5945af3df27f2936a1e9752ecbb4a82dc23bd86f7e5a0ee048e5eeaedc2deb9237872795
-  languageName: node
-  linkType: hard
-
-"unist-util-remove@npm:2.0.0":
-  version: 2.0.0
-  resolution: "unist-util-remove@npm:2.0.0"
-  dependencies:
-    unist-util-is: ^4.0.0
-  checksum: 0e0bddf890e5de2eed6cd2dc5178f70ff5ff497e60877f9e4242b87418d24f272a684c3fb200c810f032e6bc9847bf0b40e3aefb3e8fde1059f1b34d3991adc9
   languageName: node
   linkType: hard
 
@@ -21048,18 +21760,18 @@ typescript@^3.9.7:
   languageName: node
   linkType: hard
 
-"wait-on@npm:^6.0.0":
-  version: 6.0.0
-  resolution: "wait-on@npm:6.0.0"
+"wait-on@npm:^6.0.1":
+  version: 6.0.1
+  resolution: "wait-on@npm:6.0.1"
   dependencies:
-    axios: ^0.21.1
-    joi: ^17.4.0
+    axios: ^0.25.0
+    joi: ^17.6.0
     lodash: ^4.17.21
     minimist: ^1.2.5
-    rxjs: ^7.1.0
+    rxjs: ^7.5.4
   bin:
     wait-on: bin/wait-on
-  checksum: 6ae7bd2a933715c3b2f1c49f033d97c576b2c6a0257420d4c83964d2846c3967bfce33bc9af9a1a631ef38dfa6185be03cef57d2867c8c30c523278f964ac9e3
+  checksum: e4d62aa4145d99fe34747ccf7506d4b4d6e60dd677c0eb18a51e316d38116ace2d194e4b22a9eb7b767b0282f39878ddcc4ae9440dcb0c005c9150668747cf5b
   languageName: node
   linkType: hard
 
@@ -21148,7 +21860,7 @@ typescript@^3.9.7:
   languageName: node
   linkType: hard
 
-"webpack-bundle-analyzer@npm:^4.4.2":
+"webpack-bundle-analyzer@npm:^4.5.0":
   version: 4.5.0
   resolution: "webpack-bundle-analyzer@npm:4.5.0"
   dependencies:
@@ -21182,7 +21894,7 @@ typescript@^3.9.7:
   languageName: node
   linkType: hard
 
-"webpack-dev-server@npm:^4.7.1":
+"webpack-dev-server@npm:^4.7.4":
   version: 4.7.4
   resolution: "webpack-dev-server@npm:4.7.4"
   dependencies:
@@ -21237,7 +21949,7 @@ typescript@^3.9.7:
   languageName: node
   linkType: hard
 
-"webpack-sources@npm:^1.1.0, webpack-sources@npm:^1.4.3":
+"webpack-sources@npm:^1.4.3":
   version: 1.4.3
   resolution: "webpack-sources@npm:1.4.3"
   dependencies:
@@ -21254,7 +21966,14 @@ typescript@^3.9.7:
   languageName: node
   linkType: hard
 
-"webpack@npm:^5.37.0, webpack@npm:^5.61.0":
+"webpack-sources@npm:^3.2.3":
+  version: 3.2.3
+  resolution: "webpack-sources@npm:3.2.3"
+  checksum: 989e401b9fe3536529e2a99dac8c1bdc50e3a0a2c8669cbafad31271eadd994bc9405f88a3039cd2e29db5e6d9d0926ceb7a1a4e7409ece021fe79c37d9c4607
+  languageName: node
+  linkType: hard
+
+"webpack@npm:^5.37.0":
   version: 5.65.0
   resolution: "webpack@npm:5.65.0"
   dependencies:
@@ -21288,6 +22007,43 @@ typescript@^3.9.7:
   bin:
     webpack: bin/webpack.js
   checksum: 221ab8ccd440cb678269e86689704bbef81cf41393eb266625873e30c6980ffaa055bb1a7d14bf9fc0f5a2e6f03d15d068cbb995bc876757c01a4ca27fd2870c
+  languageName: node
+  linkType: hard
+
+"webpack@npm:^5.69.1":
+  version: 5.69.1
+  resolution: "webpack@npm:5.69.1"
+  dependencies:
+    "@types/eslint-scope": ^3.7.3
+    "@types/estree": ^0.0.51
+    "@webassemblyjs/ast": 1.11.1
+    "@webassemblyjs/wasm-edit": 1.11.1
+    "@webassemblyjs/wasm-parser": 1.11.1
+    acorn: ^8.4.1
+    acorn-import-assertions: ^1.7.6
+    browserslist: ^4.14.5
+    chrome-trace-event: ^1.0.2
+    enhanced-resolve: ^5.8.3
+    es-module-lexer: ^0.9.0
+    eslint-scope: 5.1.1
+    events: ^3.2.0
+    glob-to-regexp: ^0.4.1
+    graceful-fs: ^4.2.9
+    json-parse-better-errors: ^1.0.2
+    loader-runner: ^4.2.0
+    mime-types: ^2.1.27
+    neo-async: ^2.6.2
+    schema-utils: ^3.1.0
+    tapable: ^2.1.1
+    terser-webpack-plugin: ^5.1.3
+    watchpack: ^2.3.1
+    webpack-sources: ^3.2.3
+  peerDependenciesMeta:
+    webpack-cli:
+      optional: true
+  bin:
+    webpack: bin/webpack.js
+  checksum: 490a6e9e4cd9d0ed3b6c7ca08015da2628919fda8fcf9c36f0f6c0e3ad71eaaaf4b0d12753109f22a4faf79fe9a9063552d9708e0ee2352cf8568433b8e296a7
   languageName: node
   linkType: hard
 
@@ -21417,6 +22173,15 @@ typescript@^3.9.7:
   dependencies:
     string-width: ^4.0.0
   checksum: 03db6c9d0af9329c37d74378ff1d91972b12553c7d72a6f4e8525fe61563fa7adb0b9d6e8d546b7e059688712ea874edd5ded475999abdeedf708de9849310e0
+  languageName: node
+  linkType: hard
+
+"widest-line@npm:^4.0.1":
+  version: 4.0.1
+  resolution: "widest-line@npm:4.0.1"
+  dependencies:
+    string-width: ^5.0.1
+  checksum: 64c48cf27171221be5f86fc54b94dd29879165bdff1a7aa92dde723d9a8c99fb108312768a5d62c8c2b80b701fa27bbd36a1ddc58367585cd45c0db7920a0cba
   languageName: node
   linkType: hard
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -2482,19 +2482,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@docusaurus/types@npm:2.0.0-beta.ff31de0ff":
-  version: 2.0.0-beta.ff31de0ff
-  resolution: "@docusaurus/types@npm:2.0.0-beta.ff31de0ff"
-  dependencies:
-    commander: ^5.1.0
-    joi: ^17.4.0
-    querystring: 0.2.0
-    webpack: ^5.37.0
-    webpack-merge: ^5.7.3
-  checksum: 48458c02c953a07acc011f3d99734ff8fdd4b0a9936f43a325309b8f8af21a0d67727d84ae37ed99cfec5c69de2508b02efa0a16dce93c0fc727cde8848d229e
-  languageName: node
-  linkType: hard
-
 "@docusaurus/utils-common@npm:2.0.0-beta.16":
   version: 2.0.0-beta.16
   resolution: "@docusaurus/utils-common@npm:2.0.0-beta.16"
@@ -2504,7 +2491,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@docusaurus/utils-validation@npm:2.0.0-beta.16":
+"@docusaurus/utils-validation@npm:2.0.0-beta.16, @docusaurus/utils-validation@npm:^2.0.0-beta.4":
   version: 2.0.0-beta.16
   resolution: "@docusaurus/utils-validation@npm:2.0.0-beta.16"
   dependencies:
@@ -2516,19 +2503,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@docusaurus/utils-validation@npm:^2.0.0-beta.4":
-  version: 2.0.0-beta.ff31de0ff
-  resolution: "@docusaurus/utils-validation@npm:2.0.0-beta.ff31de0ff"
-  dependencies:
-    "@docusaurus/utils": 2.0.0-beta.ff31de0ff
-    chalk: ^4.1.1
-    joi: ^17.4.0
-    tslib: ^2.1.0
-  checksum: b9edad2b0ca8986bc8ce911c4bc2df5e60ecb32b533443e16441f97e52aa278f6291104bf86668752887184e53e1b348ea61d6d73f16c2289766b433f1459bab
-  languageName: node
-  linkType: hard
-
-"@docusaurus/utils@npm:2.0.0-beta.16":
+"@docusaurus/utils@npm:2.0.0-beta.16, @docusaurus/utils@npm:^2.0.0-beta.4":
   version: 2.0.0-beta.16
   resolution: "@docusaurus/utils@npm:2.0.0-beta.16"
   dependencies:
@@ -2548,23 +2523,6 @@ __metadata:
     url-loader: ^4.1.1
     webpack: ^5.69.1
   checksum: e9b52823ca952b654932870b4a55fae2428669a9fa484e92a6cd8de54709543fd48589cb6d2d2c463b3455d275103cd54053c6c04e79296616f7d3c805773029
-  languageName: node
-  linkType: hard
-
-"@docusaurus/utils@npm:2.0.0-beta.ff31de0ff, @docusaurus/utils@npm:^2.0.0-beta.4":
-  version: 2.0.0-beta.ff31de0ff
-  resolution: "@docusaurus/utils@npm:2.0.0-beta.ff31de0ff"
-  dependencies:
-    "@docusaurus/types": 2.0.0-beta.ff31de0ff
-    "@types/github-slugger": ^1.3.0
-    chalk: ^4.1.1
-    escape-string-regexp: ^4.0.0
-    fs-extra: ^10.0.0
-    gray-matter: ^4.0.3
-    lodash: ^4.17.20
-    resolve-pathname: ^3.0.0
-    tslib: ^2.2.0
-  checksum: 0aad6e43ba9d72da72d7b494e5792845b9c9fe7c9cefcae13e51717f4f576fd87815dd05df880e7f9d235af883ade0162c1b1083c41290aae7022f1eef4ee2c4
   languageName: node
   linkType: hard
 
@@ -3750,15 +3708,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@sideway/address@npm:^4.1.0":
-  version: 4.1.2
-  resolution: "@sideway/address@npm:4.1.2"
-  dependencies:
-    "@hapi/hoek": ^9.0.0
-  checksum: 1e4910f7b3205347f78e698923dd7e0bb400c9e9e9bdd4a059edb6d2e32a540b426aba4652d095ea299fb75019d87883251dd9b96b350c00a35454bcdfa5f9f5
-  languageName: node
-  linkType: hard
-
 "@sideway/address@npm:^4.1.3":
   version: 4.1.3
   resolution: "@sideway/address@npm:4.1.3"
@@ -4227,16 +4176,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@types/eslint-scope@npm:^3.7.0":
-  version: 3.7.1
-  resolution: "@types/eslint-scope@npm:3.7.1"
-  dependencies:
-    "@types/eslint": "*"
-    "@types/estree": "*"
-  checksum: 4271c9adad19ad8a1d23062d9020468a51c7f81594b12b8e68f7d460c09e14d57cae3e82b077c402766369c0c17e2de72da72c405fa465d18a46c0b14ce92530
-  languageName: node
-  linkType: hard
-
 "@types/eslint-scope@npm:^3.7.3":
   version: 3.7.3
   resolution: "@types/eslint-scope@npm:3.7.3"
@@ -4257,7 +4196,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@types/estree@npm:*, @types/estree@npm:^0.0.50":
+"@types/estree@npm:*":
   version: 0.0.50
   resolution: "@types/estree@npm:0.0.50"
   checksum: 9a2b6a4a8c117f34d08fbda5e8f69b1dfb109f7d149b60b00fd7a9fb6ac545c078bc590aa4ec2f0a256d680cf72c88b3b28b60c326ee38a7bc8ee1ee95624922
@@ -4298,13 +4237,6 @@ __metadata:
     "@types/qs": "*"
     "@types/serve-static": "*"
   checksum: 12a2a0e6c4b993fc0854bec665906788aea0d8ee4392389d7a98a5de1eefdd33c9e1e40a91f3afd274011119c506f7b4126acb97fae62ae20b654974d44cba12
-  languageName: node
-  linkType: hard
-
-"@types/github-slugger@npm:^1.3.0":
-  version: 1.3.0
-  resolution: "@types/github-slugger@npm:1.3.0"
-  checksum: 6561f26814d7c6bf619b1abfba07930ddc2f71e1e1d58a03c20852fd4086ec17f8ee98a44a8ac77ba917c0ff7052cd3fe74071fba59bd526dff8a3a980e2e528
   languageName: node
   linkType: hard
 
@@ -6804,7 +6736,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"chalk@npm:^4.0.0, chalk@npm:^4.1.0, chalk@npm:^4.1.1, chalk@npm:^4.1.2":
+"chalk@npm:^4.0.0, chalk@npm:^4.1.0, chalk@npm:^4.1.2":
   version: 4.1.2
   resolution: "chalk@npm:4.1.2"
   dependencies:
@@ -13349,19 +13281,6 @@ __metadata:
   bin:
     jest: bin/jest.js
   checksum: 96f1d69042b3c6dfc695f2a4e4b0db38af6fb78582ad1a02beaa57cfcd77cbd31567d7d865c1c85709b7c3e176eefa3b2035ffecd646005f15d8ef528eccf205
-  languageName: node
-  linkType: hard
-
-"joi@npm:^17.4.0":
-  version: 17.4.2
-  resolution: "joi@npm:17.4.2"
-  dependencies:
-    "@hapi/hoek": ^9.0.0
-    "@hapi/topo": ^5.0.0
-    "@sideway/address": ^4.1.0
-    "@sideway/formula": ^3.0.0
-    "@sideway/pinpoint": ^2.0.0
-  checksum: 977ada1f9d38c2762689b61cec1272176968ccea731a16b71713ebaa067f140460e0b6f7eccff6fc12206fddce22e7f4ed74724651bc1b24b1e26d43280633d0
   languageName: node
   linkType: hard
 
@@ -21939,7 +21858,7 @@ typescript@^3.9.7:
   languageName: node
   linkType: hard
 
-"webpack-merge@npm:^5.7.3, webpack-merge@npm:^5.8.0":
+"webpack-merge@npm:^5.8.0":
   version: 5.8.0
   resolution: "webpack-merge@npm:5.8.0"
   dependencies:
@@ -21959,54 +21878,10 @@ typescript@^3.9.7:
   languageName: node
   linkType: hard
 
-"webpack-sources@npm:^3.2.2":
-  version: 3.2.2
-  resolution: "webpack-sources@npm:3.2.2"
-  checksum: cc81f1f1bfd1c25c7a565598850294b515bcccf7974d0249b4a0c8c607307866ce3f9e8cdef1c74d5facfb0d993944c499cfd4b7c8f52d01359b6671cc5823d4
-  languageName: node
-  linkType: hard
-
 "webpack-sources@npm:^3.2.3":
   version: 3.2.3
   resolution: "webpack-sources@npm:3.2.3"
   checksum: 989e401b9fe3536529e2a99dac8c1bdc50e3a0a2c8669cbafad31271eadd994bc9405f88a3039cd2e29db5e6d9d0926ceb7a1a4e7409ece021fe79c37d9c4607
-  languageName: node
-  linkType: hard
-
-"webpack@npm:^5.37.0":
-  version: 5.65.0
-  resolution: "webpack@npm:5.65.0"
-  dependencies:
-    "@types/eslint-scope": ^3.7.0
-    "@types/estree": ^0.0.50
-    "@webassemblyjs/ast": 1.11.1
-    "@webassemblyjs/wasm-edit": 1.11.1
-    "@webassemblyjs/wasm-parser": 1.11.1
-    acorn: ^8.4.1
-    acorn-import-assertions: ^1.7.6
-    browserslist: ^4.14.5
-    chrome-trace-event: ^1.0.2
-    enhanced-resolve: ^5.8.3
-    es-module-lexer: ^0.9.0
-    eslint-scope: 5.1.1
-    events: ^3.2.0
-    glob-to-regexp: ^0.4.1
-    graceful-fs: ^4.2.4
-    json-parse-better-errors: ^1.0.2
-    loader-runner: ^4.2.0
-    mime-types: ^2.1.27
-    neo-async: ^2.6.2
-    schema-utils: ^3.1.0
-    tapable: ^2.1.1
-    terser-webpack-plugin: ^5.1.3
-    watchpack: ^2.3.1
-    webpack-sources: ^3.2.2
-  peerDependenciesMeta:
-    webpack-cli:
-      optional: true
-  bin:
-    webpack: bin/webpack.js
-  checksum: 221ab8ccd440cb678269e86689704bbef81cf41393eb266625873e30c6980ffaa055bb1a7d14bf9fc0f5a2e6f03d15d068cbb995bc876757c01a4ca27fd2870c
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
This PR updates Docusaurus packages to [v2.0.0-beta.16](https://github.com/facebook/docusaurus/releases/tag/v2.0.0-beta.16).