### PR TITLE
update Babel decorator plugin config

### DIFF
--- a/packages/site/babel.config.js
+++ b/packages/site/babel.config.js
@@ -1,4 +1,4 @@
 module.exports = {
   presets: [require.resolve("@docusaurus/core/lib/babel/preset")],
-  plugins: [[`@babel/plugin-proposal-decorators`, { legacy: true }]],
+  plugins: [[`@babel/plugin-proposal-decorators`, { version: "legacy" }]],
 }


### PR DESCRIPTION
Use `version: "legacy"` instead of the deprecated `legacy: true` config in the docs config.