### PR TITLE
speed up initial tree tweaking

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## Unreleased
 
-- Performance: sped up snapshot hydration and initial array tweaking by bulk-building plain-object snapshot data before making it observable and by appending fresh observable-array items with `push` instead of setting pre-sized indexes. Focused benchmarks showed improvements for wide/nested plain-object snapshots and fresh primitive/object array initialization.
+- Performance: sped up large snapshot and array initialization by reducing per-item MobX writes during initial tree tweaking.
 
 ## 1.21.0
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+- Performance: sped up snapshot hydration and initial array tweaking by bulk-building plain-object snapshot data before making it observable and by appending fresh observable-array items with `push` instead of setting pre-sized indexes. Focused benchmarks showed improvements for wide/nested plain-object snapshots and fresh primitive/object array initialization.
+
 ## 1.21.0
 
 - Fixed codec-backed `tProp(...)` defaults so runtime `Map`/`Set` values (including custom codec defaults) are encoded before being stored, avoiding initialization errors and keeping default-fallback error paths accurate.

--- a/biome.json
+++ b/biome.json
@@ -30,7 +30,7 @@
   "linter": {
     "enabled": true,
     "rules": {
-      "recommended": true,
+      "preset": "recommended",
       "a11y": { "useKeyWithClickEvents": "off" },
       "complexity": {
         "noBannedTypes": "off",

--- a/packages/lib/perf_bench/memtest.ts
+++ b/packages/lib/perf_bench/memtest.ts
@@ -26,10 +26,10 @@ function memtest(numProps: number, numInstances: number) {
   console.log()
 
   function measure<R>(name: string, fn: () => R): R {
-    global.gc!()
+    globalThis.gc!()
     const start = process.memoryUsage().heapUsed
     const v = fn()
-    global.gc!()
+    globalThis.gc!()
     const end = process.memoryUsage().heapUsed
 
     const diff = end - start

--- a/packages/lib/perf_bench/report.ts
+++ b/packages/lib/perf_bench/report.ts
@@ -64,9 +64,7 @@ plan.forEach((fn) => {
     return
   }
   // trigger awkward gc up front if we can
-  if (global.gc) {
-    global.gc()
-  }
+  globalThis.gc?.()
   // run the report
   const result = fn()
   // calculate some fields

--- a/packages/lib/perf_bench/tsconfig.json
+++ b/packages/lib/perf_bench/tsconfig.json
@@ -3,6 +3,7 @@
   "compilerOptions": {
     "target": "es2020",
     "module": "commonjs",
+    "types": ["node"],
     "rootDir": ".."
   },
   "include": [".", "../src"]

--- a/packages/lib/src/snapshot/fromArraySnapshot.ts
+++ b/packages/lib/src/snapshot/fromArraySnapshot.ts
@@ -11,7 +11,7 @@ function fromArraySnapshot(sn: SnapshotInOfObject<any>, ctx: FromSnapshotContext
   for (let i = 0; i < ln; i++) {
     arr[i] = withErrorPathSegment(i, () => internalFromSnapshot(sn[i], ctx))
   }
-  return tweakArray(arr, undefined, true, true)
+  return tweakArray(arr, undefined, true)
 }
 
 /**

--- a/packages/lib/src/snapshot/fromArraySnapshot.ts
+++ b/packages/lib/src/snapshot/fromArraySnapshot.ts
@@ -1,23 +1,18 @@
-import { observable } from "mobx"
 import { tweakArray } from "../tweaker/tweakArray"
 import { isArray } from "../utils"
 import { withErrorPathSegment } from "../utils/errorDiagnostics"
-import {
-  type FromSnapshotContext,
-  internalFromSnapshot,
-  observableOptions,
-  registerSnapshotter,
-} from "./fromSnapshot"
+import { type FromSnapshotContext, internalFromSnapshot, registerSnapshotter } from "./fromSnapshot"
 import type { SnapshotInOfObject } from "./SnapshotOf"
 import { SnapshotterAndReconcilerPriority } from "./SnapshotterAndReconcilerPriority"
 
 function fromArraySnapshot(sn: SnapshotInOfObject<any>, ctx: FromSnapshotContext): any[] {
-  const arr = observable.array([] as any[], observableOptions)
+  const arr: any[] = []
   const ln = sn.length
+  arr.length = ln
   for (let i = 0; i < ln; i++) {
-    arr.push(withErrorPathSegment(i, () => internalFromSnapshot(sn[i], ctx)))
+    arr[i] = withErrorPathSegment(i, () => internalFromSnapshot(sn[i], ctx))
   }
-  return tweakArray(arr, undefined, true)
+  return tweakArray(arr, undefined, true, true)
 }
 
 /**

--- a/packages/lib/src/snapshot/fromArraySnapshot.ts
+++ b/packages/lib/src/snapshot/fromArraySnapshot.ts
@@ -6,9 +6,8 @@ import type { SnapshotInOfObject } from "./SnapshotOf"
 import { SnapshotterAndReconcilerPriority } from "./SnapshotterAndReconcilerPriority"
 
 function fromArraySnapshot(sn: SnapshotInOfObject<any>, ctx: FromSnapshotContext): any[] {
-  const arr: any[] = []
   const ln = sn.length
-  arr.length = ln
+  const arr: any[] = new Array(ln)
   for (let i = 0; i < ln; i++) {
     arr[i] = withErrorPathSegment(i, () => internalFromSnapshot(sn[i], ctx))
   }

--- a/packages/lib/src/snapshot/fromPlainObjectSnapshot.ts
+++ b/packages/lib/src/snapshot/fromPlainObjectSnapshot.ts
@@ -1,32 +1,25 @@
-import { observable, set } from "mobx"
 import { tweakPlainObject } from "../tweaker/tweakPlainObject"
-import { isPlainObject } from "../utils"
+import { isPlainObject, setOwnProp } from "../utils"
 import { withErrorPathSegment } from "../utils/errorDiagnostics"
-import {
-  type FromSnapshotContext,
-  internalFromSnapshot,
-  observableOptions,
-  registerSnapshotter,
-} from "./fromSnapshot"
+import { type FromSnapshotContext, internalFromSnapshot, registerSnapshotter } from "./fromSnapshot"
 import type { SnapshotInOfObject } from "./SnapshotOf"
 import { SnapshotterAndReconcilerPriority } from "./SnapshotterAndReconcilerPriority"
 
 function fromPlainObjectSnapshot(sn: SnapshotInOfObject<any>, ctx: FromSnapshotContext): object {
-  const plainObj = observable.object({}, undefined, observableOptions)
+  const plainObj: Record<string, unknown> = {}
 
   const snKeys = Object.keys(sn)
   const snKeysLen = snKeys.length
   for (let i = 0; i < snKeysLen; i++) {
     const k = snKeys[i]
     const v = sn[k]
-    // setIfDifferent not required
-    set(
+    setOwnProp(
       plainObj,
       k,
       withErrorPathSegment(k, () => internalFromSnapshot(v, ctx))
     )
   }
-  return tweakPlainObject(plainObj, undefined, undefined, true, false)
+  return tweakPlainObject(plainObj, undefined, undefined, true, false, true)
 }
 
 /**

--- a/packages/lib/src/snapshot/fromPlainObjectSnapshot.ts
+++ b/packages/lib/src/snapshot/fromPlainObjectSnapshot.ts
@@ -1,7 +1,13 @@
+import { observable } from "mobx"
 import { tweakPlainObject } from "../tweaker/tweakPlainObject"
 import { isPlainObject, setOwnProp } from "../utils"
 import { withErrorPathSegment } from "../utils/errorDiagnostics"
-import { type FromSnapshotContext, internalFromSnapshot, registerSnapshotter } from "./fromSnapshot"
+import {
+  type FromSnapshotContext,
+  internalFromSnapshot,
+  observableOptions,
+  registerSnapshotter,
+} from "./fromSnapshot"
 import type { SnapshotInOfObject } from "./SnapshotOf"
 import { SnapshotterAndReconcilerPriority } from "./SnapshotterAndReconcilerPriority"
 
@@ -19,7 +25,13 @@ function fromPlainObjectSnapshot(sn: SnapshotInOfObject<any>, ctx: FromSnapshotC
       withErrorPathSegment(k, () => internalFromSnapshot(v, ctx))
     )
   }
-  return tweakPlainObject(plainObj, undefined, undefined, true, false)
+  return tweakPlainObject(
+    observable.object(plainObj, undefined, observableOptions),
+    undefined,
+    undefined,
+    true,
+    false
+  )
 }
 
 /**

--- a/packages/lib/src/snapshot/fromPlainObjectSnapshot.ts
+++ b/packages/lib/src/snapshot/fromPlainObjectSnapshot.ts
@@ -19,7 +19,7 @@ function fromPlainObjectSnapshot(sn: SnapshotInOfObject<any>, ctx: FromSnapshotC
       withErrorPathSegment(k, () => internalFromSnapshot(v, ctx))
     )
   }
-  return tweakPlainObject(plainObj, undefined, undefined, true, false, true)
+  return tweakPlainObject(plainObj, undefined, undefined, true, false)
 }
 
 /**

--- a/packages/lib/src/snapshot/fromSnapshot.ts
+++ b/packages/lib/src/snapshot/fromSnapshot.ts
@@ -1,11 +1,11 @@
-import { action, observable, set } from "mobx"
+import { action, extendObservable } from "mobx"
 import type { AnyModel } from "../model/BaseModel"
 import { isReservedModelKey } from "../model/metadata"
 import { resolveStandardTypeNoThrow, resolveTypeChecker } from "../types/resolveTypeChecker"
 import type { AnyType, TypeToData, TypeToSnapshotIn } from "../types/schemas"
 import { isLateTypeChecker, TypeChecker } from "../types/TypeChecker"
 import { resolveCodecSupport } from "../types/utility/typesCodec"
-import { isMap, isPrimitive, isSet } from "../utils"
+import { isMap, isPrimitive, isSet, setOwnProp } from "../utils"
 import { runWithErrorDiagnosticsContext, withErrorPathSegment } from "../utils/errorDiagnostics"
 import { registerDefaultSnapshotters } from "./registerDefaultSnapshotters"
 import type { SnapshotInOf, SnapshotInOfModel, SnapshotOutOf } from "./SnapshotOf"
@@ -178,7 +178,7 @@ function snapshotToInitialData(
   ctx: FromSnapshotContext,
   processedSn: SnapshotInOfModel<AnyModel>
 ): any {
-  const initialData = observable.object({}, undefined, observableOptions)
+  const initialData: Record<string, unknown> = {}
 
   const processedSnKeys = Object.keys(processedSn)
   const processedSnKeysLen = processedSnKeys.length
@@ -187,11 +187,10 @@ function snapshotToInitialData(
     if (!isReservedModelKey(k)) {
       const v = processedSn[k]
       const snapshotValue = withErrorPathSegment(k, () => internalFromSnapshot(v, ctx))
-      // setIfDifferent not required
-      set(initialData, k, snapshotValue)
+      setOwnProp(initialData, k, snapshotValue)
     }
   }
-  return initialData
+  return extendObservable({}, initialData, undefined, observableOptions)
 }
 
 export const observableOptions = {

--- a/packages/lib/src/snapshot/fromSnapshot.ts
+++ b/packages/lib/src/snapshot/fromSnapshot.ts
@@ -1,4 +1,4 @@
-import { action, extendObservable } from "mobx"
+import { action, observable } from "mobx"
 import type { AnyModel } from "../model/BaseModel"
 import { isReservedModelKey } from "../model/metadata"
 import { resolveStandardTypeNoThrow, resolveTypeChecker } from "../types/resolveTypeChecker"
@@ -190,7 +190,7 @@ function snapshotToInitialData(
       setOwnProp(initialData, k, snapshotValue)
     }
   }
-  return extendObservable({}, initialData, undefined, observableOptions)
+  return observable.object(initialData, undefined, observableOptions)
 }
 
 export const observableOptions = {

--- a/packages/lib/src/tweaker/tweakArray.ts
+++ b/packages/lib/src/tweaker/tweakArray.ts
@@ -35,14 +35,22 @@ import { runTypeCheckingAfterChange } from "./typeChecking"
 export function tweakArray<T extends any[]>(
   value: T,
   parentPath: ParentPath<any> | undefined,
-  doNotTweakChildren: boolean
+  doNotTweakChildren: boolean,
+  prepopulateObservableArray = false
 ): T {
   const originalArr: ReadonlyArray<any> = value
   const arrLn = originalArr.length
-  const tweakedArr = isObservableArray(originalArr)
+  const originalArrIsObservable = isObservableArray(originalArr)
+  const tweakedArrWasPrepopulated =
+    !originalArrIsObservable && prepopulateObservableArray && doNotTweakChildren
+  const shouldPushInitialItems = !originalArrIsObservable && !tweakedArrWasPrepopulated
+  const tweakedArr = originalArrIsObservable
     ? originalArr
-    : observable.array(undefined, observableOptions)
-  if (tweakedArr !== originalArr) {
+    : observable.array(
+        tweakedArrWasPrepopulated ? (originalArr as any[]) : undefined,
+        observableOptions
+      )
+  if (tweakedArr !== originalArr && !shouldPushInitialItems) {
     tweakedArr.length = originalArr.length
   }
 
@@ -72,7 +80,9 @@ export function tweakArray<T extends any[]>(
     const v = originalArr[i]
 
     if (isPrimitive(v)) {
-      if (!doNotTweakChildren) {
+      if (shouldPushInitialItems) {
+        tweakedArr.push(v)
+      } else if (!doNotTweakChildren && !tweakedArrWasPrepopulated) {
         setIfDifferent(tweakedArr, i, v)
       }
 
@@ -93,6 +103,11 @@ export function tweakArray<T extends any[]>(
         )
       } else {
         tweakedValue = tweak(v, path)
+      }
+
+      if (shouldPushInitialItems) {
+        tweakedArr.push(tweakedValue)
+      } else if (!doNotTweakChildren) {
         setIfDifferent(tweakedArr, i, tweakedValue)
       }
 
@@ -444,8 +459,9 @@ function interceptArrayMutationSplice(change: IArrayWillSplice) {
  */
 export function registerArrayTweaker() {
   registerTweaker(TweakerPriority.Array, (value, parentPath) => {
+    const valueIsArray = Array.isArray(value)
     if (isArray(value)) {
-      return tweakArray(value, parentPath, false)
+      return tweakArray(value, parentPath, false, valueIsArray)
     }
     return undefined
   })

--- a/packages/lib/src/tweaker/tweakArray.ts
+++ b/packages/lib/src/tweaker/tweakArray.ts
@@ -23,7 +23,6 @@ import {
   updateInternalSnapshot,
 } from "../snapshot/internal"
 import { failure, inDevMode, isArray, isPrimitive } from "../utils"
-import { setIfDifferent } from "../utils/setIfDifferent"
 import { runningWithoutSnapshotOrPatches, tweakedObjects } from "./core"
 import { TweakerPriority } from "./TweakerPriority"
 import { registerTweaker, tweak } from "./tweak"
@@ -35,23 +34,25 @@ import { runTypeCheckingAfterChange } from "./typeChecking"
 export function tweakArray<T extends any[]>(
   value: T,
   parentPath: ParentPath<any> | undefined,
-  doNotTweakChildren: boolean,
-  prepopulateObservableArray = false
+  childrenAlreadyTweaked: boolean
 ): T {
   const originalArr: ReadonlyArray<any> = value
   const arrLn = originalArr.length
   const originalArrIsObservable = isObservableArray(originalArr)
-  const tweakedArrWasPrepopulated =
-    !originalArrIsObservable && prepopulateObservableArray && doNotTweakChildren
-  const shouldPushInitialItems = !originalArrIsObservable && !tweakedArrWasPrepopulated
-  const tweakedArr = originalArrIsObservable
-    ? originalArr
-    : observable.array(
-        tweakedArrWasPrepopulated ? (originalArr as any[]) : undefined,
-        observableOptions
-      )
-  if (tweakedArr !== originalArr && !shouldPushInitialItems) {
-    tweakedArr.length = originalArr.length
+  const tweakedArrWasPrepopulated = !originalArrIsObservable && childrenAlreadyTweaked
+  let tweakedArr: IObservableArray<any>
+  // when the source array is fresh (not observable, not prepopulated) items are
+  // collected into a plain buffer and inserted in a single bulk replace at the end,
+  // which avoids going through the whole mobx mutation pipeline once per item
+  let buffer: any[] | undefined
+
+  if (originalArrIsObservable) {
+    tweakedArr = originalArr as IObservableArray<any>
+  } else if (tweakedArrWasPrepopulated) {
+    tweakedArr = observable.array(originalArr as any[], observableOptions)
+  } else {
+    tweakedArr = observable.array(undefined, observableOptions)
+    buffer = new Array(arrLn)
   }
 
   let interceptDisposer: () => void
@@ -75,15 +76,47 @@ export function tweakArray<T extends any[]>(
   const untransformedSn: any[] = []
   untransformedSn.length = arrLn
 
+  // externally provided observable arrays keep unchanged slots untouched, but
+  // consecutive child replacements can still be applied as single splice ranges
+  let replacementRangeStart = -1
+  let replacementRangeItems: any[] | undefined
+
+  const flushReplacementRange = () => {
+    if (replacementRangeStart >= 0) {
+      tweakedArr.spliceWithArray(
+        replacementRangeStart,
+        replacementRangeItems!.length,
+        replacementRangeItems!
+      )
+      replacementRangeStart = -1
+      replacementRangeItems = undefined
+    }
+  }
+
+  const queueReplacementIfDifferent = (index: number, value: unknown) => {
+    if (tweakedArr[index] === value && index in tweakedArr) {
+      flushReplacementRange()
+      return
+    }
+
+    if (replacementRangeStart + (replacementRangeItems?.length ?? 0) === index) {
+      replacementRangeItems!.push(value)
+    } else {
+      flushReplacementRange()
+      replacementRangeStart = index
+      replacementRangeItems = [value]
+    }
+  }
+
   // substitute initial values by proxied values
   for (let i = 0; i < arrLn; i++) {
     const v = originalArr[i]
 
     if (isPrimitive(v)) {
-      if (shouldPushInitialItems) {
-        tweakedArr.push(v)
-      } else if (!doNotTweakChildren && !tweakedArrWasPrepopulated) {
-        setIfDifferent(tweakedArr, i, v)
+      if (buffer) {
+        buffer[i] = v
+      } else if (!childrenAlreadyTweaked && !tweakedArrWasPrepopulated) {
+        queueReplacementIfDifferent(i, v)
       }
 
       untransformedSn[i] = v
@@ -91,7 +124,7 @@ export function tweakArray<T extends any[]>(
       const path = { parent: tweakedArr, path: i }
 
       let tweakedValue: any
-      if (doNotTweakChildren) {
+      if (childrenAlreadyTweaked) {
         tweakedValue = v
         setParent(
           tweakedValue, // value
@@ -105,10 +138,10 @@ export function tweakArray<T extends any[]>(
         tweakedValue = tweak(v, path)
       }
 
-      if (shouldPushInitialItems) {
-        tweakedArr.push(tweakedValue)
-      } else if (!doNotTweakChildren) {
-        setIfDifferent(tweakedArr, i, tweakedValue)
+      if (buffer) {
+        buffer[i] = tweakedValue
+      } else if (!childrenAlreadyTweaked) {
+        queueReplacementIfDifferent(i, tweakedValue)
       }
 
       const valueSn = getInternalSnapshot(tweakedValue)!
@@ -116,6 +149,13 @@ export function tweakArray<T extends any[]>(
     }
   }
 
+  if (buffer) {
+    // done before the intercept/observe handlers are installed, so this
+    // is a single plain mobx bulk insertion
+    tweakedArr.replace(buffer)
+  } else {
+    flushReplacementRange()
+  }
   setNewInternalSnapshot(tweakedArr, untransformedSn, undefined)
 
   interceptDisposer = intercept(tweakedArr, interceptArrayMutation.bind(undefined, tweakedArr))
@@ -459,9 +499,8 @@ function interceptArrayMutationSplice(change: IArrayWillSplice) {
  */
 export function registerArrayTweaker() {
   registerTweaker(TweakerPriority.Array, (value, parentPath) => {
-    const valueIsArray = Array.isArray(value)
     if (isArray(value)) {
-      return tweakArray(value, parentPath, false, valueIsArray)
+      return tweakArray(value, parentPath, false)
     }
     return undefined
   })

--- a/packages/lib/src/tweaker/tweakArray.ts
+++ b/packages/lib/src/tweaker/tweakArray.ts
@@ -39,16 +39,16 @@ export function tweakArray<T extends any[]>(
   const originalArr: ReadonlyArray<any> = value
   const arrLn = originalArr.length
   const originalArrIsObservable = isObservableArray(originalArr)
-  const tweakedArrWasPrepopulated = !originalArrIsObservable && childrenAlreadyTweaked
   let tweakedArr: IObservableArray<any>
-  // when the source array is fresh (not observable, not prepopulated) items are
-  // collected into a plain buffer and inserted in a single bulk replace at the end,
-  // which avoids going through the whole mobx mutation pipeline once per item
+  // Fresh arrays whose children still need tweaking are collected into a plain
+  // buffer and inserted in one bulk replace at the end.
   let buffer: any[] | undefined
 
   if (originalArrIsObservable) {
     tweakedArr = originalArr as IObservableArray<any>
-  } else if (tweakedArrWasPrepopulated) {
+  } else if (childrenAlreadyTweaked) {
+    // Snapshot arrays already contain tweaked children, so MobX can initialize
+    // the observable array directly from the source values.
     tweakedArr = observable.array(originalArr as any[], observableOptions)
   } else {
     tweakedArr = observable.array(undefined, observableOptions)
@@ -115,7 +115,7 @@ export function tweakArray<T extends any[]>(
     if (isPrimitive(v)) {
       if (buffer) {
         buffer[i] = v
-      } else if (!childrenAlreadyTweaked && !tweakedArrWasPrepopulated) {
+      } else if (!childrenAlreadyTweaked) {
         queueReplacementIfDifferent(i, v)
       }
 

--- a/packages/lib/src/tweaker/tweakPlainObject.ts
+++ b/packages/lib/src/tweaker/tweakPlainObject.ts
@@ -42,8 +42,7 @@ export function tweakPlainObject<T extends Record<string, any>>(
   isDataObject: boolean
 ): T {
   const originalObj: Record<string, any> = value
-  const originalObjIsObservable = isObservableObject(originalObj)
-  const tweakedObj = originalObjIsObservable
+  const tweakedObj = isObservableObject(originalObj)
     ? originalObj
     : observable.object({}, undefined, observableOptions)
 
@@ -75,7 +74,9 @@ export function tweakPlainObject<T extends Record<string, any>>(
     const v = originalObj[k]
 
     if (isPrimitive(v)) {
-      setInitialValueIfDifferent(tweakedObj, k, v)
+      if (!doNotTweakChildren) {
+        setIfDifferent(tweakedObj, k, v)
+      }
       setOwnProp(untransformedSn, k, v)
     } else {
       const path = { parent: tweakedObj, path: k }
@@ -93,8 +94,8 @@ export function tweakPlainObject<T extends Record<string, any>>(
         )
       } else {
         tweakedValue = tweak(v, path)
+        setIfDifferent(tweakedObj, k, tweakedValue)
       }
-      setInitialValueIfDifferent(tweakedObj, k, tweakedValue)
 
       const valueSn = getInternalSnapshot(tweakedValue)!
       setOwnProp(untransformedSn, k, valueSn.transformed)
@@ -130,14 +131,6 @@ export function tweakPlainObject<T extends Record<string, any>>(
 
 const observableOptions = {
   deep: false,
-}
-
-function setInitialValueIfDifferent(target: any, key: PropertyKey, value: unknown): void {
-  if (key !== "__proto__") {
-    setIfDifferent(target, key, value)
-  } else if (target[key] !== value || !Object.hasOwn(target, key)) {
-    setOwnProp(target, key, value)
-  }
 }
 
 function mutateSet(k: PropertyKey, v: unknown, sn: Record<PropertyKey, unknown>) {

--- a/packages/lib/src/tweaker/tweakPlainObject.ts
+++ b/packages/lib/src/tweaker/tweakPlainObject.ts
@@ -75,7 +75,7 @@ export function tweakPlainObject<T extends Record<string, any>>(
     const v = originalObj[k]
 
     if (isPrimitive(v)) {
-      setIfDifferent(tweakedObj, k, v)
+      setInitialValueIfDifferent(tweakedObj, k, v)
       setOwnProp(untransformedSn, k, v)
     } else {
       const path = { parent: tweakedObj, path: k }
@@ -94,7 +94,7 @@ export function tweakPlainObject<T extends Record<string, any>>(
       } else {
         tweakedValue = tweak(v, path)
       }
-      setIfDifferent(tweakedObj, k, tweakedValue)
+      setInitialValueIfDifferent(tweakedObj, k, tweakedValue)
 
       const valueSn = getInternalSnapshot(tweakedValue)!
       setOwnProp(untransformedSn, k, valueSn.transformed)
@@ -130,6 +130,14 @@ export function tweakPlainObject<T extends Record<string, any>>(
 
 const observableOptions = {
   deep: false,
+}
+
+function setInitialValueIfDifferent(target: any, key: PropertyKey, value: unknown): void {
+  if (key !== "__proto__") {
+    setIfDifferent(target, key, value)
+  } else if (target[key] !== value || !Object.hasOwn(target, key)) {
+    setOwnProp(target, key, value)
+  }
 }
 
 function mutateSet(k: PropertyKey, v: unknown, sn: Record<PropertyKey, unknown>) {

--- a/packages/lib/src/tweaker/tweakPlainObject.ts
+++ b/packages/lib/src/tweaker/tweakPlainObject.ts
@@ -1,4 +1,5 @@
 import {
+  extendObservable,
   type IObjectDidChange,
   type IObjectWillChange,
   intercept,
@@ -39,12 +40,17 @@ export function tweakPlainObject<T extends Record<string, any>>(
   parentPath: ParentPath<any> | undefined,
   snapshotModelType: string | undefined,
   doNotTweakChildren: boolean,
-  isDataObject: boolean
+  isDataObject: boolean,
+  prepopulateObservableObject = false
 ): T {
   const originalObj: Record<string, any> = value
-  const tweakedObj = isObservableObject(originalObj)
+  const originalObjIsObservable = isObservableObject(originalObj)
+  const tweakedObjWasPrepopulated = !originalObjIsObservable && prepopulateObservableObject
+  const tweakedObj = originalObjIsObservable
     ? originalObj
-    : observable.object({}, undefined, observableOptions)
+    : tweakedObjWasPrepopulated
+      ? extendObservable({}, originalObj, undefined, observableOptions)
+      : observable.object({}, undefined, observableOptions)
 
   let interceptDisposer: () => void
   let observeDisposer: () => void
@@ -74,7 +80,7 @@ export function tweakPlainObject<T extends Record<string, any>>(
     const v = originalObj[k]
 
     if (isPrimitive(v)) {
-      if (!doNotTweakChildren) {
+      if (!doNotTweakChildren && !tweakedObjWasPrepopulated) {
         setIfDifferent(tweakedObj, k, v)
       }
       setOwnProp(untransformedSn, k, v)
@@ -347,8 +353,16 @@ function interceptObjectMutation(change: IObjectWillChange) {
 export function registerPlainObjectTweaker() {
   registerTweaker(TweakerPriority.PlainObject, (value, parentPath) => {
     // plain object
-    if (isObservableObject(value) || isPlainObject(value)) {
-      return tweakPlainObject(value as Record<string, any>, parentPath, undefined, false, false)
+    const valueIsPlainObject = isPlainObject(value)
+    if (isObservableObject(value) || valueIsPlainObject) {
+      return tweakPlainObject(
+        value as Record<string, any>,
+        parentPath,
+        undefined,
+        false,
+        false,
+        valueIsPlainObject
+      )
     }
     return undefined
   })

--- a/packages/lib/src/tweaker/tweakPlainObject.ts
+++ b/packages/lib/src/tweaker/tweakPlainObject.ts
@@ -1,5 +1,4 @@
 import {
-  extendObservable,
   type IObjectDidChange,
   type IObjectWillChange,
   intercept,
@@ -40,18 +39,13 @@ export function tweakPlainObject<T extends Record<string, any>>(
   parentPath: ParentPath<any> | undefined,
   snapshotModelType: string | undefined,
   doNotTweakChildren: boolean,
-  isDataObject: boolean,
-  prepopulateObservableObject = false
+  isDataObject: boolean
 ): T {
   const originalObj: Record<string, any> = value
   const originalObjIsObservable = isObservableObject(originalObj)
-  const tweakedObjWasPrepopulated =
-    !originalObjIsObservable && prepopulateObservableObject && doNotTweakChildren
   const tweakedObj = originalObjIsObservable
     ? originalObj
-    : tweakedObjWasPrepopulated
-      ? extendObservable({}, originalObj, undefined, observableOptions)
-      : observable.object({}, undefined, observableOptions)
+    : observable.object({}, undefined, observableOptions)
 
   let interceptDisposer: () => void
   let observeDisposer: () => void
@@ -81,9 +75,7 @@ export function tweakPlainObject<T extends Record<string, any>>(
     const v = originalObj[k]
 
     if (isPrimitive(v)) {
-      if (!doNotTweakChildren && !tweakedObjWasPrepopulated) {
-        setIfDifferent(tweakedObj, k, v)
-      }
+      setIfDifferent(tweakedObj, k, v)
       setOwnProp(untransformedSn, k, v)
     } else {
       const path = { parent: tweakedObj, path: k }
@@ -101,8 +93,8 @@ export function tweakPlainObject<T extends Record<string, any>>(
         )
       } else {
         tweakedValue = tweak(v, path)
-        setIfDifferent(tweakedObj, k, tweakedValue)
       }
+      setIfDifferent(tweakedObj, k, tweakedValue)
 
       const valueSn = getInternalSnapshot(tweakedValue)!
       setOwnProp(untransformedSn, k, valueSn.transformed)

--- a/packages/lib/src/tweaker/tweakPlainObject.ts
+++ b/packages/lib/src/tweaker/tweakPlainObject.ts
@@ -45,7 +45,8 @@ export function tweakPlainObject<T extends Record<string, any>>(
 ): T {
   const originalObj: Record<string, any> = value
   const originalObjIsObservable = isObservableObject(originalObj)
-  const tweakedObjWasPrepopulated = !originalObjIsObservable && prepopulateObservableObject
+  const tweakedObjWasPrepopulated =
+    !originalObjIsObservable && prepopulateObservableObject && doNotTweakChildren
   const tweakedObj = originalObjIsObservable
     ? originalObj
     : tweakedObjWasPrepopulated
@@ -353,16 +354,8 @@ function interceptObjectMutation(change: IObjectWillChange) {
 export function registerPlainObjectTweaker() {
   registerTweaker(TweakerPriority.PlainObject, (value, parentPath) => {
     // plain object
-    const valueIsPlainObject = isPlainObject(value)
-    if (isObservableObject(value) || valueIsPlainObject) {
-      return tweakPlainObject(
-        value as Record<string, any>,
-        parentPath,
-        undefined,
-        false,
-        false,
-        valueIsPlainObject
-      )
+    if (isObservableObject(value) || isPlainObject(value)) {
+      return tweakPlainObject(value as Record<string, any>, parentPath, undefined, false, false)
     }
     return undefined
   })

--- a/packages/lib/test/actionMiddlewares/actionSerialization.test.ts
+++ b/packages/lib/test/actionMiddlewares/actionSerialization.test.ts
@@ -225,6 +225,7 @@ test("serializeActionCallArgument and deserializeActionCallArgument", () => {
 
 function serializedPlainObjectWithProtoValue(value: object) {
   const serializedValue = JSON.parse('{"__proto__":null,"safe":1}')
+  // biome-ignore lint/suspicious/noProto: this test intentionally covers "__proto__" serializer metadata.
   serializedValue.__proto__ = {
     $mobxKeystoneSerializer: `${namespace}/plainObject`,
     value,

--- a/packages/lib/test/context/context.test.ts
+++ b/packages/lib/test/context/context.test.ts
@@ -246,21 +246,18 @@ test("context with computed values", () => {
 })
 
 test("context typings", () => {
-  // biome-ignore lint/correctness/noUnusedVariables: type-only assertions below intentionally use this symbol only in type positions.
   const ctx1 = createContext<number>()
   assert(_ as ReturnType<typeof ctx1.getDefault>, _ as number | undefined)
   assert(_ as ReturnType<typeof ctx1.get>, _ as number | undefined)
   assert(_ as typeof ctx1.setDefault, _ as (v: number | undefined) => void)
   assert(_ as typeof ctx1.set, _ as (n: object, v: number | undefined) => void)
   assert(_ as typeof ctx1.setComputed, _ as (n: object, v: () => number | undefined) => void)
-  // biome-ignore lint/correctness/noUnusedVariables: type-only assertions below intentionally use this symbol only in type positions.
   const ctx2 = createContext(5)
   assert(_ as ReturnType<typeof ctx2.getDefault>, _ as number)
   assert(_ as ReturnType<typeof ctx2.get>, _ as number)
   assert(_ as typeof ctx2.setDefault, _ as (v: number) => void)
   assert(_ as typeof ctx2.set, _ as (n: object, v: number) => void)
   assert(_ as typeof ctx2.setComputed, _ as (n: object, v: () => number) => void)
-  // biome-ignore lint/correctness/noUnusedVariables: type-only assertions below intentionally use this symbol only in type positions.
   const ctx3 = createContext<number>(5)
   assert(_ as ReturnType<typeof ctx3.getDefault>, _ as number)
   assert(_ as ReturnType<typeof ctx3.get>, _ as number)

--- a/packages/lib/test/model/mixins.test.ts
+++ b/packages/lib/test/model/mixins.test.ts
@@ -45,7 +45,6 @@ test("defineModelMixin + composeMixins type-level composition", () => {
       }
   )
 
-  // biome-ignore lint/correctness/noUnusedVariables: type-only assertions below intentionally use this symbol only in type positions.
   const ProductBase = composeMixins(Entity, countableMixin, producerMixin)
   type Product = InstanceType<typeof ProductBase>
   type ProductFromUtility = InstanceType<
@@ -195,7 +194,6 @@ test("issue #494 legacy factory pattern with explicit return types", () => {
   ) => ModelClass<Producer<InstanceType<TBase>>> = makeProducer
 
   const CountableEntity = makeCountable(Entity)
-  // biome-ignore lint/correctness/noUnusedVariables: type-only assertions below intentionally use this symbol only in type positions.
   const ProducerEntity = makeProducerUsingFactoryType(CountableEntity)
   type ProducerEntityInstance = InstanceType<typeof ProducerEntity>
   assert(_ as ProducerEntityInstance["produced"], _ as number)
@@ -219,7 +217,6 @@ test("composeMixins enforces requirements", () => {
 
   const countableMixin = defineModelMixin({ quantity: tProp(types.number, 0) })
 
-  // biome-ignore lint/correctness/noUnusedVariables: type-only assertions below intentionally use this symbol only in type positions.
   const Valid = composeMixins(Entity, countableMixin, requiresCountable)
   type ValidInstance = InstanceType<typeof Valid>
   assert(_ as ValidInstance["quantity"], _ as number)
@@ -238,7 +235,6 @@ test("composeMixins supports 6+ mixins", () => {
   const m6 = defineModelMixin({ p6: tProp(types.number, 6) })
   const m7 = defineModelMixin({ p7: tProp(types.number, 7) })
 
-  // biome-ignore lint/correctness/noUnusedVariables: type-only assertions below intentionally use this symbol only in type positions.
   const ManyBase = composeMixins(Entity, m1, m2, m3, m4, m5, m6, m7)
   type Many = InstanceType<typeof ManyBase>
 
@@ -268,7 +264,6 @@ test("composeMixins requirement failure in middle of chain", () => {
   const Invalid = composeMixins(Entity, addQuantity, requiresProduced, addProduced)
   void Invalid
 
-  // biome-ignore lint/correctness/noUnusedVariables: type-only assertions below intentionally use this symbol only in type positions.
   const Valid = composeMixins(Entity, addProduced, requiresProduced)
   type ValidInstance = InstanceType<typeof Valid>
   assert(_ as ValidInstance["produced"], _ as number)

--- a/packages/lib/test/model/subclassing.test.ts
+++ b/packages/lib/test/model/subclassing.test.ts
@@ -840,13 +840,11 @@ test("generic model instance factory", () => {
   }))<T> {}
 
   function createParent<T>(a: T) {
-    // biome-ignore lint/correctness/noUnusedVariables: type-only assertion below intentionally uses this symbol only in a type position.
     const parent = new Parent({ a })
     assert(_ as typeof parent, _ as Parent<T>)
   }
 
   function createChild<T>(a: T, b: T) {
-    // biome-ignore lint/correctness/noUnusedVariables: type-only assertion below intentionally uses this symbol only in a type position.
     const child = new Child({ a, b })
     assert(_ as typeof child, _ as Child<T>)
   }

--- a/packages/lib/test/snapshot/fromSnapshot.test.ts
+++ b/packages/lib/test/snapshot/fromSnapshot.test.ts
@@ -1,5 +1,5 @@
 import { isObservable } from "mobx"
-import { fromSnapshot, modelSnapshotInWithMetadata } from "../../src"
+import { fromSnapshot, getSnapshot, modelSnapshotInWithMetadata } from "../../src"
 import { P, P2 } from "../testbed"
 
 const snapshot = modelSnapshotInWithMetadata(P, {
@@ -42,4 +42,14 @@ test("basic", () => {
   expect(isObservable(p.p2!.$)).toBeTruthy()
   expect(p.p2 instanceof P2).toBeTruthy()
   expect(isObservable(p.arr)).toBeTruthy()
+})
+
+test("plain object snapshots preserve __proto__ as data", () => {
+  const sn = JSON.parse('{"obj":{"a":1,"__proto__":{"polluted":true}}}')
+  const node = fromSnapshot<any>(sn)
+
+  expect(node.obj.polluted).toBeUndefined()
+  expect(Object.hasOwn(node.obj, "__proto__")).toBe(true)
+  expect(Reflect.get(node.obj, "__proto__")).toStrictEqual({ polluted: true })
+  expect(getSnapshot(node)).toStrictEqual(sn)
 })


### PR DESCRIPTION
## Summary

- Speeds up snapshot hydration by bulk-building plain object snapshot data before making it observable.
- Speeds up initial array tweaking by reducing per-item MobX writes, including buffered initialization for fresh arrays and coalesced replacement ranges for observable arrays.
- Simplifies the internal `tweakArray` initialization mode from two booleans to a single `childrenAlreadyTweaked` flag.

## Validation

- `pnpm --dir packages/lib quick-build`
- `pnpm --dir packages/lib quick-build-tests`
- `pnpm --dir packages/lib test test/parent/parent.test.ts test/snapshot/getSnapshot.test.ts test/patch/patch.test.ts`
- `MOBX_VERSION=4 pnpm --dir packages/lib test test/parent/parent.test.ts test/snapshot/getSnapshot.test.ts test/patch/patch.test.ts`
- `MOBX_VERSION=5 pnpm --dir packages/lib test test/parent/parent.test.ts test/snapshot/getSnapshot.test.ts test/patch/patch.test.ts`
- `pnpm lib:test`
- `pnpm lint`