### PR TITLE
use @typeparam tag consistently

### DIFF
--- a/packages/lib/src/redux/redux.ts
+++ b/packages/lib/src/redux/redux.ts
@@ -54,7 +54,7 @@ export interface ReduxMiddleware<T> {
 /**
  * Generates a redux compatible store out of a mobx-keystone object.
  *
- * @template T Object type.
+ * @typeparam T Object type.
  * @param target Root object.
  * @param middlewares Optional list of redux middlewares.
  * @returns A redux compatible store.

--- a/packages/lib/src/types/primitiveBased/enum.ts
+++ b/packages/lib/src/types/primitiveBased/enum.ts
@@ -56,7 +56,7 @@ export type EnumValues<E extends EnumLike> = E extends Record<
  * const colorType = types.enum(Color)
  * ```
  *
- * @template E Enum type.
+ * @typeparam E Enum type.
  * @param enumObject
  * @returns
  */

--- a/packages/lib/src/types/utility/refinement.ts
+++ b/packages/lib/src/types/utility/refinement.ts
@@ -28,7 +28,7 @@ import { TypeCheckError } from "../TypeCheckError"
  * })
  * ```
  *
- * @template T Base type.
+ * @typeparam T Base type.
  * @param baseType Base type.
  * @param checkFn Function that will receive the data (if it passes the base type
  * check) and return null or false if there were no errors or either a TypeCheckError instance or


### PR DESCRIPTION
Both `@typeparam` and `@template` are fine, but I think it's good to stick with one and be consistent. In almost all cases, `@typeparam` was used, so that's what I went for.