### PR TITLE
Fix: tag type wrapper check func captures wrong 'this'

### DIFF
--- a/packages/lib/src/types/utility/typesTag.ts
+++ b/packages/lib/src/types/utility/typesTag.ts
@@ -49,7 +49,7 @@ export function typesTag<T extends AnyType, A>(baseType: T, tag: A, typeName?: s
 
     const thisTc: TypeChecker = new TypeChecker(
       baseChecker.baseType,
-      baseChecker.check,
+      (data, path) => baseChecker.check(data, path),
       getTypeName,
       typeInfoGen,
       (sn) => baseChecker.snapshotType(sn),


### PR DESCRIPTION
Version 0.69.5 uncovered a bug in the `typesTag`: the baseChecker's check function was assigned directly rather than being wrapped within another function, which caused an endlessly recursive call to the check function from within itself because it captures `this` (i.e. `this.check()` invokes `_check()`, which is `this.check()`, which invokes `_check()`...).