### PR TITLE
Add Redux DevTools child action logging option

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+- Added a `logChildActions` option to `connectReduxDevTools` for suppressing nested action entries and logging the outermost tracked action instead.
+
 ## 1.21.0
 
 - Fixed codec-backed `tProp(...)` defaults so runtime `Map`/`Set` values (including custom codec defaults) are encoded before being stored, avoiding initialization errors and keeping default-fallback error paths accurate.

--- a/apps/site/docs/integrations/reduxCompatibility.mdx
+++ b/apps/site/docs/integrations/reduxCompatibility.mdx
@@ -40,5 +40,6 @@ connectReduxDevTools(remotedev, connection, todoList)
 This function also accepts an optional options object with the following properties:
 
 - `logArgsNearName` - if it should show the arguments near the action name (default is `true`).
+- `logChildActions` - if it should log child actions when they run inside another action tracked by the same target tree (default is `true`). Set it to `false` to keep nested action calls grouped under the outermost tracked action.
 
 If you want to see it in action feel free to check the [Todo List Example](../examples/todoList/todoList.mdx), open the Redux DevTools and perform some actions.

--- a/packages/lib/src/redux/connectReduxDevTools.ts
+++ b/packages/lib/src/redux/connectReduxDevTools.ts
@@ -9,26 +9,42 @@ import { applySnapshot } from "../snapshot/applySnapshot"
 import { getSnapshot } from "../snapshot/getSnapshot"
 import { assertTweakedObject } from "../tweaker/core"
 
+export interface ConnectReduxDevToolsOptions {
+  /**
+   * If it should show the arguments near the action name.
+   *
+   * @default true
+   */
+  logArgsNearName?: boolean
+
+  /**
+   * If it should log child actions when they run inside another action tracked
+   * by the same target tree.
+   *
+   * @default true
+   */
+  logChildActions?: boolean
+}
+
 /**
  * Connects a tree node to a redux dev tools instance.
  *
  * @param remotedevPackage The remotedev package (usually the result of `require("remoteDev")`) (https://www.npmjs.com/package/remotedev).
  * @param remotedevConnection The result of a connect method from the remotedev package (usually the result of `remoteDev.connectViaExtension(...)`).
  * @param target Object to use as root.
- * @param [options] Optional options object. `logArgsNearName` if it should show the arguments near the action name (default is `true`).
+ * @param [options] Optional options object.
  */
 export function connectReduxDevTools(
   remotedevPackage: any,
   remotedevConnection: any,
   target: object,
-  options?: {
-    logArgsNearName?: boolean
-  }
+  options?: ConnectReduxDevToolsOptions
 ) {
   assertTweakedObject(target, "target")
 
   const opts = {
     logArgsNearName: true,
+    logChildActions: true,
     ...options,
   }
 
@@ -48,12 +64,15 @@ export function connectReduxDevTools(
   const actionIdSymbol = Symbol("actionId")
 
   actionTrackingMiddleware(target, {
+    filter(ctx) {
+      return opts.logChildActions || !hasDevToolsTrackedParentContext(ctx)
+    },
     onStart(ctx) {
       ctx.data[actionIdSymbol] = currentActionId++
     },
     onResume(ctx) {
       // give a chance to the parent to log its own changes before the child starts
-      if (ctx.parentContext) {
+      if (opts.logChildActions && ctx.parentContext) {
         log(ctx.parentContext, undefined)
       }
       log(ctx, undefined)
@@ -183,5 +202,18 @@ export function connectReduxDevTools(
     }
 
     return name
+  }
+
+  function hasDevToolsTrackedParentContext(ctx: SimpleActionContext) {
+    let parentContext = ctx.parentContext
+
+    while (parentContext) {
+      if (parentContext.data[actionIdSymbol] !== undefined) {
+        return true
+      }
+      parentContext = parentContext.parentContext
+    }
+
+    return false
   }
 }

--- a/packages/lib/test/redux/connectReduxDevTools.test.ts
+++ b/packages/lib/test/redux/connectReduxDevTools.test.ts
@@ -175,13 +175,23 @@ class M extends Model({
   setXYAsyncThrowAsync = _async(this._setXYAsyncThrowAsync)
 }
 
+@testModel("TestRootModel")
+class RootM extends Model({
+  child: prop<M>(),
+}) {
+  @modelAction
+  runChildSetXY() {
+    this.child.setXY()
+  }
+}
+
 let m = new M({})
 function mockDevTools() {
   return { init: vi.fn(), subscribe: vi.fn(), send: vi.fn() }
 }
 let devTools = mockDevTools()
 
-function initTest() {
+function initTest(options?: Parameters<typeof connectReduxDevTools>[3]) {
   const devToolsManager = {
     connectViaExtension: () => mockDevTools(),
     extractState: vi.fn(),
@@ -189,7 +199,7 @@ function initTest() {
   devTools = devToolsManager.connectViaExtension()
 
   m = new M({})
-  connectReduxDevTools(devToolsManager, devTools, m)
+  connectReduxDevTools(devToolsManager, devTools, m, options)
 }
 
 function addStandardTests() {
@@ -296,3 +306,44 @@ beforeEach(() => {
 })
 
 addStandardTests()
+
+test("m.setXY() -> m.setX(), m.setY() with logChildActions false", () => {
+  initTest({ logChildActions: false })
+
+  m.setXY()
+
+  expect(devTools.send.mock.calls).toHaveLength(1)
+  expect(devTools.send.mock.calls[0][0]).toMatchObject({
+    args: [],
+    path: [],
+    type: "[/] setXY() (id 0)",
+  })
+  expect(devTools.send.mock.calls[0][1]).toMatchObject({
+    x: "setXY ends",
+    y: "setY",
+  })
+})
+
+test("subtree action called from untracked parent with logChildActions false", () => {
+  const devToolsManager = {
+    connectViaExtension: () => mockDevTools(),
+    extractState: vi.fn(),
+  }
+  devTools = devToolsManager.connectViaExtension()
+
+  const root = new RootM({ child: new M({}) })
+  connectReduxDevTools(devToolsManager, devTools, root.child, { logChildActions: false })
+
+  root.runChildSetXY()
+
+  expect(devTools.send.mock.calls).toHaveLength(1)
+  expect(devTools.send.mock.calls[0][0]).toMatchObject({
+    args: [],
+    path: ["child"],
+  })
+  expect(devTools.send.mock.calls[0][0].type).toContain("[/child] setXY() (id 0)")
+  expect(devTools.send.mock.calls[0][1]).toMatchObject({
+    x: "setXY ends",
+    y: "setY",
+  })
+})


### PR DESCRIPTION
## Summary

Adds a `logChildActions` option to `connectReduxDevTools`, defaulting to `true` to preserve current behavior. When set to `false`, nested actions that are already inside a tracked parent action are suppressed so Redux DevTools shows the outermost tracked action as the transaction.

The implementation uses the DevTools middleware's own action marker to decide whether a parent context is already tracked, which keeps subtree-mounted DevTools connections working correctly.

Closes #385.

Original issue/comment: https://github.com/xaviergonz/mobx-keystone/issues/385#issuecomment-4885542477

## Validation

- `pnpm --dir packages/lib test test/redux/connectReduxDevTools.test.ts`
- `pnpm --dir packages/lib quick-build`
- `pnpm --dir packages/lib quick-build-tests`
- `pnpm lib:test`
- `pnpm lint` passed with existing unrelated Biome warnings