### PR TITLE
fix: rename `runForCurrentChildren` to `fireForCurrentChildren`

### DIFF
--- a/packages/lib/src/parent/onChildAttachedTo.ts
+++ b/packages/lib/src/parent/onChildAttachedTo.ts
@@ -34,7 +34,7 @@ export function onChildAttachedTo(
 
   const opts = {
     deep: false,
-    runForCurrentChildren: true,
+    fireForCurrentChildren: true,
     ...options,
   }
 
@@ -73,7 +73,7 @@ export function onChildAttachedTo(
     return set
   }
 
-  const currentChildren = opts.runForCurrentChildren ? new Set<object>() : getCurrentChildren()
+  const currentChildren = opts.fireForCurrentChildren ? new Set<object>() : getCurrentChildren()
 
   const disposer = reaction(
     () => getCurrentChildren(),


### PR DESCRIPTION
`fireForCurrentChildren: false` has no effect.

I should add corresponding tests but I'm busy at the moment. ( Sorry, but the bug is really clear. The fix should definitely work 😁. )
