### PR TITLE
update compiler configs and docs

### DIFF
--- a/packages/lib/babel.config.js
+++ b/packages/lib/babel.config.js
@@ -1,5 +1,3 @@
-const { mobxVersion } = require("./env")
-
 module.exports = {
   presets: [
     ["@babel/preset-env", { targets: { node: "current" } }],
@@ -7,6 +5,6 @@ module.exports = {
   ],
   plugins: [
     ["@babel/plugin-proposal-decorators", { version: "legacy" }],
-    ["@babel/plugin-proposal-class-properties", { loose: mobxVersion <= 5 }],
+    ["@babel/plugin-proposal-class-properties"],
   ],
 }

--- a/packages/lib/jest.config.js
+++ b/packages/lib/jest.config.js
@@ -1,18 +1,11 @@
 const { mobxVersion, compiler } = require("./env")
 
-const tsconfigFiles = {
-  6: "tsconfig.json",
-  5: "tsconfig.mobx5.json",
-  4: "tsconfig.mobx4.json",
-}
-
 const mobxModuleNames = {
   6: "mobx",
   5: "mobx-v5",
   4: "mobx-v4",
 }
 
-const tsconfigFile = tsconfigFiles[mobxVersion]
 const mobxModuleName = mobxModuleNames[mobxVersion]
 
 const config = {
@@ -29,7 +22,7 @@ switch (compiler) {
       testEnvironment: "node",
       globals: {
         "ts-jest": {
-          tsconfig: `./test/${tsconfigFile}`,
+          tsconfig: "./test/tsconfig.json",
         },
       },
     })

--- a/packages/lib/swc.config.js
+++ b/packages/lib/swc.config.js
@@ -2,14 +2,11 @@
 // loading it in `jest.config.js` manually, so not a problem.
 // https://github.com/swc-project/swc/issues/1547
 
-const { mobxVersion } = require("./env")
-
 module.exports = {
   jsc: {
     parser: {
       syntax: "typescript",
       decorators: true,
     },
-    loose: mobxVersion <= 5,
   },
 }

--- a/packages/lib/test/tsconfig.mobx4.json
+++ b/packages/lib/test/tsconfig.mobx4.json
@@ -1,6 +1,0 @@
-{
-  "extends": "./tsconfig.json",
-  "compilerOptions": {
-    "useDefineForClassFields": false
-  }
-}

--- a/packages/lib/test/tsconfig.mobx5.json
+++ b/packages/lib/test/tsconfig.mobx5.json
@@ -1,4 +1,0 @@
-{
-  "extends": "./tsconfig.json",
-  "compilerOptions": {}
-}

--- a/packages/site/docs/installation.mdx
+++ b/packages/site/docs/installation.mdx
@@ -47,10 +47,7 @@ This library uses JavaScript decorators and class properties which are supported
   "compilerOptions": {
     // ...
     "experimentalDecorators": true,
-    // MobX 5/6
     "useDefineForClassFields": true
-    // MobX 4
-    "useDefineForClassFields": false
   }
 }
 ```
@@ -67,10 +64,7 @@ This library uses JavaScript decorators and class properties which are supported
   ],
   "plugins": [
     ["@babel/plugin-proposal-decorators", { "version": "legacy" }],
-    // MobX 5/6
     ["@babel/plugin-proposal-class-properties"]
-    // MobX 4
-    ["@babel/plugin-proposal-class-properties", { "loose": true }]
   ]
 }
 ```
@@ -89,11 +83,7 @@ This library uses JavaScript decorators and class properties which are supported
       // Optional if you use TypeScript
       // Required if you use JavaScript
       "legacyDecorator": true
-    },
-    // MobX 5/6
-    "loose": false
-    // MobX 4
-    "loose": true
+    }
   }
 }
 ```


### PR DESCRIPTION
It seems using different compiler settings for MobX 4 and 5/6 isn't necessary. Do you think this is generally valid? At least the test suite passes.