### PR TITLE
remove redundant docs link

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,7 +80,3 @@ If you are using TypeScript, then version >= 4.2.0 is recommended, though it _mi
 > `npm install mobx-keystone`
 
 > `yarn add mobx-keystone`
-
-## Full documentation
-
-Full documentation can be found on [mobx-keystone.js.org](https://mobx-keystone.js.org)

--- a/README.md
+++ b/README.md
@@ -28,6 +28,10 @@
   </a>
 </p>
 
+> ### Full documentation can be found on the site:
+>
+> ## [mobx-keystone.js.org](https://mobx-keystone.js.org)
+
 ## Introduction
 
 `mobx-keystone` is a state container that combines the _simplicity and ease of mutable data_ with the _traceability of immutable data_ and the _reactiveness and performance of observable data_, all with a fully compatible TypeScript syntax.

--- a/README.md
+++ b/README.md
@@ -28,10 +28,6 @@
   </a>
 </p>
 
-> ### Full documentation can be found on the site:
->
-> ## [mobx-keystone.js.org](https://mobx-keystone.js.org)
-
 ## Introduction
 
 `mobx-keystone` is a state container that combines the _simplicity and ease of mutable data_ with the _traceability of immutable data_ and the _reactiveness and performance of observable data_, all with a fully compatible TypeScript syntax.


### PR DESCRIPTION
Totally subjective, but I think the reference to the docs is a bit redundant. There's this one, there's one at the bottom of the README, and there's the link in the GitHub project's "About" section in the top-right of the landing page. I think the README looks a bit cleaner without this one. But I don't insist on its removal if you feel differently. :wink: 