### PR TITLE
fix computed tree with array of models

### DIFF
--- a/packages/lib/src/computedTree/computedTree.ts
+++ b/packages/lib/src/computedTree/computedTree.ts
@@ -78,7 +78,6 @@ export function computedTree(
     const oldTweakedValue = entry.tweakedValue
     tweak(oldTweakedValue, undefined)
     tryUntweak(oldTweakedValue)
-    tryUntweak(oldValue)
 
     const tweakedValue = tweakComputedTreeNode(newValue, this, propertyKey)
     entry.value = newValue

--- a/packages/lib/src/computedTree/computedTree.ts
+++ b/packages/lib/src/computedTree/computedTree.ts
@@ -75,7 +75,9 @@ export function computedTree(
       return entry.tweakedValue
     }
 
-    tweak(oldValue, undefined)
+    const oldTweakedValue = entry.tweakedValue
+    tweak(oldTweakedValue, undefined)
+    tryUntweak(oldTweakedValue)
     tryUntweak(oldValue)
 
     const tweakedValue = tweakComputedTreeNode(newValue, this, propertyKey)

--- a/packages/lib/test/computedTree/computedTree.test.ts
+++ b/packages/lib/test/computedTree/computedTree.test.ts
@@ -527,8 +527,12 @@ test("computed tree works with an array of models", () => {
   const r = new R({})
 
   r.setValue(10)
-  expect(r.arrayOfModels).toEqual([1, 2].map((i) => new M({ id: `${r.id}.model${i}`, value: 10 })))
+  expect(r.arrayOfModels.slice()).toEqual(
+    [1, 2].map((i) => new M({ id: `${r.id}.model${i}`, value: 10 }))
+  )
 
   r.setValue(20)
-  expect(r.arrayOfModels).toEqual([1, 2].map((i) => new M({ id: `${r.id}.model${i}`, value: 20 })))
+  expect(r.arrayOfModels.slice()).toEqual(
+    [1, 2].map((i) => new M({ id: `${r.id}.model${i}`, value: 20 }))
+  )
 })

--- a/packages/lib/test/computedTree/computedTree.test.ts
+++ b/packages/lib/test/computedTree/computedTree.test.ts
@@ -74,6 +74,11 @@ class R extends Model({
   }
 
   @computedTree
+  get arrayOfModels() {
+    return [1, 2].map((i) => new M({ id: `${this.id}.model${i}`, value: this.value }))
+  }
+
+  @computedTree
   get plainObject() {
     return { key: "value" }
   }
@@ -325,8 +330,9 @@ describe("tree traversal functions", () => {
     const r = new R({})
 
     const children = getChildrenObjects(r, { deep })
-    expect(children.size).toBe(3)
+    expect(children.size).toBe(deep ? 6 : 4)
     expect(children.has(r.array)).toBeTruthy()
+    expect(children.has(r.arrayOfModels)).toBeTruthy()
     expect(children.has(r.plainObject)).toBeTruthy()
     expect(children.has(r.model)).toBeTruthy()
   })
@@ -336,11 +342,46 @@ describe("tree traversal functions", () => {
     (mode) => {
       const r = new R({})
 
-      expect(walkTree(r, (node) => (isArray(node) ? node : undefined), mode)).toBe(r.array)
-      expect(walkTree(r, (node) => (isPlainObject(node) ? node : undefined), mode)).toBe(
-        r.plainObject
+      const nodes: unknown[] = []
+
+      walkTree(
+        r,
+        (node) => {
+          if (isArray(node)) {
+            nodes.push(node)
+          }
+        },
+        mode
       )
-      expect(walkTree(r, (node) => (node instanceof M ? node : undefined), mode)).toBe(r.model)
+      expect(nodes).toEqual([r.array, r.arrayOfModels])
+
+      // reset
+      nodes.length = 0
+
+      walkTree(
+        r,
+        (node) => {
+          if (isPlainObject(node)) {
+            nodes.push(node)
+          }
+        },
+        mode
+      )
+      expect(nodes).toEqual([r.plainObject])
+
+      // reset
+      nodes.length = 0
+
+      walkTree(
+        r,
+        (node) => {
+          if (node instanceof M) {
+            nodes.push(node)
+          }
+        },
+        mode
+      )
+      expect(nodes).toEqual([...r.arrayOfModels, r.model])
     }
   )
 })
@@ -480,4 +521,14 @@ test("computed tree is readonly", () => {
   expect(() => r.model.setValue(11)).toThrow(
     "tried to invoke action 'setValue' over a readonly node"
   )
+})
+
+test("computed tree works with an array of models", () => {
+  const r = new R({})
+
+  r.setValue(10)
+  expect(r.arrayOfModels).toEqual([1, 2].map((i) => new M({ id: `${r.id}.model${i}`, value: 10 })))
+
+  r.setValue(20)
+  expect(r.arrayOfModels).toEqual([1, 2].map((i) => new M({ id: `${r.id}.model${i}`, value: 20 })))
 })


### PR DESCRIPTION
I think it was actually incorrect to untweak `oldValue` and not `entry.tweakedValue` (i.e. `oldTweakedVlaue`) because `oldValue` hasn't been tweaked. I also saw this when stepping through the code with the debugger:

https://github.com/xaviergonz/mobx-keystone/blob/e35a792789fc66734b43cbf801d93a4e29ef9bd1/packages/lib/src/computedTree/computedTree.ts#L78

didn't execute

https://github.com/xaviergonz/mobx-keystone/blob/e35a792789fc66734b43cbf801d93a4e29ef9bd1/packages/lib/src/tweaker/tweak.ts#L91-L100

WDYT, @xaviergonz?

Fixes #483. :crossed_fingers: