### PR TITLE
Pin benchmark chalk dependency to pre-ESM version

### DIFF
--- a/packages/benchmark/package.json
+++ b/packages/benchmark/package.json
@@ -12,7 +12,7 @@
   },
   "dependencies": {
     "benchmark": "^2.1.4",
-    "chalk": "^5.0.0",
+    "chalk": "^4.1.2",
     "mobx": "^6.4.1",
     "mobx-keystone": "workspace:packages/lib",
     "mobx-state-tree": "^5.1.3",

--- a/yarn.lock
+++ b/yarn.lock
@@ -6131,7 +6131,7 @@ __metadata:
   dependencies:
     "@types/benchmark": ^2.1.1
     benchmark: ^2.1.4
-    chalk: ^5.0.0
+    chalk: ^4.1.2
     cross-env: ^7.0.3
     mobx: ^6.4.1
     mobx-keystone: "workspace:packages/lib"


### PR DESCRIPTION
The benchmark was failing to compile because chalk v5.0.0 is ESM only which the build system is not yet ok with. This reverts the dependency bump back to a non ESM version which makes the benchmarks run again.