### PR TITLE
factor out internal identityFn to utils

### DIFF
--- a/packages/lib/src/snapshot/getSnapshot.ts
+++ b/packages/lib/src/snapshot/getSnapshot.ts
@@ -1,15 +1,13 @@
 import { assertTweakedObject } from "../tweaker/core"
 import { resolveTypeChecker } from "../types/resolveTypeChecker"
 import { AnyType, TypeToData } from "../types/schemas"
-import { failure, isPrimitive } from "../utils"
+import { failure, identityFn, isPrimitive } from "../utils"
 import {
   freezeInternalSnapshot,
   getInternalSnapshot,
   reportInternalSnapshotObserved,
 } from "./internal"
 import type { SnapshotOutOf } from "./SnapshotOf"
-
-const identityFn = (x: any) => x
 
 /**
  * Retrieves an immutable snapshot for a data structure.
@@ -37,7 +35,7 @@ export function getSnapshot<T extends AnyType>(
 export function getSnapshot<T>(nodeOrPrimitive: T): SnapshotOutOf<T>
 
 export function getSnapshot(arg1: any, arg2?: any): any {
-  let toSnapshotProcessor = identityFn
+  let toSnapshotProcessor = identityFn as (sn: any) => unknown
   let nodeOrPrimitive: any
 
   if (arguments.length >= 2) {

--- a/packages/lib/src/types/primitiveBased/primitives.ts
+++ b/packages/lib/src/types/primitiveBased/primitives.ts
@@ -1,11 +1,9 @@
-import { assertIsPrimitive } from "../../utils"
+import { assertIsPrimitive, identityFn } from "../../utils"
 import type { PrimitiveValue } from "../../utils/types"
 import { registerStandardTypeResolver } from "../resolveTypeChecker"
 import type { AnyStandardType, IdentityType } from "../schemas"
 import { TypeChecker, TypeCheckerBaseType, TypeInfo, TypeInfoGen } from "../TypeChecker"
 import { TypeCheckError } from "../TypeCheckError"
-
-const identityFn = <T>(x: T): T => x
 
 /**
  * A type that represents a certain value of a primitive (for example an *exact* number or string).

--- a/packages/lib/src/types/utility/unchecked.ts
+++ b/packages/lib/src/types/utility/unchecked.ts
@@ -1,7 +1,6 @@
+import { identityFn } from "../../utils"
 import type { IdentityType } from "../schemas"
 import { TypeChecker, TypeCheckerBaseType, TypeInfo } from "../TypeChecker"
-
-const identityFn = (x: any) => x
 
 const unchecked: IdentityType<any> = new TypeChecker(
   TypeCheckerBaseType.Any,

--- a/packages/lib/src/utils/index.ts
+++ b/packages/lib/src/utils/index.ts
@@ -376,6 +376,11 @@ export function lazy<A extends unknown[], R>(getter: (...args: A) => R): typeof 
 /**
  * @internal
  */
+export const identityFn = <T>(x: T): T => x
+
+/**
+ * @internal
+ */
 export const mobx6 = {
   // eslint-disable-next-line no-useless-concat
   makeObservable: (mobx as any)[


### PR DESCRIPTION
Just a minor refactoring. `identityFn` was defined in several places, so I factored it out into `utils/index.ts`. One type assertion is necessary in `getSnapshot(...)` to make it work though.