### PR TITLE
Issue #460 - add type.annotation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Change Log
 
+## 0.69.0
+
+- Added `types.annotation` to be able to annotate types.
+
 ## 0.68.6
 
 - Fixed `applySnapshot` generating no-op patches sometimes.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## 0.69.0
 
-- Added `types.annotation` to be able to annotate types.
+- Added `types.tag` to be able to annotate types.
 
 ## 0.68.6
 

--- a/apps/site/docs/runtimeTypeChecking.mdx
+++ b/apps/site/docs/runtimeTypeChecking.mdx
@@ -282,10 +282,9 @@ const sumModelType = types.refinement(types.model(Sum), (sum) => {
 })
 ```
 
-### `types.annotation<T>(baseType, annotation: T)`
+### `types.annotation<T>(baseType, annotation: T, typeName?: string)`
 
-Wraps a given type with annotation information. This allows you to associate arbitrary metadata with the
-type of a prop that you can then use at runtime against instances.
+Wraps a given type with annotation information. This allows you to associate arbitrary metadata with the type of a prop that you can then use at runtime against instances.
 
 ```ts
 const widthType = types.annotation(
@@ -293,11 +292,13 @@ const widthType = types.annotation(
   { displayName: "Width in inches", required: true },
   "dimension"
 )
+
 const heightType = types.annotation(
   types.number,
   { displayName: "Height in inches", required: true },
   "dimension"
 )
+
 @model("MyModel")
 class MyModel extends Model({
   width: tProp(widthType, 10),

--- a/apps/site/docs/runtimeTypeChecking.mdx
+++ b/apps/site/docs/runtimeTypeChecking.mdx
@@ -282,18 +282,18 @@ const sumModelType = types.refinement(types.model(Sum), (sum) => {
 })
 ```
 
-### `types.annotation<T>(baseType, annotation: T, typeName?: string)`
+### `types.tag<T>(baseType, tag: T, typeName?: string)`
 
-Wraps a given type with annotation information. This allows you to associate arbitrary metadata with the type of a prop that you can then use at runtime against instances.
+Wraps a given type with tag information. This allows you to associate arbitrary metadata with the type of a prop that you can then use at runtime against instances.
 
 ```ts
-const widthType = types.annotation(
+const widthType = types.tag(
   types.number,
   { displayName: "Width in inches", required: true },
   "dimension"
 )
 
-const heightType = types.annotation(
+const heightType = types.tag(
   types.number,
   { displayName: "Height in inches", required: true },
   "dimension"
@@ -308,10 +308,10 @@ class MyModel extends Model({
 const m = new MyModel({})
 const type = types.model<typeof Model>(m.constructor)
 const modelTypeInfo = getTypeInfo(type) as ModelTypeInfo
-const propTypeInfo = modelTypeInfo.props.width.typeInfo as AnnotationTypeInfo<{
+const propTypeInfo = modelTypeInfo.props.width.typeInfo as TagTypeInfo<{
   displayName: string
 }>
-const displayName = propTypeInfo.annotation.displayName
+const displayName = propTypeInfo.tag.displayName
 ```
 
 ### Syntactic sugar for optional primitives with a default value

--- a/apps/site/docs/runtimeTypeChecking.mdx
+++ b/apps/site/docs/runtimeTypeChecking.mdx
@@ -282,7 +282,7 @@ const sumModelType = types.refinement(types.model(Sum), (sum) => {
 })
 ```
 
-### types.annotation<T>(baseType, annotation: T)
+### `types.annotation<T>(baseType, annotation: T)`
 
 Wraps a given type with annotation information. This allows you to associate arbitrary metadata with the
 type of a prop that you can then use at runtime against instances.

--- a/apps/site/docs/runtimeTypeChecking.mdx
+++ b/apps/site/docs/runtimeTypeChecking.mdx
@@ -282,6 +282,37 @@ const sumModelType = types.refinement(types.model(Sum), (sum) => {
 })
 ```
 
+### types.annotation<T>(baseType, annotation: T)
+
+Wraps a given type with annotation information. This allows you to associate arbitrary metadata with the
+type of a prop that you can then use at runtime against instances.
+
+```ts
+const widthType = types.annotation(
+  types.number,
+  { displayName: "Width in inches", required: true },
+  "dimension"
+)
+const heightType = types.annotation(
+  types.number,
+  { displayName: "Height in inches", required: true },
+  "dimension"
+)
+@model("MyModel")
+class MyModel extends Model({
+  width: tProp(widthType, 10),
+  height: tProp(heightType, 10),
+}) {}
+
+const m = new MyModel({})
+const type = types.model<typeof Model>(m.constructor)
+const modelTypeInfo = getTypeInfo(type) as ModelTypeInfo
+const propTypeInfo = modelTypeInfo.props.width.typeInfo as AnnotationTypeInfo<{
+  displayName: string
+}>
+const displayName = propTypeInfo.annotation.displayName
+```
+
 ### Syntactic sugar for optional primitives with a default value
 
 You can also do `tProp(defaultValue: string | number | boolean)`, which is equivalent to `tProp(types.string|number|boolean, defaultValue)`.

--- a/packages/lib/src/types/types.ts
+++ b/packages/lib/src/types/types.ts
@@ -28,6 +28,7 @@ import {
 } from "./primitiveBased/primitives"
 import { typesInteger, typesNonEmptyString } from "./primitiveBased/refinedPrimitives"
 import type { AnyType } from "./schemas"
+import { typesAnnotation } from "./utility/annotation"
 import { typesMaybe, typesMaybeNull } from "./utility/maybe"
 import { OrTypeInfo, typesOr } from "./utility/or"
 import { RefinementTypeInfo, typesRefinement } from "./utility/refinement"
@@ -73,6 +74,7 @@ export const types = {
   ref: typesRef,
   frozen: typesFrozen,
   enum: typesEnum,
+  annotation: typesAnnotation,
   refinement: typesRefinement,
   integer: typesInteger,
   nonEmptyString: typesNonEmptyString,

--- a/packages/lib/src/types/types.ts
+++ b/packages/lib/src/types/types.ts
@@ -8,7 +8,7 @@ import {
   ObjectTypeInfo,
   ObjectTypeInfoProps,
   typesFrozen,
-  typesObject
+  typesObject,
 } from "./objectBased/object"
 import { ObjectMapTypeInfo, typesObjectMap } from "./objectBased/objectMap"
 import { RecordTypeInfo, typesRecord } from "./objectBased/record"
@@ -24,7 +24,7 @@ import {
   typesNull,
   typesNumber,
   typesString,
-  typesUndefined
+  typesUndefined,
 } from "./primitiveBased/primitives"
 import { typesInteger, typesNonEmptyString } from "./primitiveBased/refinedPrimitives"
 import type { AnyType } from "./schemas"

--- a/packages/lib/src/types/types.ts
+++ b/packages/lib/src/types/types.ts
@@ -8,7 +8,7 @@ import {
   ObjectTypeInfo,
   ObjectTypeInfoProps,
   typesFrozen,
-  typesObject,
+  typesObject
 } from "./objectBased/object"
 import { ObjectMapTypeInfo, typesObjectMap } from "./objectBased/objectMap"
 import { RecordTypeInfo, typesRecord } from "./objectBased/record"
@@ -24,11 +24,11 @@ import {
   typesNull,
   typesNumber,
   typesString,
-  typesUndefined,
+  typesUndefined
 } from "./primitiveBased/primitives"
 import { typesInteger, typesNonEmptyString } from "./primitiveBased/refinedPrimitives"
 import type { AnyType } from "./schemas"
-import { typesAnnotation } from "./utility/annotation"
+import { AnnotationTypeInfo, typesAnnotation } from "./utility/annotation"
 import { typesMaybe, typesMaybeNull } from "./utility/maybe"
 import { OrTypeInfo, typesOr } from "./utility/or"
 import { RefinementTypeInfo, typesRefinement } from "./utility/refinement"
@@ -43,6 +43,7 @@ export {
   StringTypeInfo,
   FrozenTypeInfo,
   ObjectMapTypeInfo,
+  AnnotationTypeInfo,
   RefinementTypeInfo,
   RecordTypeInfo,
   RefTypeInfo,

--- a/packages/lib/src/types/types.ts
+++ b/packages/lib/src/types/types.ts
@@ -28,10 +28,10 @@ import {
 } from "./primitiveBased/primitives"
 import { typesInteger, typesNonEmptyString } from "./primitiveBased/refinedPrimitives"
 import type { AnyType } from "./schemas"
-import { AnnotationTypeInfo, typesAnnotation } from "./utility/annotation"
 import { typesMaybe, typesMaybeNull } from "./utility/maybe"
 import { OrTypeInfo, typesOr } from "./utility/or"
 import { RefinementTypeInfo, typesRefinement } from "./utility/refinement"
+import { TagTypeInfo, typesTag } from "./utility/tag"
 import { typesUnchecked, UncheckedTypeInfo } from "./utility/unchecked"
 export { getTypeInfo } from "./getTypeInfo"
 export { TypeInfo } from "./TypeChecker"
@@ -43,7 +43,7 @@ export {
   StringTypeInfo,
   FrozenTypeInfo,
   ObjectMapTypeInfo,
-  AnnotationTypeInfo,
+  TagTypeInfo,
   RefinementTypeInfo,
   RecordTypeInfo,
   RefTypeInfo,
@@ -75,7 +75,7 @@ export const types = {
   ref: typesRef,
   frozen: typesFrozen,
   enum: typesEnum,
-  annotation: typesAnnotation,
+  tag: typesTag,
   refinement: typesRefinement,
   integer: typesInteger,
   nonEmptyString: typesNonEmptyString,

--- a/packages/lib/src/types/utility/annotation.ts
+++ b/packages/lib/src/types/utility/annotation.ts
@@ -1,7 +1,7 @@
 import { getTypeInfo } from "../getTypeInfo"
-import { resolveStandardType,resolveTypeChecker } from "../resolveTypeChecker"
-import type { AnyStandardType,AnyType } from "../schemas"
-import { lateTypeChecker,TypeChecker,TypeInfo,TypeInfoGen } from "../TypeChecker"
+import { resolveStandardType, resolveTypeChecker } from "../resolveTypeChecker"
+import type { AnyStandardType, AnyType } from "../schemas"
+import { lateTypeChecker, TypeChecker, TypeInfo, TypeInfoGen } from "../TypeChecker"
 
 /**
  * Wrap a given type with annotation information.

--- a/packages/lib/src/types/utility/annotation.ts
+++ b/packages/lib/src/types/utility/annotation.ts
@@ -13,6 +13,7 @@ import { lateTypeChecker, TypeChecker, TypeInfo, TypeInfoGen } from "../TypeChec
  * const widthType = types.annotation(types.number, { displayName: "Width in Inches", required: true }, "dimension")
  * const heightType = types.annotation(types.number, { displayName: "Height in Inches", required: true }, "dimension")
  * ```
+ *
  * These can then be accessed at runtime through inspection APIs, e.g.
  * ```
  * @model('MyModel')

--- a/packages/lib/src/types/utility/annotation.ts
+++ b/packages/lib/src/types/utility/annotation.ts
@@ -1,0 +1,83 @@
+import { getTypeInfo } from "../getTypeInfo"
+import { resolveStandardType,resolveTypeChecker } from "../resolveTypeChecker"
+import type { AnyStandardType,AnyType } from "../schemas"
+import { lateTypeChecker,TypeChecker,TypeInfo,TypeInfoGen } from "../TypeChecker"
+
+/**
+ * Wrap a given type with annotation information.
+ * This allows you to associate metadata with the type of a prop that
+ * you can use at runtime.
+ *
+ * Example:
+ * ```ts
+ * const widthType = types.annotation(types.number, { displayName: "Width in Inches", required: true }, "dimension")
+ * const heightType = types.annotation(types.number, { displayName: "Height in Inches", required: true }, "dimension")
+ * ```
+ * These can then be accessed at runtime through inspection APIs, e.g.
+ * ```
+ * @model('MyModel')
+ * class MyModel extends Model({
+ *   width: tProp(widthType, 10),
+ *   height: tProp(heightType, 10)
+ * }) {}
+ *
+ * const m = new MyModel({})
+ * const type = types.model<typeof Model>(m.constructor)
+ * const modelTypeInfo = getTypeInfo(type) as ModelTypeInfo
+ * const propTypeInfo = modelTypeInfo.props.width.typeInfo as AnnotationTypeInfo
+ * const displayName = propTypeInfo.displayName
+ * ```
+ * @typeparam T Base type.
+ * @param baseType Base type.
+ * @typeparam A Annotation object.
+ * @param annotation Abitrary object that can be queried at runtime.
+ * @returns
+ */
+export function typesAnnotation<T extends AnyType, A>(
+  baseType: T,
+  annotation: A,
+  typeName?: string
+): T {
+  const typeInfoGen: TypeInfoGen = (t) =>
+    new AnnotationTypeInfo(t, resolveStandardType(baseType), annotation, typeName)
+
+  return lateTypeChecker(() => {
+    const baseChecker = resolveTypeChecker(baseType)
+
+    const getTypeName = (...recursiveTypeCheckers: TypeChecker[]) => {
+      const baseTypeName = baseChecker.getTypeName(...recursiveTypeCheckers, baseChecker)
+      const annotatedName = typeName || "annotated"
+      return `${annotatedName}<${baseTypeName}>`
+    }
+
+    const thisTc: TypeChecker = new TypeChecker(
+      baseChecker.baseType,
+      baseChecker.check,
+      getTypeName,
+      typeInfoGen,
+      (sn) => baseChecker.snapshotType(sn),
+      (sn) => baseChecker.fromSnapshotProcessor(sn),
+      (sn) => baseChecker.toSnapshotProcessor(sn)
+    )
+
+    return thisTc
+  }, typeInfoGen) as any
+}
+
+/**
+ * `types.annotation` type info.
+ */
+export class AnnotationTypeInfo<A> extends TypeInfo {
+  get baseTypeInfo(): TypeInfo {
+    return getTypeInfo(this.baseType)
+  }
+
+  constructor(
+    thisType: AnyStandardType,
+    readonly baseType: AnyStandardType,
+    readonly annotation: A,
+    readonly typeName: string | undefined
+  ) {
+    super(thisType)
+  }
+}

--- a/packages/lib/src/types/utility/tag.ts
+++ b/packages/lib/src/types/utility/tag.ts
@@ -4,14 +4,14 @@ import type { AnyStandardType, AnyType } from "../schemas"
 import { lateTypeChecker, TypeChecker, TypeInfo, TypeInfoGen } from "../TypeChecker"
 
 /**
- * Wrap a given type with annotation information.
+ * Wrap a given type with tag information.
  * This allows you to associate metadata with the type of a prop that
  * you can use at runtime.
  *
  * Example:
  * ```ts
- * const widthType = types.annotation(types.number, { displayName: "Width in Inches", required: true }, "dimension")
- * const heightType = types.annotation(types.number, { displayName: "Height in Inches", required: true }, "dimension")
+ * const widthType = types.tag(types.number, { displayName: "Width in Inches", required: true }, "dimension")
+ * const heightType = types.tag(types.number, { displayName: "Height in Inches", required: true }, "dimension")
  * ```
  *
  * These can then be accessed at runtime through inspection APIs, e.g.
@@ -25,30 +25,26 @@ import { lateTypeChecker, TypeChecker, TypeInfo, TypeInfoGen } from "../TypeChec
  * const m = new MyModel({})
  * const type = types.model<typeof Model>(m.constructor)
  * const modelTypeInfo = getTypeInfo(type) as ModelTypeInfo
- * const propTypeInfo = modelTypeInfo.props.width.typeInfo as AnnotationTypeInfo
+ * const propTypeInfo = modelTypeInfo.props.width.typeInfo as TagTypeInfo
  * const displayName = propTypeInfo.displayName
  * ```
  * @typeparam T Base type.
  * @param baseType Base type.
- * @typeparam A Annotation object.
- * @param annotation Abitrary object that can be queried at runtime.
+ * @typeparam A Tag object.
+ * @param tag Abitrary object that can be queried at runtime.
  * @returns
  */
-export function typesAnnotation<T extends AnyType, A>(
-  baseType: T,
-  annotation: A,
-  typeName?: string
-): T {
+export function typesTag<T extends AnyType, A>(baseType: T, tag: A, typeName?: string): T {
   const typeInfoGen: TypeInfoGen = (t) =>
-    new AnnotationTypeInfo(t, resolveStandardType(baseType), annotation, typeName)
+    new TagTypeInfo(t, resolveStandardType(baseType), tag, typeName)
 
   return lateTypeChecker(() => {
     const baseChecker = resolveTypeChecker(baseType)
 
     const getTypeName = (...recursiveTypeCheckers: TypeChecker[]) => {
       const baseTypeName = baseChecker.getTypeName(...recursiveTypeCheckers, baseChecker)
-      const annotatedName = typeName || "annotated"
-      return `${annotatedName}<${baseTypeName}>`
+      const taggedName = typeName || "tagged"
+      return `${taggedName}<${baseTypeName}>`
     }
 
     const thisTc: TypeChecker = new TypeChecker(
@@ -66,9 +62,9 @@ export function typesAnnotation<T extends AnyType, A>(
 }
 
 /**
- * `types.annotation` type info.
+ * `types.tag` type info.
  */
-export class AnnotationTypeInfo<A> extends TypeInfo {
+export class TagTypeInfo<A> extends TypeInfo {
   get baseTypeInfo(): TypeInfo {
     return getTypeInfo(this.baseType)
   }
@@ -76,7 +72,7 @@ export class AnnotationTypeInfo<A> extends TypeInfo {
   constructor(
     thisType: AnyStandardType,
     readonly baseType: AnyStandardType,
-    readonly annotation: A,
+    readonly tag: A,
     readonly typeName: string | undefined
   ) {
     super(thisType)

--- a/packages/lib/test/types/typeChecking.test.ts
+++ b/packages/lib/test/types/typeChecking.test.ts
@@ -1297,18 +1297,21 @@ test("syntax sugar for primitives in tProp", () => {
   ss.setOr(5)
 })
 
-test("issue #460", () => {
+test("types.annotation", () => {
   const testDisplayName = "Test"
+  const annotationData = { displayName: testDisplayName }
+
   @model("M")
   class M extends Model({
-    p: tProp(types.annotation(types.string, { displayName: testDisplayName }), ""),
+    p: tProp(types.annotation(types.string, annotationData, "someTypeName"), ""),
   }) {}
 
   const m = new M({})
   const type = types.model<typeof Model>(m.constructor)
   const modelTypeInfo = getTypeInfo(type) as ModelTypeInfo
   const propTypeInfo = modelTypeInfo.props.p.typeInfo as AnnotationTypeInfo<{ displayName: string }>
-  expect(propTypeInfo.annotation.displayName).toEqual(testDisplayName)
+  expect(propTypeInfo.annotation).toBe(annotationData)
+  expect(propTypeInfo.typeName).toEqual("someTypeName")
 })
 
 test("issue #445", () => {

--- a/packages/lib/test/types/typeChecking.test.ts
+++ b/packages/lib/test/types/typeChecking.test.ts
@@ -2,7 +2,6 @@ import { reaction, toJS } from "mobx"
 import { assert, _ } from "spec.ts"
 import {
   actionTrackingMiddleware,
-  AnnotationTypeInfo,
   AnyModel,
   AnyType,
   ArraySet,
@@ -45,6 +44,7 @@ import {
   rootRef,
   setGlobalConfig,
   StringTypeInfo,
+  TagTypeInfo,
   tProp,
   TupleTypeInfo,
   typeCheck,
@@ -1297,20 +1297,20 @@ test("syntax sugar for primitives in tProp", () => {
   ss.setOr(5)
 })
 
-test("types.annotation", () => {
+test("types.tag", () => {
   const testDisplayName = "Test"
-  const annotationData = { displayName: testDisplayName }
+  const tagData = { displayName: testDisplayName }
 
   @model("M")
   class M extends Model({
-    p: tProp(types.annotation(types.string, annotationData, "someTypeName"), ""),
+    p: tProp(types.tag(types.string, tagData, "someTypeName"), ""),
   }) {}
 
   const m = new M({})
   const type = types.model<typeof Model>(m.constructor)
   const modelTypeInfo = getTypeInfo(type) as ModelTypeInfo
-  const propTypeInfo = modelTypeInfo.props.p.typeInfo as AnnotationTypeInfo<{ displayName: string }>
-  expect(propTypeInfo.annotation).toBe(annotationData)
+  const propTypeInfo = modelTypeInfo.props.p.typeInfo as TagTypeInfo<{ displayName: string }>
+  expect(propTypeInfo.tag).toBe(tagData)
   expect(propTypeInfo.typeName).toEqual("someTypeName")
 })
 

--- a/packages/lib/test/types/typeChecking.test.ts
+++ b/packages/lib/test/types/typeChecking.test.ts
@@ -2,6 +2,7 @@ import { reaction, toJS } from "mobx"
 import { assert, _ } from "spec.ts"
 import {
   actionTrackingMiddleware,
+  AnnotationTypeInfo,
   AnyModel,
   AnyType,
   ArraySet,
@@ -1294,6 +1295,20 @@ test("syntax sugar for primitives in tProp", () => {
     // expectTypeCheckFail(type, ss, ["or"], "string | number | boolean")
   }).toThrow(`snapshot '{}' does not match the following type: string | number | boolean`)
   ss.setOr(5)
+})
+
+test("issue #460", () => {
+  const testDisplayName = "Test"
+  @model("M")
+  class M extends Model({
+    p: tProp(types.annotation(types.string, { displayName: testDisplayName }), ""),
+  }) {}
+
+  const m = new M({})
+  const type = types.model<typeof Model>(m.constructor)
+  const modelTypeInfo = getTypeInfo(type) as ModelTypeInfo
+  const propTypeInfo = modelTypeInfo.props.p.typeInfo as AnnotationTypeInfo<{ displayName: string }>
+  expect(propTypeInfo.annotation.displayName).toEqual(testDisplayName)
 })
 
 test("issue #445", () => {


### PR DESCRIPTION
Implements a proposal for adding a new type, called type.annotation, that can wrap a prop's type to provide runtime access to metadata about the prop. See discussion [here]( https://github.com/xaviergonz/mobx-keystone/issues/460).