### PR TITLE
use @typeparam tag instead of unsupported @typename

### DIFF
--- a/packages/lib/src/types/typeCheck.ts
+++ b/packages/lib/src/types/typeCheck.ts
@@ -5,7 +5,7 @@ import type { TypeCheckError } from "./TypeCheckError"
 /**
  * Checks if a value conforms to a given type.
  *
- * @typename T Type.
+ * @typeparam T Type.
  * @param type Type to check for.
  * @param value Value to check.
  * @returns A TypeError if the check fails or null if no error.


### PR DESCRIPTION
`@typename` is not recognized by TypeDoc.